### PR TITLE
README and repo overhaul for the ROCm 2.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ## Are You Ready to ROCK?
-The ROCm Platform brings a rich foundation to advanced computing by seamlessly
-integrating the CPU and GPU with the goal of solving real-world problems.
-This software enables the high-performance operation of AMD GPUs for computationally-oriented tasks in the Linux operating system.
+The ROCm Platform brings a rich foundation to advanced computing by seamlessly integrating the CPU and GPU with the goal of solving real-world problems.
+This software enables the high-performance operation of AMD GPUs for computationally oriented tasks in the Linux operating system.
 
 ### Current ROCm Version: 2.0
 
@@ -10,52 +9,58 @@ This software enables the high-performance operation of AMD GPUs for computation
   * [Supported CPUs](#supported-cpus)
   * [Not supported or very limited support under ROCm](#not-supported-or-very-limited-support-under-rocm)
 - [New features and enhancements in ROCm 2.0](#new-features-and-enhancements-in-rocm-20)
-- [New features and enhancements in ROCm 1.9.2](#new-features-and-enhancements-in-rocm-192)
-- [New features and enhancements in ROCm 1.9.1](#new-features-and-enhancements-in-rocm-191)
-- [New features and enhancements in ROCm 1.9.0](#new-features-and-enhancements-in-rocm-190)
 - [The latest ROCm platform - ROCm 2.0](#the-latest-rocm-platform---rocm-20)
+  * [Supported Operating Systems](#supported-operating-systems---new-operating-systems-available)
+  * [ROCm support in upstream Linux kernels](#rocm-support-in-upstream-linux-kernels)
 - [Installing from AMD ROCm repositories](#installing-from-amd-rocm-repositories)
-  * [Ubuntu Support - Installing from a Debian repository](#ubuntu-support---installing-from-a-debian-repository)
-  * [CentOS/RHEL 7 (7.4, 7.5 and 7.6) Support](#centosrhel-7-74-75-76-support)
-- [Known Issues / Workarounds](#known-issues--workarounds)
+  * [ROCm Binary Package Structure](#rocm-binary-package-structure)
+  * [Ubuntu Support - installing from a Debian repository](#ubuntu-support---installing-from-a-debian-repository)
+  * [CentOS/RHEL 7 (7.4, 7.5, 7.6) Support](#centosrhel-7-74-75-76-support)
+- [Known issues / workarounds](#known-issues--workarounds)
 - [Closed source components](#closed-source-components)
 - [Getting ROCm source code](#getting-rocm-source-code)
+  * [Installing repo](#installing-repo)
+  * [Downloading the ROCm source code](#downloading-the-rocm-source-code)
+  * [Building the ROCm source code](#building-the-rocm-source-code)
+- [Final notes](#final-notes)
 
 ### Hardware Support
-ROCm is focused on using AMD GPUs to accelerate computational tasks, such as machine learning, engineering workloads, and scientific computing. In order to focus our development efforts on these domains of interest, ROCm supports a targeted set of hardware configurations which are detailed further in this section. 
+ROCm is focused on using AMD GPUs to accelerate computational tasks such as machine learning, engineering workloads, and scientific computing.
+In order to focus our development efforts on these domains of interest, ROCm supports a targeted set of hardware configurations which are detailed further in this section.
 
 #### Supported GPUs
 Because the ROCm Platform has a focus on particular computational domains, we offer official support for a selection of AMD GPUs that are designed to offer good performance and price in these domains.
 
-ROCm officially supports AMD GPUs that have use following chips:
+ROCm officially supports AMD GPUs that use following chips:
   * GFX8 GPUs
-    * "Fiji" chips, such as on the the AMD Radeon R9 Fury X and Radeon Instinct MI8
+    * "Fiji" chips, such as on the AMD Radeon R9 Fury X and Radeon Instinct MI8
     * "Polaris 10" chips, such as on the AMD Radeon RX 580 and Radeon Instinct MI6
     * "Polaris 11" chips, such as on the AMD Radeon RX 570 and Radeon Pro WX 4100
+    * "Polaris 12" chips, such as on the AMD Radeon RX 550 and Radeon RX 540
   * GFX9 GPUs
-    * "Vega 10" chips, such as on the AMD Radeon Radeon RX Vega 64 and Radeon Instinct MI25
-    * Vega 7nm
+    * "Vega 10" chips, such as on the AMD Radeon RX Vega 64 and Radeon Instinct MI25
+    * "Vega 7nm" chips
 
 ROCm is a collection of software ranging from drivers and runtimes to libraries and developer tools.
 Some of this software may work with more GPUs than the "officially supported" list above, though AMD does not make any official claims of support for these devices on the ROCm software platform.
-The following list of GPUs are likely to work within ROCm, though full support is not guaranteed:
+The following list of GPUs are enabled in the ROCm software, though full support is not guaranteed:
   * GFX7 GPUs
     * "Hawaii" chips, such as the AMD Radeon R9 390X and FirePro W9100
 
-As described in the next section, GFX8 GPUs require PCIe gen 3 with support for PCIe atomics. This requires both CPU and motherboard support. GFX9 GPUs, by default, also require PCIe gen 3 with support for PCIe atomics, but they can operate in most cases without this capability.
+As described in the next section, GFX8 GPUs require PCI Express 3.0 (PCIe 3.0) with support for PCIe atomics. This requires both CPU and motherboard support. GFX9 GPUs, by default, also require PCIe 3.0 with support for PCIe atomics, but they can operate in most cases without this capability.
 
 At this time, the integrated GPUs in AMD APUs are not officially supported targets for ROCm.
 
 For a more detailed list of hardware support, please see [the following documentation](https://rocm.github.io/hardware.html).
 
 #### Supported CPUs
-As described above, GFX8 and GFX9 GPUs require PCI Express 3.0 with PCIe atomics in the default ROCm configuration.
-In particular, the CPU and every active PCIe point between the CPU and GPU require support for PCIe gen 3 and PCIe atomics.
+As described above, GFX8 GPUs require PCIe 3.0 with PCIe atomics in order to run ROCm.
+In particular, the CPU and every active PCIe point between the CPU and GPU require support for PCIe 3.0 and PCIe atomics.
 The CPU root must indicate PCIe AtomicOp Completion capabilities and any intermediate switch must indicate PCIe AtomicOp Routing capabilities.
 
 Current CPUs which support PCIe Gen3 + PCIe Atomics are: 
   * AMD Ryzen CPUs;
-  * AMD Ryzen APUs;
+  * The CPUs in AMD Ryzen APUs;
   * AMD Ryzen Threadripper CPUs
   * AMD EPYC CPUs;  
   * Intel Xeon E7 v3 or newer CPUs;
@@ -64,15 +69,15 @@ Current CPUs which support PCIe Gen3 + PCIe Atomics are:
   * Intel Core i7 v4, Core i5 v4, Core i3 v4 or newer CPUs (i.e. Haswell family or newer).
   * Some Ivy Bridge-E systems
 
-Beginning with ROCm 1.8, we have relaxed the requirements for PCIe Atomics on GFX9 GPUs such as Vega 10.
+Beginning with ROCm 1.8, GFX9 GPUs (such as Vega 10) no longer require PCIe atomics.
 We have similarly opened up more options for number of PCIe lanes.
-GFX9 GPUs can now be run on CPUs without PCIe atomics and on older PCIe generations such as gen 2.
-This is not supported on GPUs below GFX9, e.g. GFX8 cards in Fiji and Polaris families.
+GFX9 GPUs can now be run on CPUs without PCIe atomics and on older PCIe generations, such as PCIe 2.0.
+This is not supported on GPUs below GFX9, e.g. GFX8 cards in the Fiji and Polaris families.
 
 If you are using any PCIe switches in your system, please note that PCIe Atomics are only supported on some switches, such as Broadcom PLX.
-When you install your GPUs, make sure you install them in a fully PCIe Gen3 x16 or x8, x4 or x1 slot attached either directly to the CPU's Root I/O controller or via a PCIe switch directly attached to the CPU's Root I/O controller.
+When you install your GPUs, make sure you install them in a PCIe 3.0 x16, x8, x4, or x1 slot attached either directly to the CPU's Root I/O controller or via a PCIe switch directly attached to the CPU's Root I/O controller.
 
-In our experience, many issues stem from trying to use consumer motherboards which provide physical x16 connectors that are electrically connected as e.g. PCIe Gen2 x4, PCIe slots connected via the Southbridge PCIe I/O controller, or PCIe slots connected through a PCIe switch that does
+In our experience, many issues stem from trying to use consumer motherboards which provide physical x16 connectors that are electrically connected as e.g. PCIe 2.0 x4, PCIe slots connected via the Southbridge PCIe I/O controller, or PCIe slots connected through a PCIe switch that does
 not support PCIe atomics.
 
 If you attempt to run ROCm on a system without proper PCIe atomic support, you may see an error in the kernel log (`dmesg`):
@@ -87,24 +92,26 @@ from the list provided above for compatibility purposes.
 #### Not supported or very limited support under ROCm 
 ###### Limited support 
 
-* ROCm 2.0.x should support PCIe Gen2 enabled CPUs such as the AMD Opteron, Phenom, Phenom II, Athlon, Athlon X2, Athlon II and older Intel Xeon and Intel Core Architecture and Pentium CPUs. However, we have done very limited testing on these configurations, since our test farm has been catering to CPU listed above. This is where we need community support; if you find problems on such setups, please report these issues.
- * Thunderbolt 1, 2, and 3 enabled breakout boxes should now be able to work with ROCm. Thunderbolt 1 and 2 are PCIe Gen2 based, and thus are only supported with GPUs that do not require PCIe Gen 3 atomics (i.e. Vega 10). However, we have done no testing on this configuration and would need comunity support due to limited access to this type of equipment 
+* ROCm 2.0.x should support PCIe 2.0 enabled CPUs such as the AMD Opteron, Phenom, Phenom II, Athlon, Athlon X2, Athlon II and older Intel Xeon and Intel Core Architecture and Pentium CPUs. However, we have done very limited testing on these configurations, since our test farm has been catering to CPUs listed above. This is where we need community support. _If you find problems on such setups, please report these issues_.
+ * Thunderbolt 1, 2, and 3 enabled breakout boxes should now be able to work with ROCm. Thunderbolt 1 and 2 are PCIe 2.0 based, and thus are only supported with GPUs that do not require PCIe 3.0 atomics (e.g. Vega 10). However, we have done no testing on this configuration and would need community support due to limited access to this type of equipment.
 
 ###### Not supported 
 
-* "Tonga", "Iceland", "Polaris 12", and "Vega M" GPUs are not supported in ROCm 2.0.x
-* We do not support GFX8-class GPUs (Fiji, Polaris, etc.) on CPUs that do not have PCIe Gen 3 with PCIe atomics.
-  * As such, do not support AMD Carrizo and Kaveri APUs as hosts for such GPUs..
-  * Thunderbolt 1 and 2 enabled GPUs are not supported by GFX8 GPUs on ROCm. Thunderbolt 1 & 2 are PCIe Gen2 based.
+* "Tonga", "Iceland", and "Vega M" GPUs are not supported in ROCm 2.0.x
+* We do not support GFX8-class GPUs (Fiji, Polaris, etc.) on CPUs that do not have PCIe 3.0 with PCIe atomics.
+  * As such, do not support AMD Carrizo and Kaveri APUs as hosts for such GPUs.
+  * Thunderbolt 1 and 2 enabled GPUs are not supported by GFX8 GPUs on ROCm. Thunderbolt 1 & 2 are based on PCIe 2.0.
 * AMD Carrizo based APUs have limited support due to OEM & ODM's choices when it comes to some key configuration parameters. In particular, we have observed that Carrizo laptops, AIOs, and desktop systems showed inconsistencies in exposing and enabling the System BIOS parameters required by the ROCm stack. Before purchasing a Carrizo system for ROCm, please verify that the BIOS provides an option for enabling IOMMUv2 and that the system BIOS properly exposes the correct CRAT table - please inquire with the OEM about the latter.
  * AMD Merlin/Falcon Embedded System is not currently supported by the public repo.
- * AMD Raven Ridge APU are currently not supported as GPU targets
+ * AMD Raven Ridge APU are currently not supported as GPU targets.
 
 ### New features and enhancements in ROCm 2.0
 
+Features and enhancements introduced in previous versions of ROCm can be found in [version_history.md](version_history.md)
+
 #### Adds support for RHEL 7.6 / CentOS 7.6 and Ubuntu 18.04.1
 
-#### Adds support for Vega 7nm
+#### Adds support for Vega 7nm, Polaris 12 GPUs
 
 #### Introduces MIVisionX
 * A comprehensive computer vision and machine intelligence libraries, utilities and applications bundled into a single toolkit.
@@ -135,156 +142,190 @@ from the list provided above for compatibility purposes.
 #### OpenCL 2.0 support
 * ROCm 2.0 introduces full support for kernels written in the OpenCL 2.0 C language on certain devices and systems.  Applications can detect this support by calling the “clGetDeviceInfo” query function with “parame_name” argument set to “CL_DEVICE_OPENCL_C_VERSION”.  In order to make use of OpenCL 2.0 C language features, the application must include the option “-cl-std=CL2.0” in options passed to the runtime API calls responsible for compiling or building device programs.  The complete specification for the OpenCL 2.0 C language can be obtained using the following link: https://www.khronos.org/registry/OpenCL/specs/opencl-2.0-openclc.pdf 
 
-#### Improved Virtual Addressing (48 bit VA) management for Vega 10 and later GPUs
+#### Improved Virtual Addressing (48-bit VA) management for Vega 10 and later GPUs
 * Fixes Clang AddressSanitizer and potentially other 3rd-party memory debugging tools with ROCm
 * Small performance improvement on workloads that do a lot of memory management
 * Removes virtual address space limitations on systems with more VRAM than system memory
 
 #### Kubernetes support
- 
-### New features and enhancements in ROCm 1.9.2
-#### RDMA(MPI) support on Vega 7nm
-* Support ROCnRDMA based on Mellanox InfiniBand
-
-#### Improvements to HCC
-* Improved link time optimization
-
-#### Improvements to ROCProfiler tool
-* General bug fixes and implemented versioning APIs
-
-### New features and enhancements in ROCm 1.9.2
-#### RDMA(MPI) support on Vega 7nm
-* Support ROCnRDMA based on Mellanox InfiniBand
-
-#### Improvements to HCC
-* Improved link time optimization
-
-#### Improvements to ROCProfiler tool
-* General bug fixes and implemented versioning APIs
-
-#### Critical bug fixes
-
-### New features and enhancements in ROCm 1.9.1
-#### Added DPM support to Vega 7nm
-* Dynamic Power Management feature is enabled on Vega 7nm.
- 
-#### Fix for 'ROCm profiling' that used to fail with a “Version mismatch between HSA runtime and libhsa-runtime-tools64.so.1” error
-
-### New features and enhancements in ROCm 1.9.0
-
-#### Preview for Vega 7nm
-* Enables developer preview support for Vega 7nm
-
-#### System Management Interface
-* Adds support for the ROCm SMI (System Management Interface) library, which provides monitoring and management capabilities for AMD GPUs.
-
-#### Improvements to HIP/HCC
-* Support for gfx906
-* Added deprecation warning for C++AMP.  This will be the last version of HCC supporting C++AMP.
-* Improved optimization for global address space pointers passing into a GPU kernel
-* Fixed several race conditions in the HCC runtime
-* Performance tuning to the unpinned copy engine
-* Several codegen enhancement fixes in the compiler backend
-
-#### Preview for rocprof Profiling Tool
-Developer preview (alpha) of profiling tool rocProfiler. It includes a command-line front-end, `rpl_run.sh`, which enables:
-* Cmd-line tool for dumping public per kernel perf-counters/metrics and kernel timestamps
-* Input file with counters list and kernels selecting parameters
-* Multiple counters groups and app runs supported
-* Output results in CSV format
-
-The tool can be installed from the `rocprofiler-dev` package. It will be installed into: /opt/rocm/bin/rpl_run.sh
-
-#### Preview for rocr Debug Agent rocr_debug_agent
-The ROCr Debug Agent is a library that can be loaded by ROCm Platform Runtime to provide the following functionality:
-* Print the state for wavefronts that report memory violation or upon executing a "s_trap 2" instruction.
-* Allows SIGINT (`ctrl c`) or SIGTERM (`kill -15`) to print wavefront state of aborted GPU dispatches.
-* It is enabled on Vega10 GPUs on ROCm1.9.
-
-The ROCm1.9 release will install the ROCr Debug Agent library at /opt/rocm/lib/librocr_debug_agent64.so
-
-
-#### New distribution support 
-
-* Binary package support for Ubuntu 18.04
-
-#### ROCm 1.9 is ABI compatible with KFD in upstream Linux kernels. 
-Upstream Linux kernels support the following GPUs in these releases:
-4.17: Fiji, Polaris 10, Polaris 11
-4.18: Fiji, Polaris 10, Polaris 11, Vega10
-
-Some ROCm features are not available in the upstream KFD:
-* More system memory available to ROCm applications
-* Interoperability between graphics and compute
-* RDMA
-* IPC
-
-To try ROCm with an upstream kernel, install ROCm as normal, but do not install the rock-dkms package. Also add a udev rule to control /dev/kfd permissions:
-
-    echo 'SUBSYSTEM=="kfd", KERNEL=="kfd", TAG+="uaccess", GROUP="video"' | sudo tee /etc/udev/rules.d/70-kfd.rules
-
-
-### New features as of ROCm 1.8.3
-
-* ROCm 1.8.3 is a minor update meant to fix compatibility issues on Ubuntu releases running kernel 4.15.0-33
-
-### New features as of ROCm 1.8.2
-
-#### DKMS driver installation
-
- * Debian packages are provided for DKMS on Ubuntu
- * RPM packages are provided for CentOS/RHEL 7.4 and 7.5 support
- * See the [ROCT-Thunk-Interface](https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/tree/roc-1.8.x) and [ROCK-Kernel-Driver](https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver/tree/roc-1.8.x) for additional documentation on driver setup
-
-#### New distribution support 
-
- * Binary package support for Ubuntu 16.04 and 18.04
- * Binary package support for CentOS 7.4 and 7.5
- * Binary package support for RHEL 7.4 and 7.5
- 
-#### Improved OpenMPI via UCX support 
-
- * UCX support for OpenMPI
- * ROCm RDMA
 
 ### The latest ROCm platform - ROCm 2.0
 
-The latest tested version of the drivers, tools, libraries and source code for
-the ROCm platform have been released and are available under the roc-2.0.0 or rocm-2.0.x tag
-of the following GitHub repositories:
+The latest supported version of the drivers, tools, libraries and source code for the ROCm platform have been released and are available from the following GitHub repositories:
 
-* [ROCK-Kernel-Driver](https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver/tree/roc-2.0.x)
-* [ROCR-Runtime](https://github.com/RadeonOpenCompute/ROCR-Runtime/tree/roc-2.0.x)
-* [ROCT-Thunk-Interface](https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/tree/roc-2.0.x)
-* [ROC-smi](https://github.com/RadeonOpenCompute/ROC-smi/tree/roc-2.0.x)
-* [HCC compiler](https://github.com/RadeonOpenCompute/hcc/tree/roc-2.0.x)
-* [compiler-runtime](https://github.com/RadeonOpenCompute/compiler-rt/tree/roc-2.0.x)
-* [HIP](https://github.com/GPUOpen-ProfessionalCompute-Tools/HIP/tree/roc-2.0.x)
-* [HIP-Examples](https://github.com/GPUOpen-ProfessionalCompute-Tools/HIP-Examples/tree/roc-2.0.x)
-* [atmi](https://github.com/RadeonOpenCompute/atmi/tree/0.3.7)
-
-Additionally, the following mirror repositories that support the HCC compiler
-are also available on GitHub, and frozen for the rocm-2.0.x release:
-
-* [llvm](https://github.com/RadeonOpenCompute/llvm/tree/roc-2.0.x)
-* [ldd](https://github.com/RadeonOpenCompute/lld/tree/roc-2.0.x)
-* [hcc-clang-upgrade](https://github.com/RadeonOpenCompute/hcc-clang-upgrade/tree/roc-2.0.x)
-* [ROCm-Device-Libs](https://github.com/RadeonOpenCompute/ROCm-Device-Libs/tree/roc-2.0.x)
+* ROCm Core Components
+  - [ROCk Kernel Driver](https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver/tree/roc-2.0.0)
+  - [ROCr Runtime](https://github.com/RadeonOpenCompute/ROCR-Runtime/tree/roc-2.0.0)
+  - [ROCt Thunk Interface](https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/tree/roc-2.0.0)
+* ROCm Support Software
+  - [ROCm SMI](https://github.com/RadeonOpenCompute/ROC-smi/tree/roc-2.0.0)
+  - [ROCm cmake](https://github.com/RadeonOpenCompute/rocm-cmake/tree/ac45c6e6)
+  - [rocminfo](https://github.com/RadeonOpenCompute/rocminfo/tree/1bb0ccc7)
+  - [ROCm Bandwidth Test](https://github.com/RadeonOpenCompute/rocm_bandwidth_test/tree/roc-2.0.0)
+* ROCm Development Tools
+  - [HCC compiler](https://github.com/RadeonOpenCompute/hcc/tree/roc-2.0.0)
+  - [HIP](https://github.com/ROCm-Developer-Tools/HIP/tree/roc-2.0.0)
+  - [ROCm Device Libraries](https://github.com/RadeonOpenCompute/ROCm-Device-Libs/tree/roc-2.0.0)
+  - ROCm OpenCL, which is created from the following components:
+    - [ROCm OpenCL Runtime](http://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/tree/roc-2.0.0)
+    - [ROCm OpenCL Driver](http://github.com/RadeonOpenCompute/ROCm-OpenCL-Driver/tree/roc-2.0.0)
+    - The ROCm OpenCL compiler, which is created from the following components:
+      - [ROCm LLVM](http://github.com/RadeonOpenCompute/llvm/tree/roc-2.0.0)
+      - [ROCm Clang](http://github.com/RadeonOpenCompute/clang/tree/roc-2.0.0)
+      - [ROCm lld](http://github.com/RadeonOpenCompute/lld/tree/roc-2.0.0)
+      - [ROCm Device Libraries](https://github.com/RadeonOpenCompute/ROCm-Device-Libs/tree/roc-2.0.0)
+  - [ROCM Clang-OCL Kernel Compiler](https://github.com/RadeonOpenCompute/clang-ocl/tree/688fe5d9)
+  - [Asynchronous Task and Memory Interface (ATMI)](https://github.com/RadeonOpenCompute/atmi/tree/4dd14ad8)
+  - [ROCr Debug Agent](https://github.com/ROCm-Developer-Tools/rocr_debug_agent/tree/roc-2.0.0)
+  - [ROCm Code Object Manager](https://github.com/RadeonOpenCompute/ROCm-CompilerSupport/tree/roc-2.0.0)
+  - Example Applications:
+    - [HCC Examples](https://github.com/ROCm-Developer-Tools/HCC-Example-Application/tree/ffd65333)
+    - [HIP Examples](https://github.com/ROCm-Developer-Tools/HIP-Examples/tree/roc-2.0.x)
+* ROCm Libraries
+  - [rocBLAS](https://github.com/ROCmSoftwarePlatform/rocBLAS/tree/v2.0.0)
+  - [hipBLAS](https://github.com/ROCmSoftwarePlatform/hipBLAS/tree/v0.12.1.0)
+  - [rocFFT](https://github.com/ROCmSoftwarePlatform/rocFFT/tree/v0.8.8)
+  - [rocRAND](https://github.com/ROCmSoftwarePlatform/rocRAND/tree/7278524e)
+  - [rocSPARSE](https://github.com/ROCmSoftwarePlatform/rocSPARSE/tree/v1.0.1)
+  - [hipSPARSE](https://github.com/ROCmSoftwarePlatform/hipSPARSE/tree/v1.0.2)
+  - [rocALUTION](https://github.com/ROCmSoftwarePlatform/rocALUTION/tree/v1.3.7)
+  - [MIOpenGEMM](https://github.com/ROCmSoftwarePlatform/MIOpenGEMM/tree/9547fb9e)
+  - [MIOpen](https://github.com/ROCmSoftwarePlatform/MIOpen/tree/1.7.0)
+  - [HIP Thrust](https://github.com/ROCmSoftwarePlatform/Thrust/tree/e0b8fe2a)
+  - [ROCm SMI Lib](https://github.com/RadeonOpenCompute/rocm_smi_lib/tree/roc-2.0.0)
+  - [RCCL](https://github.com/ROCmSoftwarePlatform/rccl/tree/0.7.1)
+  - [MIVisionX](https://github.com/GPUOpen-ProfessionalCompute-Libraries/MIVisionX/tree/1.0.0)
 
 #### Supported Operating Systems - New operating systems available
 
 The ROCm 2.0.x platform supports the following operating systems:
- * Ubuntu 16.04.x & 18.04.x (Version 16.04.3 and newer or kernels 4.13 and newer)
- * CentOS 7.4 & 7.5 & 7.6 (Using devtoolset-7 runtime support)
- * RHEL 7.4 & 7.5 & 7.6 (Using devtoolset-7 runtime support)
+ * Ubuntu 16.04.x and 18.04.x (Version 16.04.3 and newer or kernels 4.13 and newer)
+ * CentOS 7.4, 7.5, and 7.6 (Using devtoolset-7 runtime support)
+ * RHEL 7.4, 7.5, and 7.6 (Using devtoolset-7 runtime support)
+
+#### ROCm support in upstream Linux kernels
+
+As of ROCm 1.9.0, the ROCm user-level software is compatible with the AMD drivers in certain upstream Linux kernels.
+As such, users have the option of either using the ROCK kernel driver that are part of AMD's ROCm repositories or using the upstream driver and only installing ROCm user-level utilities from AMD's ROCm repositories.
+
+These releases of the upstream Linux kernel support the following GPUs in ROCm:
+ * 4.17: Fiji, Polaris 10, Polaris 11
+ * 4.18: Fiji, Polaris 10, Polaris 11, Vega10
+
+The upstream driver may be useful for running ROCm software on systems that are not compatible with the kernel driver available in AMD's repositories.
+For users that have the option of using either AMD's or the upstreamed driver, there are various tradeoffs to take into consideration:
+
+|   | Using AMD's `rock-dkms` package | Using the upstream kernel driver |
+| ---- | ------------------------------------------------------------| ----- |
+| Pros | More GPU features, and they are enabled earlier | Includes the latest Linux kernel features |
+|      | Tested by AMD on supported distributions | May work on other distributions and with custom kernels |
+|      | Supported GPUs enabled regardless of kernel version | |
+|      | Includes the latest GPU firmware | |
+| Cons | May not work on all Linux distributions or versions | Features and hardware support varies depending on kernel version |
+|      | Not currently supported on kernels newer than 4.18 | Limits GPU's usage of system memory to 3/8 of system memory |
+|      |   | IPC and RDMA capabilities are not yet enabled |
+|      |   | Not tested by AMD to the same level as `rock-dkms` package |
+|      |   | Does not include most up-to-date firmware |
+
 
 ### Installing from AMD ROCm repositories
 
-AMD is hosting both Debian and RPM repositories for the ROCm 2.0.x packages at this time.
+AMD hosts both [Debian](http://repo.radeon.com/rocm/apt/debian/) and [RPM](http://repo.radeon.com/rocm/yum/rpm/) repositories for the ROCm 2.0.x packages at this time.
 
 The packages in the Debian repository have been signed to ensure package integrity.
 
+#### ROCm Binary Package Structure
+
+ROCm is a collection of software ranging from drivers and runtimes to libraries and developer tools.
+In AMD's package distributions, these software projects are provided as a separate packages.
+This allows users to install only the packages they need, if they do not wish to install all of ROCm.
+These packages will install most of the ROCm software into `/opt/rocm/` by default.
+
+The packages for each of the major ROCm components are:
+* ROCm Core Components
+  - ROCk Kernel Driver: `rock-dkms`
+  - ROCr Runtime: `hsa-rocr-dev`, `hsa-ext-rocr-dev`
+  - ROCt Thunk Interface: `hsakmt-roct`, `hsakmt-roct-dev`
+* ROCm Support Software
+  - ROCm SMI: `rocm-smi`
+  - ROCm cmake: `rocm-cmake`
+  - rocminfo: `rocminfo`
+  - ROCm Bandwidth Test: `rocm_bandwidth_test`
+* ROCm Development Tools
+  - HCC compiler: `hcc`
+  - HIP: `hip_base`, `hip_doc`, `hip_hcc`, `hip_samples`
+  - ROCm Device Libraries: `rocm-device-libs`
+  - ROCm OpenCL: `rocm-opencl`, `rocm-opencl-devel` (on RHEL/CentOS), `rocm-opencl-dev` (on Ubuntu)
+  - ROCM Clang-OCL Kernel Compiler: `rocm-clang-ocl`
+  - Asynchronous Task and Memory Interface (ATMI): `atmi`
+  - ROCr Debug Agent: `rocr_debug_agent`
+  - ROCm Code Object Manager: `comgr`
+* ROCm Libraries
+  - rocBLAS: `rocblas`
+  - hipBLAS: `hipblas`
+  - rocFFT: `rocfft`
+  - rocRAND: `rocrand`
+  - rocSPARSE: `rocsparse`
+  - hipSPARSE: `hipsparse`
+  - rocALUTION: `rocalution:`
+  - MIOpenGEMM: `miopengemm`
+  - MIOpen: `MIOpen-HIP` (for the HIP version), `MIOpen-OpenCL` (for the OpenCL version)
+  - HIP Thrust: `thrust` (on RHEL/CentOS), `hip-thrust` (on Ubuntu)
+  - ROCm SMI Lib: `rocm_smi_lib64`
+  - RCCL: `rccl`
+  - MIVisionX: `mivisionx`
+
+To make it easier to install ROCm, the AMD binary repos provide a number of meta-packages that will automatically install multiple other packages.
+For example, `rocm-dkms` is the primary meta-package that is used to install most of the base technology needed for ROCm to operate.
+It will install the `rock-dkms` kernel driver, and another meta-package (`rocm-dev`) which installs most of the user-land ROCm core components, support software, and development tools.
+
+The `rocm-utils` meta-package will install useful utilities that, while not required for ROCm to operate, may still be beneficial to have.
+Finally, the `rocm-libs` meta-package will install some (but not all) of the libraries that are part of ROCm.
+
+The chain of software installed by these meta-packages is illustrated below
+
+```
+rocm-dkms
+ |-- rock-dkms
+ \-- rocm-dev
+      |--hsa-rocr-dev
+      |--hsa-ext-rocr-dev
+      |--rocm-device-libs
+      |--rocm-utils
+          |-- rocminfo
+          |-- rocm-cmake
+          \-- rocm-clang-ocl # This will cause OpenCL to be installed
+      |--hcc
+      |--hip_base
+      |--hip_doc
+      |--hip_hcc
+      |--hip_samples
+      |--rocm-smi
+      |--hsakmt-roct
+      |--hsakmt-roct-dev
+      |--hsa-amd-aqlprofile
+      |--comgr
+      \--rocr_debug_agent
+
+rocm-libs
+ |-- rocblas
+ |-- rocfft
+ |-- rocrand
+ \-- hipblas
+```
+
+These meta-packages are not required but may be useful to make it easier to install ROCm on most systems.
+Some users may want to skip certain packages. For instance, a user that wants to use the upstream kernel drivers (rather than those supplied by AMD) may want to skip the `rocm-dkms` and `rock-dkms` packages, and instead directly install `rocm-dev`.
+
+Similarly, a user that only wants to install OpenCL support instead of HCC and HIP may want to skip the `rocm-dkms` and `rocm-dev` packages.
+Instead, they could directly install `rock-dkms`, `rocm-opencl`, and `rocm-opencl-dev` and their dependencies.
+
 #### Ubuntu Support - installing from a Debian repository
+
+The following directions show how to install ROCm on supported Debian-based systems such as Ubuntu 18.04.
+These directions may not work as written on unsupported Debian-based distributions.
+For example, newer versions of Ubuntu may not be compatible with the `rock-dkms` kernel driver.
+As such, users may want to skip the `rocm-dkms` and `rock-dkms` packages, as described [above](#rocm-binary-package-structure), and instead [use the upstream kernel driver](#using-debian-based-rocm-with-upstream-kernel-drivers).
 
 ##### First make sure your system is up to date 
 
@@ -297,7 +338,7 @@ sudo reboot
 
 ##### Add the ROCm apt repository
 
-For Debian based systems, like Ubuntu, configure the Debian ROCm repository as
+For Debian-based systems like Ubuntu, configure the Debian ROCm repository as
 follows:
 
 ```shell
@@ -309,14 +350,11 @@ If the key signature verification is failed while update, please re-add the key 
 ROCm apt repository. The current rocm.gpg.key is not available in a standard key ring 
 distribution, but has the following sha1sum hash:
 
-f7f8147431c75e505c58a6f3a3548510869357a6  rocm.gpg.key
+`f7f8147431c75e505c58a6f3a3548510869357a6  rocm.gpg.key`
 
 ##### Install
 
-Next, update the apt repository list and install the rocm package:
-
->**Warning**: Before proceeding, make sure to completely
->[uninstall any previous ROCm package](https://github.com/RadeonOpenCompute/ROCm#removing-pre-release-packages):
+Next, update the apt repository list and install the `rocm-dkms` meta-package:
 
 ```shell
 sudo apt update
@@ -325,10 +363,9 @@ sudo apt install rocm-dkms
 
 ###### Next set your permissions 
 
-With move to upstreaming the KFD driver and the support of DKMS,  for all Console aka headless user, you will need to add all  your users to the  'video" group by setting the Unix permissions
-
-Configure 
-Ensure that your user account is a member of the "video" group prior to using the ROCm driver. You can find which groups you are a member of with the following command:
+Users will need to be in the `video` group in order to have access to the GPU.
+As such, you should ensure that your user account is a member of the `video` group prior to using ROCm.
+You can find which groups you are a member of with the following command:
 
 ```shell
 groups
@@ -341,6 +378,7 @@ sudo usermod -a -G video $LOGNAME
 ``` 
 
 You may want to ensure that any future users you add to your system are put into the "video" group by default. To do that, you can run the following commands:
+
 ```shell
 echo 'ADD_EXTRA_GROUPS=1' | sudo tee -a /etc/adduser.conf
 echo 'EXTRA_GROUPS=video' | sudo tee -a /etc/adduser.conf
@@ -348,63 +386,46 @@ echo 'EXTRA_GROUPS=video' | sudo tee -a /etc/adduser.conf
 
 Once complete, reboot your system.
 
-Upon Reboot run the following commands to verify that the ROCm installation was successful. If you see your GPUs listed by both of these commands, you should be ready to go!
+###### Test basic ROCm installation
+
+After rebooting the system run the following commands to verify that the ROCm installation was successful. If you see your GPUs listed by both of these commands, you should be ready to go!
+
 ```shell
 /opt/rocm/bin/rocminfo 
 /opt/rocm/opencl/bin/x86_64/clinfo 
 ``` 
 
-Note that, to make running ROCm programs easier, you may wish to put the ROCm libraries in your LD_LIBRARY_PATH environment variable and the ROCm binaries in your PATH.
+Note that, to make running ROCm programs easier, you may wish to put the ROCm binaries in your PATH.
+
 ```shell
-echo 'export LD_LIBRARY_PATH=/opt/rocm/opencl/lib/x86_64:/opt/rocm/hsa/lib:$LD_LIBRARY_PATH' | sudo tee -a /etc/profile.d/rocm.sh
 echo 'export PATH=$PATH:/opt/rocm/bin:/opt/rocm/profiler/bin:/opt/rocm/opencl/bin/x86_64' | sudo tee -a /etc/profile.d/rocm.sh
 ```
 
-If you have an [Install Issue](https://rocm.github.io/install_issues.html) please read this FAQ .
+If you have an [install issue](https://rocm.github.io/install_issues.html) please read this FAQ.
 
 ###### Performing an OpenCL-only Installation of ROCm
 
-Some users may want to install a subset of the full ROCm installation. In particular, if you are trying to install on a system with a limited amount of storage space, or which will only run a small collection of known applications, you may want to install only the packages that are required to run OpenCL applications. To do that, you can run the following installation command **instead** of the command to install `rocm-dkms`.
+Some users may want to install a subset of the full ROCm installation.
+In particular, if you are trying to install on a system with a limited amount of storage space, or which will only run a small collection of known applications, you may want to install only the packages that are required to run OpenCL applications.
+To do that, you can run the following installation command **instead** of the command to install `rocm-dkms`.
 
 ```shell
 sudo apt-get install dkms rock-dkms rocm-opencl
 ```
 
-###### Upon restart, to test your OpenCL instance 
+##### How to uninstall from Ubuntu 16.04 or Ubuntu 18.04
 
-Build and run Hello World OCL app.
-
-HelloWorld sample:
+To uninstall the ROCm packages installed in the above directions, you can execute;
 
 ```shell
- wget https://raw.githubusercontent.com/bgaster/opencl-book-samples/master/src/Chapter_2/HelloWorld/HelloWorld.cpp
- wget https://raw.githubusercontent.com/bgaster/opencl-book-samples/master/src/Chapter_2/HelloWorld/HelloWorld.cl
-```
-
- Build it using the default ROCm OpenCL include and library locations:
-
-```shell
-g++ -I /opt/rocm/opencl/include/ ./HelloWorld.cpp -o HelloWorld -L/opt/rocm/opencl/lib/x86_64 -lOpenCL
-```
-
- Run it:
-
- ```shell
- ./HelloWorld
-```
-
-##### How to un-install from Ubuntu 16.04 or Ubuntu 18.04
-
-To un-install the entire rocm development package execute:
-
-```shell
-sudo apt autoremove rocm-dkms
+sudo apt autoremove rocm-dkms rocm-dev rocm-utils
 ```
 
 ##### Installing development packages for cross compilation
 
-It is often useful to develop and test on different systems. In this scenario,
-you may prefer to avoid installing the ROCm Kernel to your development system.
+It is often useful to develop and test on different systems.
+For example, some development or build systems may not have an AMD GPU installed.
+In this scenario, you may prefer to avoid installing the ROCK kernel driver to your development system.
 
 In this case, install the development subset of packages:
 
@@ -412,34 +433,34 @@ In this case, install the development subset of packages:
 sudo apt update
 sudo apt install rocm-dev
 ```
-
 >**Note:** To execute ROCm enabled apps you will require a system with the full
 >ROCm driver stack installed
 
-##### Removing pre-release packages
-It is recommended to [remove previous rocm installations](https://github.com/RadeonOpenCompute/ROCm#how-to-un-install-from-ubuntu-1604-or-ubuntu-1804) before installing the latest version to ensure a smooth installation.
+##### Using Debian-based ROCm with upstream kernel drivers
 
-If you installed any of the ROCm pre-release packages from github, they will
-need to be manually un-installed:
+As described in [the above section about upstream Linux kernel support](#rocm-support-in-upstream-linux-kernels), users may want to try installing ROCm user-level software without installing AMD's custom ROCK kernel driver.
+Users who do want to use upstream kernels can run the following commands instead of installing `rocm-dkms`
 
 ```shell
-sudo apt purge hsakmt-roct
-sudo apt purge hsakmt-roct-dev
-sudo apt purge compute-firmware
-sudo apt purge $(dpkg -l | grep 'kfd\|rocm' | grep linux | grep -v libc | awk '{print $2}')
+sudo apt update
+sudo apt install rocm-dev
+echo 'SUBSYSTEM=="kfd", KERNEL=="kfd", TAG+="uaccess", GROUP="video"' | sudo tee /etc/udev/rules.d/70-kfd.rules
 ```
-
-If possible, we would recommend starting with a fresh OS install.
 
 #### CentOS/RHEL 7 (7.4, 7.5, 7.6) Support
 
-Support for CentOS/RHEL 7 has been added in ROCm 1.8, but requires a special 
+The following directions show how to install ROCm on supported RPM-based systems such as CentOS 7.6.
+These directions may not work as written on unsupported RPM-based distributions.
+For example, Fedora may work but may not be compatible with the `rock-dkms` kernel driver.
+As such, users may want to skip the `rocm-dkms` and `rock-dkms` packages, as described [above](#rocm-binary-package-structure), and instead [use the upstream kernel driver](#using-rpm-based-rocm-with-upstream-kernel-drivers).
+
+Support for CentOS/RHEL 7 was added in ROCm 1.8, but ROCm requires a special 
 runtime environment provided by the RHEL Software Collections and additional
-dkms support packages to properly install in run.
+dkms support packages to properly install and run.
 
 ##### Preparing RHEL 7 (7.4, 7.5, 7.6) for installation
 
-RHEL is a subscription based operating system, and must enable several external
+RHEL is a subscription-based operating system, and you must enable several external
 repositories to enable installation of the devtoolset-7 environment and the DKMS
 support files. These steps are not required for CentOS.
 
@@ -468,7 +489,7 @@ To setup the Devtoolset-7 environment, follow the instructions on this page:
 
 https://www.softwarecollections.org/en/scls/rhscl/devtoolset-7/
 
-Note that devtoolset-7 is a Software Collections package, and is not supported by AMD.
+Note that devtoolset-7 is a Software Collections package, and it is not supported by AMD.
 
 ##### Prepare CentOS/RHEL (7.4, 7.5, 7.6) for DKMS Install
 
@@ -479,10 +500,9 @@ sudo yum install -y epel-release
 sudo yum install -y dkms kernel-headers-`uname -r` kernel-devel-`uname -r`
 ```
 
-
 ##### Installing ROCm on the system
 
-It is recommended to [remove previous rocm installations](https://github.com/RadeonOpenCompute/ROCm#how-to-un-install-rocm-from-centosrhel-74-75-and-76) before installing the latest version to ensure a smooth installation.
+It is recommended to [remove previous ROCm installations](https://github.com/RadeonOpenCompute/ROCm#how-to-uninstall-rocm-from-centosrhel-74-75-and-76) before installing the latest version to ensure a smooth installation.
 
 At this point ROCm can be installed on the target system. Create a /etc/yum.repos.d/rocm.repo file with the following contents:
 
@@ -500,7 +520,9 @@ The repo's URL should point to the location of the repositories repodata databas
 sudo yum install rocm-dkms
 ```
 
-The rock-dkms component should be installed and the /dev/kfd device should be available on reboot.
+The rock-dkms component should be installed and the `/dev/kfd` device should be available on reboot.
+
+##### Set up permissions
 
 Ensure that your user account is a member of the "video" or "wheel" group prior to using the ROCm driver.
 You can find which groups you are a member of with the following command:
@@ -516,17 +538,45 @@ following command:
 sudo usermod -a -G video $LOGNAME 
 ```
 
+You may want to ensure that any future users you add to your system are put into the "video" group by default. To do that, you can run the following commands:
+
+```shell
+echo 'ADD_EXTRA_GROUPS=1' | sudo tee -a /etc/adduser.conf
+echo 'EXTRA_GROUPS=video' | sudo tee -a /etc/adduser.conf
+```
+
 Current release supports CentOS/RHEL 7.4, 7.5, 7.6. If users want to update the OS version, they should completely remove ROCm packages before updating to the latest version of the OS, to avoid DKMS related issues.
+
+Once complete, reboot your system.
+
+###### Test basic ROCm installation
+
+After rebooting the system run the following commands to verify that the ROCm installation was successful. If you see your GPUs listed by both of these commands, you should be ready to go!
+
+```shell
+/opt/rocm/bin/rocminfo
+/opt/rocm/opencl/bin/x86_64/clinfo
+```
+
+Note that, to make running ROCm programs easier, you may wish to put the ROCm binaries in your PATH.
+
+```shell
+echo 'export PATH=$PATH:/opt/rocm/bin:/opt/rocm/profiler/bin:/opt/rocm/opencl/bin/x86_64' | sudo tee -a /etc/profile.d/rocm.sh
+```
+
+If you have an [install issue](https://rocm.github.io/install_issues.html) please read this FAQ.
 
 ###### Performing an OpenCL-only Installation of ROCm
 
-Some users may want to install a subset of the full ROCm installation. In particular, if you are trying to install on a system with a limited amount of storage space, or which will only run a small collection of known applications, you may want to install only the packages that are required to run OpenCL applications. To do that, you can run the following installation command **instead** of the command to install `rocm-dkms`.
+Some users may want to install a subset of the full ROCm installation.
+In particular, if you are trying to install on a system with a limited amount of storage space, or which will only run a small collection of known applications, you may want to install only the packages that are required to run OpenCL applications.
+To do that, you can run the following installation command **instead** of the command to install `rocm-dkms`.
 
 ```shell
 sudo yum install rock-dkms rocm-opencl
 ```
 
-##### Compiling applications using hcc, hip, etc.
+##### Compiling applications using HCC, HIP, and other ROCm software
 
 To compile applications or samples, please use gcc-7.2 provided by the devtoolset-7 environment.
 To do this, compile all applications after running this command: 
@@ -534,17 +584,42 @@ To do this, compile all applications after running this command:
 ```shell
 scl enable devtoolset-7 bash
 ```
-##### How to un-install ROCm from CentOS/RHEL 7.4, 7.5 and 7.6
+##### How to uninstall ROCm from CentOS/RHEL 7.4, 7.5 and 7.6
 
-To un-install the entire rocm development package execute:
+To uninstall the ROCm packages installed by the above directions, you can execute:
 
 ```shell
-sudo yum autoremove rocm-dkms
+sudo yum autoremove rocm-dkms rock-dkms
 ```
 
-### Known Issues / Workarounds
+##### Installing development packages for cross compilation
 
-#### HCC: removed support for C++AMP
+It is often useful to develop and test on different systems.
+For example, some development or build systems may not have an AMD GPU installed.
+In this scenario, you may prefer to avoid installing the ROCK kernel driver to your development system.
+
+In this case, install the development subset of packages:
+
+```shell
+sudo yum install rocm-dev
+```
+>**Note:** To execute ROCm enabled apps you will require a system with the full
+>ROCm driver stack installed
+
+##### Using ROCm with upstream kernel drivers
+
+As described in [the above section about upstream Linux kernel support](#rocm-support-in-upstream-linux-kernels), use
+rs may want to try installing ROCm user-level software without installing AMD's custom ROCK kernel driver.
+Users who do want to use upstream kernels can run the following commands instead of installing `rocm-dkms`
+
+```shell
+sudo yum install rocm-dev
+echo 'SUBSYSTEM=="kfd", KERNEL=="kfd", TAG+="uaccess", GROUP="video"' | sudo tee /etc/udev/rules.d/70-kfd.rules
+```
+
+### Known issues / workarounds
+
+#### HCC: removed support for C++AMP in ROCm 2.0
 
 #### HipCaffe is supported on single GPU configurations
 
@@ -554,39 +629,53 @@ sudo yum autoremove rocm-dkms
 
 The ROCm platform relies on a few closed source components to provide functionality
 such as HSA image support. These components are only available through the ROCm
-repositories, and will either be deprecated or become open source components in the
+repositories, and they will either be deprecated or become open source components in the
 future. These components are made available in the following packages:
 
 *  hsa-ext-rocr-dev
 
 ### Getting ROCm source code
 
-Modifications can be made to the ROCm 2.0 components by modifying the open
-source code base and rebuilding the components. Source code can be cloned from
-each of the GitHub repositories using git, or users can use the repo command
-and the ROCm 2.0 manifest file to download the entire ROCm 2.0 source code.
+ROCm is built from open source software.
+As such, it is possible to make modifications to the various components of ROCm by downloading the source code, making modifications to it, and rebuilding the components.
+The source code for ROCm components can be cloned from each of the GitHub repositories using git.
+In order to make it easier to download the correct versions of each of these tools, this ROCm repository contains a [repo](https://gerrit.googlesource.com/git-repo/) manifest file, [default.xml](default.xml).
+Interested users can thus use this manifest file to download the source code for all of the ROCm software.
 
 #### Installing repo
 
-Google's repo tool allows you to manage multiple git repositories
-simultaneously. You can install it by executing the following commands:
+Google's repo tool allows you to manage multiple git repositories simultaneously.
+You can install it by executing the following example commands:
 
 ```shell
+mkdir -p ~/bin/
 curl https://storage.googleapis.com/git-repo-downloads/repo > ~/bin/repo
 chmod a+x ~/bin/repo
 ```
-Note: make sure ~/bin exists and it is part of your PATH
+Note that you can choose a different folder to install repo into if you desire. `~/bin/` is simply used as an example.
 
-#### Cloning the code
+#### Downloading the ROCm source code
+
+The following example shows how to use the `repo` binary downloaded above to download all of the ROCm source code.
+If you chose a directory other than `~/bin/` to install `repo`, you should use that directory below.
 
 ```shell
-mkdir ROCm && cd ROCm
-repo init -u https://github.com/RadeonOpenCompute/ROCm.git -b roc-2.0.0
+mkdir -p ~/ROCm/
+cd ~/ROCm/
+~/bin/repo init -u https://github.com/RadeonOpenCompute/ROCm.git -b roc-2.0.0
 repo sync
 ```
-These series of commands will pull all of the open source code associated with
-the ROCm 2.0 release. Please ensure that ssh-keys are configured for the
-target machine on GitHub for your GitHub ID.
 
-* OpenCL Runtime and Compiler will be submitted to the Khronos Group, prior to
-  the final release, for conformance testing.
+This will cause repo to download all of the open source code associated with this ROCm release.
+You may want to ensure that you have ssh-keys configured on your machine for your GitHub ID.
+
+#### Building the ROCm source code
+
+Each ROCm component repository contains directions for building that component.
+As such, you should go to the repository you are interested in building to find how to build it.
+
+That said, AMD also offers [a project](https://github.com/RadeonOpenCompute/Experimental_ROC) that demonstrates how to download, build, package, and install ROCm software on various distributions.
+The scripts here may be useful for anyone looking to build ROCm components.
+
+### Final notes
+* OpenCL Runtime and Compiler will be submitted to the Khronos Group for conformance testing prior to its final release.

--- a/default.xml
+++ b/default.xml
@@ -2,26 +2,67 @@
 <manifest>
 
     <remote name="roc-github"
-            fetch="http://git@github.com/RadeonOpenCompute/" />
-    <remote name="pctools-github"
-            fetch="http://git@github.com/GPUOpen-ProfessionalCompute-Tools/" />
+            fetch="http://github.com/RadeonOpenCompute/" />
+    <remote name="rocm-devtools"
+            fetch="https://github.com/ROCm-Developer-Tools/" />
+    <remote name="rocm-swplat"
+            fetch="https://github.com/ROCmSoftwarePlatform/" />
+    <remote name="gpuopen-libs"
+            fetch="https://github.com/GPUOpen-ProfessionalCompute-Libraries/" />
 
-    <default revision="roc-2.0.x"
+    <default revision="refs/tags/roc-2.0.0"
              remote="roc-github"
+             sync-c="true"
              sync-j="4" />
 
-    <project path="ROCK-Kernel-Driver" name="ROCK-Kernel-Driver" />
-    <project path="ROCT-Thunk-Interface" name="ROCT-Thunk-Interface" />
-    <project path="ROC-smi" name="ROC-smi" />
-    <project path="ROCR-Runtime" name="ROCR-Runtime" />
-    <project path="hcc" name="hcc" />
-    <project path="compiler-rt" name="compiler-rt" />
-    <project path="HIP" remote="pctools-github" name="HIP" />
-    <project path="HIP-Examples" remote="pctools-github" name="HIP-Examples" />
-    <project path="atmi" name="atmi" revision="master" />
-    <project path="llvm" name="llvm" />
-    <project path="lld" name="lld" />
-    <project path="hcc-clang-upgrade" name="hcc-clang-upgrade" />
-    <project path="ROCm-Device-Libs" name="ROCm-Device-Libs" />
+    <project name="ROCK-Kernel-Driver" />
+    <project name="ROCT-Thunk-Interface" />
+    <project name="ROCR-Runtime" />
+    <project name="ROC-smi" />
+    <project name="rocm-cmake" revision="ac45c6e269d1fd1dbd5dfc81cfe47a7452c96daf" />
+    <project name="rocminfo" revision="1bb0ccc731f772bb1a553e37b41d06eb0a684926" />
+    <project name="rocprofiler" remote="rocm-devtools" />
+    <!-- If you want to get the full OpenCL runtime, there is a separate repo
+         manifest that is more authoritative than the copy in this file. It can
+         be found at the following URL:
+         https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/blob/roc-2.0.0/opencl.xml -->
+    <remote name="KhronosGroup" fetch="https://github.com/KhronosGroup/" />
+    <project name="ROCm-OpenCL-Runtime" />
+    <project path="ROCm-OpenCL-Runtime/compiler/driver" name="ROCm-OpenCL-Driver"/>
+    <project path="ROCm-OpenCL-Runtime/compiler/llvm" name="llvm" />
+    <project path="ROCm-OpenCL-Runtime/compiler/llvm/tools/clang" name="clang" />
+    <project path="ROCm-OpenCL-Runtime/compiler/llvm/tools/lld" name="lld" />
+    <project path="ROCm-OpenCL-Runtime/library/amdgcn" name="ROCm-Device-Libs"/>
+    <project path="ROCm-OpenCL-Runtime/api/opencl/khronos/icd" name="OpenCL-ICD-Loader" remote="KhronosGroup" revision="261c1288aadd9dcc4637aca08332f603e6c13715" />
 
+    <project name="clang-ocl" revision="688fe5d98b3d6a06838f10d3a7db951c288c0f54" />
+    <!-- HCC needs to be recursively synced to get it submodules -->
+    <project name="hcc" sync-s="true" />
+    <project name="HCC-Example-Application" remote="rocm-devtools" revision="ffd6533305e79eed667badd3c4cdb7879a1281b8" />
+    <project name="HIP" remote="rocm-devtools" />
+    <project name="HIP-Examples" remote="rocm-devtools" />
+    <!-- The following projects are all associated with the AMDGPU LLVM compiler -->
+    <project name="llvm" path="llvm_amd-common" />
+    <project name="lld" path="llvm_amd-common/lld" />
+    <project name="clang" path="llvm_amd-common/clang" />
+    <project name="ROCm-Device-Libs" />
+    <project name="atmi" revision="4dd14ad8fafc64dc8f35b0646cfe84e3e36a3c64" />
+    <project name="ROCm-CompilerSupport" />
+    <project name="rocr_debug_agent" remote="rocm-devtools" />
+    <project name="rocm_bandwidth_test" />
+
+    <!-- ROCm Libraries -->
+    <project name="rocBLAS" remote="rocm-swplat" revision="refs/tags/v2.0.0" />
+    <project name="hipBLAS" remote="rocm-swplat" revision="refs/tags/v0.12.1.0" />
+    <project name="rocFFT" remote="rocm-swplat" revision="refs/tags/v0.8.8" />
+    <project name="rocRAND" remote="rocm-swplat" revision="7278524ea37f449795fdafcd0bf5307f61f06ba9" />
+    <project name="rocSPARSE" remote="rocm-swplat" revision="refs/tags/v1.0.1" />
+    <project name="hipSPARSE" remote="rocm-swplat" revision="refs/tags/v1.0.2" />
+    <project name="rocALUTION" remote="rocm-swplat" revision="refs/tags/v1.3.7" />
+    <project name="MIOpenGEMM" remote="rocm-swplat" revision="9547fb9e8499a5a9f16da83b1e6b749de82dd9fb" />
+    <project name="MIOpen" remote="rocm-swplat" revision="refs/tags/1.7.0" />
+    <project name="Thrust" remote="rocm-swplat" revision="e0b8fe2af3d345fb85689011140a20ff46fb610d" sync-s="true" />
+    <project name="rocm_smi_lib" />
+    <project name="rccl" remote="rocm-swplat" revision="refs/tags/0.7.1" />
+    <project name="MIVisionX" remote="gpuopen-libs" revision="1.0.0" />
 </manifest>

--- a/version_history.md
+++ b/version_history.md
@@ -1,0 +1,187 @@
+## ROCm Version History
+This file contains archived version history information for the [ROCm project](https://github.com/RadeonOpenCompute/ROCm)
+
+### Current ROCm Version: 2.0
+- [New features and enhancements in ROCm 2.0](#new-features-and-enhancements-in-rocm-20)
+- [New features and enhancements in ROCm 1.9.2](#new-features-and-enhancements-in-rocm-192)
+- [New features and enhancements in ROCm 1.9.2](#new-features-and-enhancements-in-rocm-192-1)
+- [New features and enhancements in ROCm 1.9.1](#new-features-and-enhancements-in-rocm-191)
+- [New features and enhancements in ROCm 1.9.0](#new-features-and-enhancements-in-rocm-190)
+- [New features as of ROCm 1.8.3](#new-features-as-of-rocm-183)
+- [New features as of ROCm 1.8](#new-features-as-of-rocm-18)
+- [New Features as of ROCm 1.7](#new-features-as-of-rocm-17)
+- [New Features as of ROCm 1.5](#new-features-as-of-rocm-15)
+
+### New features and enhancements in ROCm 2.0
+
+#### Adds support for RHEL 7.6 / CentOS 7.6 and Ubuntu 18.04.1
+
+#### Adds support for Vega 7nm, Polaris 12 GPUs
+
+#### Introduces MIVisionX
+* A comprehensive computer vision and machine intelligence libraries, utilities and applications bundled into a single toolkit.
+
+#### Improvements to ROCm Libraries
+* rocSPARSE & hipSPARSE
+* rocBLAS with improved DGEMM efficiency on Vega 7nm
+
+#### MIOpen
+* This release contains general bug fixes and an updated performance database
+* Group convolutions backwards weights performance has been improved
+* RNNs now support fp16
+
+#### Tensorflow multi-gpu and Tensorflow FP16 support for Vega 7nm
+* TensorFlow v1.12 is enabled with fp16 support
+
+#### PyTorch/Caffe2 with Vega 7nm Support
+* fp16 support is enabled
+* Several bug fixes and performance enhancements
+* Known Issue: breaking changes are introduced in ROCm 2.0 which are not addressed upstream yet. Meanwhile, please continue to use ROCm fork at https://github.com/ROCmSoftwarePlatform/pytorch
+
+#### Improvements to ROCProfiler tool
+* Support for Vega 7nm
+
+#### Support for hipStreamCreateWithPriority
+* Creates a stream with the specified priority. It creates a stream on which enqueued kernels have a different priority for execution compared to kernels enqueued on normal priority streams. The priority could be higher or lower than normal priority streams.
+
+#### OpenCL 2.0 support
+* ROCm 2.0 introduces full support for kernels written in the OpenCL 2.0 C language on certain devices and systems.  Applications can detect this support by calling the “clGetDeviceInfo” query function with “parame_name” argument set to “CL_DEVICE_OPENCL_C_VERSION”.  In order to make use of OpenCL 2.0 C language features, the application must include the option “-cl-std=CL2.0” in options passed to the runtime API calls responsible for compiling or building device programs.  The complete specification for the OpenCL 2.0 C language can be obtained using the following link: https://www.khronos.org/registry/OpenCL/specs/opencl-2.0-openclc.pdf
+
+#### Improved Virtual Addressing (48 bit VA) management for Vega 10 and later GPUs
+* Fixes Clang AddressSanitizer and potentially other 3rd-party memory debugging tools with ROCm
+* Small performance improvement on workloads that do a lot of memory management
+* Removes virtual address space limitations on systems with more VRAM than system memory
+
+#### Kubernetes support
+
+### New features and enhancements in ROCm 1.9.2
+#### RDMA(MPI) support on Vega 7nm
+* Support ROCnRDMA based on Mellanox InfiniBand
+
+#### Improvements to HCC
+* Improved link time optimization
+
+#### Improvements to ROCProfiler tool
+* General bug fixes and implemented versioning APIs
+
+### New features and enhancements in ROCm 1.9.2
+#### RDMA(MPI) support on Vega 7nm
+* Support ROCnRDMA based on Mellanox InfiniBand
+
+#### Improvements to HCC
+* Improved link time optimization
+
+#### Improvements to ROCProfiler tool
+* General bug fixes and implemented versioning APIs
+
+#### Critical bug fixes
+
+### New features and enhancements in ROCm 1.9.1
+#### Added DPM support to Vega 7nm
+* Dynamic Power Management feature is enabled on Vega 7nm.
+
+#### Fix for 'ROCm profiling' that used to fail with a “Version mismatch between HSA runtime and libhsa-runtime-tools64.so.1” error
+
+### New features and enhancements in ROCm 1.9.0
+
+#### Preview for Vega 7nm
+* Enables developer preview support for Vega 7nm
+
+#### System Management Interface
+* Adds support for the ROCm SMI (System Management Interface) library, which provides monitoring and management capabilities for AMD GPUs.
+
+#### Improvements to HIP/HCC
+* Support for gfx906
+* Added deprecation warning for C++AMP.  This will be the last version of HCC supporting C++AMP.
+* Improved optimization for global address space pointers passing into a GPU kernel
+* Fixed several race conditions in the HCC runtime
+* Performance tuning to the unpinned copy engine
+* Several codegen enhancement fixes in the compiler backend
+
+#### Preview for rocprof Profiling Tool
+Developer preview (alpha) of profiling tool rocProfiler. It includes a command-line front-end, `rpl_run.sh`, which enables:
+* Cmd-line tool for dumping public per kernel perf-counters/metrics and kernel timestamps
+* Input file with counters list and kernels selecting parameters
+* Multiple counters groups and app runs supported
+* Output results in CSV format
+
+The tool can be installed from the `rocprofiler-dev` package. It will be installed into: `/opt/rocm/bin/rpl_run.sh`
+
+#### Preview for rocr Debug Agent rocr_debug_agent
+The ROCr Debug Agent is a library that can be loaded by ROCm Platform Runtime to provide the following functionality:
+* Print the state for wavefronts that report memory violation or upon executing a "s_trap 2" instruction.
+* Allows SIGINT (`ctrl c`) or SIGTERM (`kill -15`) to print wavefront state of aborted GPU dispatches.
+* It is enabled on Vega10 GPUs on ROCm1.9.
+
+The ROCm1.9 release will install the ROCr Debug Agent library at `/opt/rocm/lib/librocr_debug_agent64.so`
+
+
+#### New distribution support
+
+* Binary package support for Ubuntu 18.04
+
+#### ROCm 1.9 is ABI compatible with KFD in upstream Linux kernels.
+Upstream Linux kernels support the following GPUs in these releases:
+4.17: Fiji, Polaris 10, Polaris 11
+4.18: Fiji, Polaris 10, Polaris 11, Vega10
+
+Some ROCm features are not available in the upstream KFD:
+* More system memory available to ROCm applications
+* Interoperability between graphics and compute
+* RDMA
+* IPC
+
+To try ROCm with an upstream kernel, install ROCm as normal, but do not install the rock-dkms package. Also add a udev rule to control `/dev/kfd` permissions:
+
+```
+    echo 'SUBSYSTEM=="kfd", KERNEL=="kfd", TAG+="uaccess", GROUP="video"' | sudo tee /etc/udev/rules.d/70-kfd.rules
+```
+
+### New features as of ROCm 1.8.3
+
+* ROCm 1.8.3 is a minor update meant to fix compatibility issues on Ubuntu releases running kernel 4.15.0-33
+
+### New features as of ROCm 1.8
+
+#### DKMS driver installation
+
+ * Debian packages are provided for DKMS on Ubuntu
+ * RPM packages are provided for CentOS/RHEL 7.4 and 7.5 support
+ * See the [ROCT-Thunk-Interface](https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/tree/roc-1.8.x) and [ROCK-Kernel-Driver](https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver/tree/roc-1.8.x) for additional documentation on driver setup
+
+#### New distribution support
+
+ * Binary package support for Ubuntu 16.04 and 18.04
+ * Binary package support for CentOS 7.4 and 7.5
+ * Binary package support for RHEL 7.4 and 7.5
+
+#### Improved OpenMPI via UCX support
+
+ * UCX support for OpenMPI
+ * ROCm RDMA
+
+### New Features as of ROCm 1.7
+
+#### DKMS driver installation
+
+ * New driver installation uses Dynamic Kernel Module Support (DKMS)
+ * Only amdkfd and amdgpu kernel modules are installed to support AMD hardware
+ * Currently only Debian packages are provided for DKMS (no Fedora suport available)
+ * See the [ROCT-Thunk-Interface](https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/tree/roc-1.7.x) and [ROCK-Kernel-Driver](https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver/tree/roc-1.7.x) for additional documentation on driver setup
+
+### New Features as of ROCm 1.5
+
+#### Developer preview of the new OpenCL 1.2 compatible language runtime and compiler
+
+ * OpenCL 2.0 compatible kernel language support with OpenCL 1.2 compatible
+   runtime 
+ * Supports offline ahead of time compilation today;
+   during the Beta phase we will add in-process/in-memory compilation. 
+
+#### Binary Package support for Ubuntu 16.04
+
+#### Binary Package support for Fedora 24 is not currently available
+
+#### Dropping binary package support for Ubuntu 14.04, Fedora 23
+ 
+#### IPC support 


### PR DESCRIPTION
Community feedback has pointed out a number of confusing,
oudated, or missing sections in our ROCm README file. For example,
we do not describe what our ROCm package structure is, or how the
packages and meta-packages fit together. This can make it confusing
for users who do not want to just install rocm-dkms and move on.

Our repo manifest (default.xml) is severely out of date. It is
missing almost all of the current ROCm projects, and it always
pulls from the main development branch. This means we do not have
a pinned manifest that allows you to pull the code from a
particular ROCm reelease. Manifest updated, and the section of the
README discussing it is majorly overhauled (including links for
information/scripts about building the code after downloading it).

Rather than continually grow our version history in the main
README page, this splits off old version information into its own
file.