### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,9 +682,6 @@ You may want to ensure that you have ssh-keys configured on your machine for you
 Each ROCm component repository contains directions for building that component.
 As such, you should go to the repository you are interested in building to find how to build it.
 
-That said, AMD also offers [a project](https://github.com/RadeonOpenCompute/Experimental_ROC) that demonstrates how to download, build, package, and install ROCm software on various distributions.
-The scripts here may be useful for anyone looking to build ROCm components.
-
 #### Deprecation Notice
 
 ### HCC


### PR DESCRIPTION
Remove mention of a crufty project; not updated since ROCm 2.0.0 and, from what I understand, isn't useful for current ROCm releases.