### PR TITLE
Update instruction for Debian-based with Upstream Kernel Drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ You can install the ROCm user-level software without installing the AMD's custom
 
 	sudo apt update	
 	sudo apt install rocm-dev	
-	echo 'SUBSYSTEM=="kfd", KERNEL=="kfd", TAG+="uaccess", GROUP="video"' 
+	echo 'SUBSYSTEM=="kfd", KERNEL=="kfd", TAG+="uaccess", GROUP="video"' |
 	sudo tee /etc/udev/rules.d/70-kfd.rules
 
 


### PR DESCRIPTION
There is a typo error on Using Debian-based ROCm with Upstream Kernel Drivers. The pipe was missing.