### PR TITLE
Updating README file to better describe hardware support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ To try ROCm with an upstream kernel, install ROCm as normal, but do not install 
 
 #### New distribution support 
 
- * Binary package support for Ubuntu 16.04
+ * Binary package support for Ubuntu 16.04 and 18.04
  * Binary package support for CentOS 7.4 and 7.5
  * Binary package support for RHEL 7.4 and 7.5
  
@@ -298,6 +298,7 @@ sudo apt install rocm-dev
 >ROCm driver stack installed
 
 ##### Removing pre-release packages
+It is recommended to [remove previous rocm installations](https://github.com/RadeonOpenCompute/ROCm#how-to-un-install-from-ubuntu-1604) before installing the latest version to ensure a smooth installation.
 
 If you installed any of the ROCm pre-release packages from github, they will
 need to be manually un-installed:
@@ -360,9 +361,10 @@ sudo yum install -y dkms kernel-headers-`uname -r` kernel-devel-`uname -r`
 ```
 
 
-At this point they system can install ROCm using the DKMS drivers.
+#### Installing ROCm on the system
 
-Installing ROCm on the system
+It is recommended to [remove previous rocm installations](https://github.com/RadeonOpenCompute/ROCm#how-to-un-install-rocm-from-centosrhel-74) before installing the latest version to ensure a smooth installation.
+
 At this point ROCm can be installed on the target system. Create a /etc/yum.repos.d/rocm.repo file with the following contents:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This software enables the high-performance operation of AMD GPUs for computation
 - [New features and enhancements in ROCm 1.9.0](#new-features-and-enhancements-in-rocm-190)
 - [The latest ROCm platform - ROCm 1.9.0](#the-latest-rocm-platform---rocm-190)
 - [Installing from AMD ROCm repositories](#installing-from-amd-rocm-repositories)
-  * [Ubuntu Support - Installing from a Debian repository](#ubunutu-support---installing-from-a-debian-repository)
+  * [Ubuntu Support - Installing from a Debian repository](#ubuntu-support---installing-from-a-debian-repository)
   * [CentOS/RHEL 7 (both 7.4 and 7.5) Support](#centosrhel-7-both-74-and-75-support)
 - [Known Issues / Workarounds](#known-issues--workarounds)
 - [Closed source components](#closed-source-components)

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ The ROCm Platform brings a rich foundation to advanced computing by seamlessly
 
 #### Supported CPUs
 
-Starting with ROCm 1.8, we have relaxed the requirements for PCIe Atomics on Vega 10 (GFX9) GPUs, and we have similarly opened up more options for number of PCIe lanes. With this release, these GFX9 GPUs can support CPUs without PCIe Atomics and, for example, run on PCIe  Gen2 x1 lanes. To enable this option, please set the environment variable `HSA_ENABLE_SDMA=0`.
-
-Currently, our GFX8 GPUs (Fiji & Polaris family) still need to use PCIe Gen 3 and PCIe Atomics, but are looking at relaxing this in a future release, once we have fully tested firmware.
+Starting with ROCm 1.8, we have relaxed the requirements for PCIe Atomics on Vega 10 (GFX9) GPUs, and we have similarly opened up more options for number of PCIe lanes. With this release, these GFX9 GPUs can support CPUs without PCIe Atomics and, for example, run on PCIe  Gen2 x1 lanes. To enable this option, please set the environment variable `HSA_ENABLE_SDMA=0`.  This is not supported on GPUs below GFX9, i.e. GFX8 cards in Fiji and Polaris families.
 
 Current CPUs which support PCIe Gen3 + PCIe Atomics are: 
   * AMD Ryzen CPUs;
@@ -35,7 +33,7 @@ from the list provided above for compatibility purposes.
 #### Not supported or very limited support under ROCm 
 ###### Limited support 
 
-* ROCm 1.8 and Vega10 should support PCIe Gen2 enabled CPUs such as the AMD Opteron, Phenom, Phenom II, Athlon, Athlon X2, Athlon II and older Intel Xeon and Intel Core Architecture and Pentium CPUs. However, we have done very limited testing on these configurations, since our test farm has been catering to CPU listed above. This is where we need community support; if you find problems on such setups, please report these issues.
+* ROCm 1.9 and Vega10 should support PCIe Gen2 enabled CPUs such as the AMD Opteron, Phenom, Phenom II, Athlon, Athlon X2, Athlon II and older Intel Xeon and Intel Core Architecture and Pentium CPUs. However, we have done very limited testing on these configurations, since our test farm has been catering to CPU listed above. This is where we need community support; if you find problems on such setups, please report these issues.
  * Thunderbolt 1, 2, and 3 enabled breakout boxes should now be able to work with ROCm. Thunderbolt 1 and 2 are PCIe Gen2 based, and thus are only supported with GPUs that do not require PCIe Gen 3 atomics (i.e. Vega 10). However, we have done no testing on this configuration and would need comunity support due to limited access to this type of equipment 
 
 ###### Not supported 
@@ -46,6 +44,58 @@ from the list provided above for compatibility purposes.
 * AMD Carrizo based APUs have limited support due to OEM & ODM's choices when it comes to some key configuration parameters. In particular, we have observed that Carrizo laptops, AIOs, and desktop systems showed inconsistencies in exposing and enabling the System BIOS parameters required by the ROCm stack. Before purchasing a Carrizo system for ROCm, please verify that the BIOS provides an option for enabling IOMMUv2 and that the system BIOS properly exposes the correct CRAT table - please inquire with the OEM about the latter.
  * AMD Merlin/Falcon Embedded System is not currently supported by the public repo.
  * AMD Raven Ridge APU are currently not supported
+
+### New features and enhancements in ROCm 1.9.0
+
+#### Preview for Vega 7nm
+* Enables developer preview support for Vega 7nm
+
+#### System Management Interface
+* Adds support for the ROCm SMI (System Management Interface) library, which provides monitoring and management capabilities for AMD GPUs.
+
+#### Improvements to HIP/HCC
+* Support for gfx906
+* Added deprecation warning for C++AMP.  This will be the last version of HCC supporting C++AMP.
+* Improved optimization for global address space pointers passing into a GPU kernel
+* Fixed several race conditions in the HCC runtime
+* Performance tuning to the unpinned copy engine
+* Several codegen enhancement fixes in the compiler backend
+
+#### Preview for rocprof Profiling Tool
+Developer preview (alpha) of profiling tool 'rpl_run.sh', cmd-line front-end for rocProfiler, enables:
+* Cmd-line tool for dumping public per kernel perf-counters/metrics and kernel timestamps
+* Input file with counters list and kernels selecting parameters
+* Multiple counters groups and app runs supported
+* Output results in CSV format
+The tool location is: /opt/rocm/rocprofiler/bin/rpl_run.sh
+
+#### Preview for rocr Debug Agent rocr_debug_agent
+The ROCr Debug Agent is a library that can be loaded by ROCm Platform Runtime to provide the following functionality:
+* Print the state for wavefronts that report memory violation or upon executing a "s_trap 2" instruction.
+* Allows SIGINT (`ctrl c`) or SIGTERM (`kill -15`) to print wavefront state of aborted GPU dispatches.
+* It is enabled on Vega10 GPUs on ROCm1.9.
+The ROCm1.9 release will install the ROCr Debug Agent library at /opt/rocm/lib/librocr_debug_agent64.so
+
+
+#### New distribution support 
+
+* Binary package support for Ubuntu 18.04
+
+#### ROCm 1.9 is ABI compatible with KFD in upstream Linux kernels. 
+Upstream Linux kernels support the following GPUs in these releases:
+4.17: Fiji, Polaris 10, Polaris 11
+4.18: Fiji, Polaris 10, Polaris 11, Vega10
+
+Some ROCm features are not available in the upstream KFD:
+* More system memory available to ROCm applications
+* Interoperability between graphics and compute
+* RDMA
+* IPC
+
+To try ROCm with an upstream kernel, install ROCm as normal, but do not install the rock-dkms package. Also add a udev rule to control /dev/kfd permissions:
+
+    echo 'SUBSYSTEM=="kfd", KERNEL=="kfd", TAG+="uaccess", GROUP="video"' | sudo tee /etc/udev/rules.d/70-kfd.rules
+
 
 ### New features to ROCm 1.8.3
 
@@ -70,40 +120,40 @@ from the list provided above for compatibility purposes.
  * UCX support for OpenMPI
  * ROCm RDMA
 
-### The latest ROCm platform - ROCm 1.8.3
+### The latest ROCm platform - ROCm 1.9.0
 
 The latest tested version of the drivers, tools, libraries and source code for
-the ROCm platform have been released and are available under the roc-1.8.x or rocm-1.8.x tag
+the ROCm platform have been released and are available under the roc-1.9.0 or rocm-1.9.x tag
 of the following GitHub repositories:
 
-* [ROCK-Kernel-Driver](https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver/tree/roc-1.8.x)
-* [ROCR-Runtime](https://github.com/RadeonOpenCompute/ROCR-Runtime/tree/roc-1.8.x)
-* [ROCT-Thunk-Interface](https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/tree/roc-1.8.x)
-* [ROC-smi](https://github.com/RadeonOpenCompute/ROC-smi/tree/roc-1.8.x)
-* [HCC compiler](https://github.com/RadeonOpenCompute/hcc/tree/roc-1.8.x)
-* [compiler-runtime](https://github.com/RadeonOpenCompute/compiler-rt/tree/roc-1.8.x)
-* [HIP](https://github.com/GPUOpen-ProfessionalCompute-Tools/HIP/tree/roc-1.8.x)
-* [HIP-Examples](https://github.com/GPUOpen-ProfessionalCompute-Tools/HIP-Examples/tree/roc-1.8.x)
+* [ROCK-Kernel-Driver](https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver/tree/roc-1.9.x)
+* [ROCR-Runtime](https://github.com/RadeonOpenCompute/ROCR-Runtime/tree/roc-1.9.x)
+* [ROCT-Thunk-Interface](https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/tree/roc-1.9.x)
+* [ROC-smi](https://github.com/RadeonOpenCompute/ROC-smi/tree/roc-1.9.x)
+* [HCC compiler](https://github.com/RadeonOpenCompute/hcc/tree/roc-1.9.x)
+* [compiler-runtime](https://github.com/RadeonOpenCompute/compiler-rt/tree/roc-1.9.x)
+* [HIP](https://github.com/GPUOpen-ProfessionalCompute-Tools/HIP/tree/roc-1.9.x)
+* [HIP-Examples](https://github.com/GPUOpen-ProfessionalCompute-Tools/HIP-Examples/tree/roc-1.9.x)
 * [atmi](https://github.com/RadeonOpenCompute/atmi/tree/0.3.7)
 
 Additionally, the following mirror repositories that support the HCC compiler
-are also available on GitHub, and frozen for the rocm-1.8.3 release:
+are also available on GitHub, and frozen for the rocm-1.9.0 release:
 
-* [llvm](https://github.com/RadeonOpenCompute/llvm/tree/roc-1.8.x)
-* [ldd](https://github.com/RadeonOpenCompute/lld/tree/roc-1.8.x)
-* [hcc-clang-upgrade](https://github.com/RadeonOpenCompute/hcc-clang-upgrade/tree/roc-1.8.x)
-* [ROCm-Device-Libs](https://github.com/RadeonOpenCompute/ROCm-Device-Libs/tree/roc-1.8.x)
+* [llvm](https://github.com/RadeonOpenCompute/llvm/tree/roc-1.9.x)
+* [ldd](https://github.com/RadeonOpenCompute/lld/tree/roc-1.9.x)
+* [hcc-clang-upgrade](https://github.com/RadeonOpenCompute/hcc-clang-upgrade/tree/roc-1.9.x)
+* [ROCm-Device-Libs](https://github.com/RadeonOpenCompute/ROCm-Device-Libs/tree/roc-1.9.x)
 
 #### Supported Operating Systems - New operating systems available
 
-The ROCm 1.8.3 platform has been tested on the following operating systems:
- * Ubuntu 16.04
+The ROCm 1.9.0 platform has been tested on the following operating systems:
+ * Ubuntu 16.04 &. 18.04
  * CentOS 7.4 &. 7.5 (Using devetoolset-7 runtime support)
  * RHEL 7.4. &. 7.5  (Using devetoolset-7 runtime support)
 
 ### Installing from AMD ROCm repositories
 
-AMD is hosting both Debian and RPM repositories for the ROCm 1.8.3 packages at this time.
+AMD is hosting both Debian and RPM repositories for the ROCm 1.9.0 packages at this time.
 
 The packages in the Debian repository have been signed to ensure package integrity.
 
@@ -224,7 +274,7 @@ g++ -I /opt/rocm/opencl/include/ ./HelloWorld.cpp -o HelloWorld -L/opt/rocm/open
  ./HelloWorld
 ```
 
-##### How to un-install from Ubuntu 16.04
+##### How to un-install from Ubuntu 16.04 or Ubuntu 18.04
 
 To un-install the entire rocm development package execute:
 
@@ -306,7 +356,7 @@ Installing kernel drivers on CentOS/RHEL 7.4/7.5 requires dkms tool being instal
 
 ```shell
 sudo yum install -y epel-release
-sudo yum install -y dkms kernel-headers-`uname -r`
+sudo yum install -y dkms kernel-headers-`uname -r` kernel-devel-`uname -r`
 ```
 
 
@@ -374,7 +424,7 @@ To do this, compile all applications after running this command:
 ```shell
 scl enable devtoolset-7 bash
 ```
-#### How to un-install ROCm from CentOS/RHEL 7.4
+#### How to un-install ROCm from CentOS/RHEL 7.4 and 7.5
 
 To un-install the entire rocm development package execute:
 
@@ -384,27 +434,17 @@ sudo yum autoremove rocm-dkms
 
 #### Known Issues / Workarounds
 
-##### If you Plan to Run with X11 - we are seeing X freezes under load
+##### Radeon Compute Profiler does not run
 
-In ROCm 1.8.3, the kernel parameter 'noretry' has been set to 1 to improve overall system performance. However it has been proven to bring instability to graphics driver shipped with Ubuntu. This is an ongoing issue and we are looking into it.
+rcprof -A <HSA_application> fails with error message: Radeon Compute Profiler could not be enabled. Version mismatch between HSA runtime and libhsa-runtime-tools64.so.1.
 
-Before that, please try apply this change by changing noretry bit to 0.
+##### Running OCLPerfCounters test results in LLVM ERROR: out of memory
 
-```shell
-echo 0 | sudo tee /sys/module/amdkfd/parameters/noretry
-```
+##### HipCaffe is supported on single GPU configurations
 
-Files under /sys won't be preserved after reboot so you'll need to do it every time.
+##### The ROCm SMI library calls to rsmi_dev_power_cap_set() and rsmi_dev_power_profile_set() will not work for all but the first gpu in multi-gpu set ups.
 
-One way to keep noretry=0 is to change /etc/modprobe.d/amdkfd.conf and make it be:
-
-options amdkfd noretry=0
-
-Once it's done, run sudo update-initramfs -u. Reboot and verify /sys/module/amdkfd/parameters/noretry stays as 0.
-
-##### If you are you are using hipCaffe Alexnet training on ImageNet - we are seeing sporadic hangs of hipCaffe during training
-
-###### Vega10 users who want to run ROCm on a system that does not support PCIe atomics must set HSA_ENABLE_SDMA=0
+##### Vega10 users who want to run ROCm on a system that does not support PCIe atomics must set HSA_ENABLE_SDMA=0
 
 Currently, if you want to run ROCm on a Vega10 GPU (GFX9) on a system without PCIe atomics, you must turn off SDMA functionality.
 
@@ -424,10 +464,10 @@ made available in the following packages:
 
 ### Getting ROCm source code
 
-Modifications can be made to the ROCm 1.8 components by modifying the open
+Modifications can be made to the ROCm 1.9 components by modifying the open
 source code base and rebuilding the components. Source code can be cloned from
 each of the GitHub repositories using git, or users can use the repo command
-and the ROCm 1.8 manifest file to download the entire ROCm 1.8 source code.
+and the ROCm 1.9 manifest file to download the entire ROCm 1.9 source code.
 
 #### Installing repo
 
@@ -444,11 +484,11 @@ Note: make sure ~/bin exists and it is part of your PATH
 
 ```shell
 mkdir ROCm && cd ROCm
-repo init -u https://github.com/RadeonOpenCompute/ROCm.git -b roc-1.8.3
+repo init -u https://github.com/RadeonOpenCompute/ROCm.git -b roc-1.9.0
 repo sync
 ```
 These series of commands will pull all of the open source code associated with
-the ROCm 1.8 release. Please ensure that ssh-keys are configured for the
+the ROCm 1.9 release. Please ensure that ssh-keys are configured for the
 target machine on GitHub for your GitHub ID.
 
 * OpenCL Runtime and Compiler will be submitted to the Khronos Group, prior to

--- a/README.md
+++ b/README.md
@@ -5,6 +5,19 @@ This software enables the high-performance operation of AMD GPUs for computation
 
 ### Current ROCm Version: 1.9.0
 
+- [Hardware Support](#hardware-support)
+  * [Supported GPUs](#supported-gpus)
+  * [Supported CPUs](#supported-cpus)
+  * [Not supported or very limited support under ROCm](#not-supported-or-very-limited-support-under-rocm)
+- [New features and enhancements in ROCm 1.9.0](#new-features-and-enhancements-in-rocm-190)
+- [The latest ROCm platform - ROCm 1.9.0](#the-latest-rocm-platform---rocm-190)
+- [Installing from AMD ROCm repositories](#installing-from-amd-rocm-repositories)
+  * [Ubuntu Support - Installing from a Debian repository](#ubunutu-support---installing-from-a-debian-repository)
+  * [CentOS/RHEL 7 (both 7.4 and 7.5) Support](#centosrhel-7-both-74-and-75-support)
+- [Known Issues / Workarounds](#known-issues--workarounds)
+- [Closed source components](#closed-source-components)
+- [Getting ROCm source code](#getting-rocm-source-code)
+
 ### Hardware Support
 ROCm is focused on using AMD GPUs to accelerate computational tasks, such as machine learning, engineering workloads, and scientific computing. In order to focus our development efforts on these domains of interest, ROCm 
 
@@ -198,7 +211,7 @@ AMD is hosting both Debian and RPM repositories for the ROCm 1.9.0 packages at t
 
 The packages in the Debian repository have been signed to ensure package integrity.
 
-#### Installing from a Debian repository
+#### Ubuntu Support - installing from a Debian repository
 
 ##### First make sure your system is up to date 
 
@@ -353,13 +366,13 @@ sudo apt purge $(dpkg -l | grep 'kfd\|rocm' | grep linux | grep -v libc | awk '{
 
 If possible, we would recommend starting with a fresh OS install.
 
-### CentOS/RHEL 7 (both 7.4 and 7.5) Support
+#### CentOS/RHEL 7 (both 7.4 and 7.5) Support
 
 Support for CentOS/RHEL 7 has been added in ROCm 1.8, but requires a special 
 runtime environment provided by the RHEL Software Collections and additional
 dkms support packages to properly install in run.
 
-#### Preparing RHEL 7 for installation
+##### Preparing RHEL 7 for installation
 
 RHEL is a subscription based operating system, and must enable several external
 repositories to enable installation of the devtoolset-7 environment and the DKMS
@@ -384,7 +397,7 @@ Third, enable additional repositories by downloading and installing the epel-rel
 sudo rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 ```
 
-#### Install and setup Devtoolset-7
+##### Install and setup Devtoolset-7
 
 To setup the Devtoolset-7 environment, follow the instructions on this page:
 
@@ -392,7 +405,7 @@ https://www.softwarecollections.org/en/scls/rhscl/devtoolset-7/
 
 Note that devtoolset-7 is a Software Collections package, and is not supported by AMD.
 
-#### Prepare CentOS/RHEL 7.4 or 7.5 for DKMS Install
+##### Prepare CentOS/RHEL 7.4 or 7.5 for DKMS Install
 
 Installing kernel drivers on CentOS/RHEL 7.4/7.5 requires dkms tool being installed:
 
@@ -402,7 +415,7 @@ sudo yum install -y dkms kernel-headers-`uname -r` kernel-devel-`uname -r`
 ```
 
 
-#### Installing ROCm on the system
+##### Installing ROCm on the system
 
 It is recommended to [remove previous rocm installations](https://github.com/RadeonOpenCompute/ROCm#how-to-un-install-rocm-from-centosrhel-74) before installing the latest version to ensure a smooth installation.
 
@@ -459,7 +472,7 @@ Some users may want to install a subset of the full ROCm installation. In partic
 sudo yum install rock-dkms rocm-opencl
 ```
 
-#### Compiling applications using hcc, hip, etc.
+##### Compiling applications using hcc, hip, etc.
 
 To compile applications or samples, please use gcc-7.2 provided by the devtoolset-7 environment.
 To do this, compile all applications after running this command: 
@@ -467,7 +480,7 @@ To do this, compile all applications after running this command:
 ```shell
 scl enable devtoolset-7 bash
 ```
-#### How to un-install ROCm from CentOS/RHEL 7.4 and 7.5
+##### How to un-install ROCm from CentOS/RHEL 7.4 and 7.5
 
 To un-install the entire rocm development package execute:
 
@@ -475,19 +488,19 @@ To un-install the entire rocm development package execute:
 sudo yum autoremove rocm-dkms
 ```
 
-#### Known Issues / Workarounds
+### Known Issues / Workarounds
 
-##### Radeon Compute Profiler does not run
+#### Radeon Compute Profiler does not run
 
 rcprof -A <HSA_application> fails with error message: Radeon Compute Profiler could not be enabled. Version mismatch between HSA runtime and libhsa-runtime-tools64.so.1.
 
-##### Running OCLPerfCounters test results in LLVM ERROR: out of memory
+#### Running OCLPerfCounters test results in LLVM ERROR: out of memory
 
-##### HipCaffe is supported on single GPU configurations
+#### HipCaffe is supported on single GPU configurations
 
-##### The ROCm SMI library calls to rsmi_dev_power_cap_set() and rsmi_dev_power_profile_set() will not work for all but the first gpu in multi-gpu set ups.
+#### The ROCm SMI library calls to rsmi_dev_power_cap_set() and rsmi_dev_power_profile_set() will not work for all but the first gpu in multi-gpu set ups.
 
-##### Vega10 users who want to run ROCm on a system that does not support PCIe atomics must set HSA_ENABLE_SDMA=0
+#### Vega10 users who want to run ROCm on a system that does not support PCIe atomics must set HSA_ENABLE_SDMA=0
 
 Currently, if you want to run ROCm on a Vega10 GPU (GFX9) on a system without PCIe atomics, you must turn off SDMA functionality.
 
@@ -495,7 +508,7 @@ Currently, if you want to run ROCm on a Vega10 GPU (GFX9) on a system without PC
 export HSA_ENABLE_SDMA=0
 ```
 
-#### Closed source components
+### Closed source components
 
 The ROCm platform relies on a few closed source components to provide legacy
 functionality like HSAIL finalization and debugging/profiling support. These

--- a/README.md
+++ b/README.md
@@ -1,34 +1,74 @@
 ## Are You Ready to ROCK?
 The ROCm Platform brings a rich foundation to advanced computing by seamlessly
- integrating the CPU and GPU with the goal of solving real-world problems.
+integrating the CPU and GPU with the goal of solving real-world problems.
+This software enables the high-performance operation of AMD GPUs for computationally-oriented tasks in the Linux operating system.
+
+### Current ROCm Version: 1.9.0
+
+### Hardware Support
+ROCm is focused on using AMD GPUs to accelerate computational tasks, such as machine learning, engineering workloads, and scientific computing. In order to focus our development efforts on these domains of interest, ROCm 
+
+#### Supported GPUs
+Because the ROCm Platform has a focus on particular computational domains, we offer official support for a selection of AMD GPUs that are designed to offer good performance and price in these domains.
+
+ROCm officially supports AMD GPUs that have use following chips:
+  * GFX8 GPUs
+    * "Fiji" chips, such as on the the AMD Radeon R9 Fury X and Radeon Instinct MI8
+    * "Polaris 10" chips, such as on the AMD Radeon RX 580 and Radeon Instinct MI6
+    * "Polaris 11" chips, such as on the AMD Radeon RX 570 and Radeon Pro WX 4100
+  * GFX9 GPUs
+    * "Vega 10" chips, such as on the AMD Radeon Radeon RX Vega 64 and Radeon Instinct MI25
+
+ROCm is a collection of software ranging from drivers and runtimnes to libraries and developer tools.
+Some of this software may work with more GPUs than the "officially supported" list above, though AMD does not make any official claims of support for these devices on the ROCm software platform.
+The following list of GPUs are likely to work within ROCm, though full support is not guaranteed:
+  * GFX7 GPUs
+    * "Hawaii" chips, such as the AMD Radeon R9 390X and FirePro W9100
+
+As described in the next section, GFX8 GPUs require PCIe gen 3 with support for PCIe atomics. This requires both CPU and motherboard support. GFX9 GPUs, by default, also require PCIe gen 3 with support for PCIe atomics; if you want to avoid using PCIe atomics, please set the environment variable `HSA_ENABLE_SDMA=0`. GFX7 GPUs do not require PCIe atomics.
+
+At this time, the integrated GPUs in AMD APUs are not officially supported targets for ROCm.
+
+For a more detailed list of hardware support, please see [the following documentation](https://rocm.github.io/hardware.html).
 
 #### Supported CPUs
-
-Starting with ROCm 1.8, we have relaxed the requirements for PCIe Atomics on Vega 10 (GFX9) GPUs, and we have similarly opened up more options for number of PCIe lanes. With this release, these GFX9 GPUs can support CPUs without PCIe Atomics and, for example, run on PCIe  Gen2 x1 lanes. To enable this option, please set the environment variable `HSA_ENABLE_SDMA=0`.  This is not supported on GPUs below GFX9, i.e. GFX8 cards in Fiji and Polaris families.
+As described above, GFX8 and GFX9 GPUs require PCI Express 3.0 with PCIe atomics in the default ROCm configuration.
+In particular, the CPU and every active PCIe point between the CPU and GPU require support for PCIe gen 3 and PCIe atomics.
+The CPU root must indicate PCIe AtomicOp Completion capabilities and any intermediate switch must indicate PCIe AtomicOp Routing capabilities.
 
 Current CPUs which support PCIe Gen3 + PCIe Atomics are: 
   * AMD Ryzen CPUs;
+  * AMD Ryzen APUs;
+  * AMD Ryzen Threadripper CPUs
   * AMD EPYC CPUs;  
-  * Intel Xeon E7 V3  or newer CPUs;
+  * Intel Xeon E7 v3 or newer CPUs;
   * Intel Xeon E5 v3 or newer CPUs; 
   * Intel Xeon E3 v3 or newer CPUs;
   * Intel Core i7 v4, Core i5 v4, Core i3 v4 or newer CPUs (i.e. Haswell family or newer).
 
-For Fiji and Polaris GPUs, the ROCm platform leverages PCIe Atomics (Fetch and Add, Compare and Swap, 
-Unconditional Swap, AtomicsOp Completion).
-PCIe Atomics are only supported on PCIe Gen3 enabled CPUs and PCIe Gen3 switches like
-Broadcom PLX. When you install your GPUs, make sure you install them in a fully
-PCIe Gen3 x16 or x8, x4 or x1  slot attached either directly to the CPU's Root I/O 
-controller or via a PCIe switch directly attached to the CPU's Root I/O 
-controller. In our experience, many issues stem from trying to use consumer 
-motherboards which provide physical x16 connectors that are electrically 
-connected as e.g. PCIe Gen2 x4, PCIe slots connected via the 
-Southbridge PCIe I/O controller, or PCIe slots connected through a PCIe switch that does
-not support PCIe atomics. 
- 
+Beginning with ROCm 1.8, we have relaxed the requirements for PCIe Atomics on GFX9 GPUs such as Vega 10.
+We have similarly opened up more options for number of PCIe lanes.
+GFX9 GPUs can now be run on CPUs without PCIe atomics and on older PCIe generations such as gen 2.
+To enable this option, please set the environment variable `HSA_ENABLE_SDMA=0`.
+This is not supported on GPUs below GFX9, e.g. GFX8 cards in Fiji and Polaris families.
+
+If you are using any PCIe switches in your system, please note that PCIe Atomics are only supported on some switches, such as Boradcom PLX.
+When you install your GPUs, make sure you install them in a fully PCIe Gen3 x16 or x8, x4 or x1 slot attached either directly to the CPU's Root I/O controller or via a PCIe switch directly attached to the CPU's Root I/O controller.
+
+In our experience, many issues stem from trying to use consumer motherboards which provide physical x16 connectors that are electrically connected as e.g. PCIe Gen2 x4, PCIe slots connected via the Southbridge PCIe I/O controller, or PCIe slots connected through a PCIe switch that does
+not support PCIe atomics.
+
+If you attempt to run ROCm on a system without proper PCIe atomic support, you may see an error in the kernel log (`dmesg`):
+```
+kfd: skipped device 1002:7300, PCI rejects atomics
+```
+
 Experimental support for our Hawaii (GFX7) GPUs (Radeon R9 290, R9 390, FirePro W9100, S9150, S9170)
 does not require or take advantage of PCIe Atomics. However, we still recommend that you use a CPU
 from the list provided above for compatibility purposes.
+
+Reminder: if you are using gfx9 GPUs, you can bypass this requirement by setting the environment variable `HSA_ENABLE_SDMA=0`.
+However, this disables the use of DMA engines to move data between the CPU and GPU memory. This can reduce performance.
 
 #### Not supported or very limited support under ROCm 
 ###### Limited support 
@@ -38,6 +78,7 @@ from the list provided above for compatibility purposes.
 
 ###### Not supported 
 
+* "Tonga", "Iceland", "Polaris 12", and "Vega M" GPUs are not supported in ROCm 1.9.0
 * We do not support GFX8-class GPUs (Fiji, Polaris, etc.) on CPUs that do not have PCIe Gen 3 with PCIe atomics.
   * As such, do not support AMD Carrizo and Kaveri APUs as hosts for such GPUs..
   * Thunderbolt 1 and 2 enabled GPUs are not supported by GFX8 GPUs on ROCm. Thunderbolt 1 & 2 are PCIe Gen2 based.
@@ -97,7 +138,7 @@ To try ROCm with an upstream kernel, install ROCm as normal, but do not install 
     echo 'SUBSYSTEM=="kfd", KERNEL=="kfd", TAG+="uaccess", GROUP="video"' | sudo tee /etc/udev/rules.d/70-kfd.rules
 
 
-### New features to ROCm 1.8.3
+### New features as of ROCm 1.8.3
 
 * ROCm 1.8.3 is a minor update meant to fix compatibility issues on Ubuntu releases running kernel 4.15.0-33
 

--- a/default.xml
+++ b/default.xml
@@ -6,7 +6,7 @@
     <remote name="pctools-github"
             fetch="http://git@github.com/GPUOpen-ProfessionalCompute-Tools/" />
 
-    <default revision="roc-1.8.x"
+    <default revision="roc-1.9.x"
              remote="roc-github"
              sync-j="4" />
 


### PR DESCRIPTION
Changes to ROCm README:
* Putting the current ROCm version right at the top to prevent confusion
* Adding a table of contents because this README is getting somewhat long.
* Updating the hardware support section to be more specific about what GPUs we support, in an attempt to match the [long-form hardware support list](https://rocm.github.io/hardware.html).
* Other minor changes:
  * Re-align sections/subsections so that CentOS/RHEL directions are contained under "Installing from AMD ROCm repositories" instead of on the same level as that.