### PR TITLE
llvm and device-libs should use tag roc-ocl-2.7.0

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -45,10 +45,10 @@
     <project name="HIP" remote="rocm-devtools" />
     <project name="HIP-Examples" remote="rocm-devtools" />
     <!-- The following projects are all associated with the AMDGPU LLVM compiler -->
-    <project name="llvm" path="llvm_amd-common" revision="refs/tags/roc-hcc-2.7.0" />
+    <project name="llvm" path="llvm_amd-common" revision="refs/tags/roc-ocl-2.7.0" />
     <project name="lld" path="llvm_amd-common/lld" revision="refs/tags/roc-ocl-2.7.0" />
     <project name="clang" path="llvm_amd-common/clang" />
-    <project name="ROCm-Device-Libs" revision="refs/tags/roc-hcc-2.7.0" />
+    <project name="ROCm-Device-Libs" revision="refs/tags/roc-ocl-2.7.0" />
     <project name="atmi" revision="refs/tags/rocm_2.7.0" />
     <project name="ROCm-CompilerSupport" />
     <project name="rocr_debug_agent" remote="rocm-devtools" />


### PR DESCRIPTION
llvm and device-libs use wrong tag and cause build errors.