### PR TITLE
Use full tag specification in manifest (repo requires this)

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -6,7 +6,7 @@
     <remote name="pctools-github"
             fetch="ssh://git@github.com/GPUOpen-ProfessionalCompute-Tools/" />
 
-    <default revision="roc-1.4.0"
+    <default revision="refs/tags/roc-1.4.0"
              remote="roc-github"
              sync-j="4" />
 


### PR DESCRIPTION
Change-Id: I228961663b6b4edabe8e3e3cba92de9d9929c404

Hi, I believe the tag specified in the manifest is incorrect - repo requires full tag specification otherwise it doesn't work. I have used the most recent repo version for this. Please, consider this for merging.

Best regards,

Jan