### PR TITLE
Hide link to main ROCm docs in ROCm repo

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,6 +8,7 @@ from rocm_docs import ROCmDocs
 
 docs_core = ROCmDocs("ROCm Docs 5.6.0")
 docs_core.setup()
+docs_core.disable_main_doc_link()
 
 for sphinx_var in ROCmDocs.SPHINX_VARS:
     globals()[sphinx_var] = getattr(docs_core, sphinx_var)


### PR DESCRIPTION
ROCm already links to main ROCm docs in default sidebar header unlike other subprojects

Build: https://readthedocs.com/projects/advanced-micro-devices-rocm/builds/1356063/