### PR TITLE
Use a newer OpenCL-ICD-Loader

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -36,7 +36,7 @@
     <project path="ROCm-OpenCL-Runtime/compiler/llvm/tools/clang" name="clang" />
     <project path="ROCm-OpenCL-Runtime/compiler/llvm/tools/lld" name="lld" revision="refs/tags/roc-ocl-2.8.0" />
     <project path="ROCm-OpenCL-Runtime/library/amdgcn" name="ROCm-Device-Libs" revision="refs/tags/roc-ocl-2.8.0" />
-    <project path="ROCm-OpenCL-Runtime/api/opencl/khronos/icd" name="OpenCL-ICD-Loader" remote="KhronosGroup" revision="261c1288aadd9dcc4637aca08332f603e6c13715" />
+    <project path="ROCm-OpenCL-Runtime/api/opencl/khronos/icd" name="OpenCL-ICD-Loader" remote="KhronosGroup" revision="6c03f8b58fafd9dd693eaac826749a5cfad515f8" />
 
     <project name="clang-ocl" />
     <!-- HCC needs to be recursively synced to get it submodules -->


### PR DESCRIPTION
As of the 2.8 release, the ROCm-OpenCL-Runtime package no longer builds with the referenced revision of the Khronos OpenCL-ICD-Loader. This [commit to the ROCm-OpenCL-Runtime](https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/commit/2c8b286a597f055b9d0fad2d78e8193845cec772) makes it compatible only with ICD loaders at least as new as [this commit to the loader repository](https://github.com/KhronosGroup/OpenCL-ICD-Loader/commit/7d2584c4b8b1ac186f67143aaa2f846184709a9e). I have used the most recent ICD loader revision in this PR. cc @kzhuravl