### PR TITLE
add hipFFT to default.xml

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -52,6 +52,7 @@ fetch="https://github.com/KhronosGroup/" />
     <project name="Tensile" remote="rocm-swplat" />
     <project name="hipBLAS" remote="rocm-swplat" />
     <project name="rocFFT" remote="rocm-swplat" />
+    <project name="hipFFT" remote="rocm-swplat" />
     <project name="rocRAND" remote="rocm-swplat" />
     <project name="rocSPARSE" remote="rocm-swplat" />
     <project name="rocSOLVER" remote="rocm-swplat" />


### PR DESCRIPTION
There is hipFFT on <http://repo.radeon.com/rocm/apt/4.1/pool/main/h/hipfft/>.
Please add related repository in default.xml.
Thank you.