### PR TITLE
Pin rocm-docs-core to a specific commit and update requirements

### DIFF
--- a/docs/.sphinx/requirements.in
+++ b/docs/.sphinx/requirements.in
@@ -1,1 +1,1 @@
-git+https://github.com/RadeonOpenCompute/rocm-docs-core.git
+rocm-docs-core @ git+https://github.com/RadeonOpenCompute/rocm-docs-core.git@13dca510bccaf1850314886a554fb76cbcad5a08

--- a/docs/.sphinx/requirements.txt
+++ b/docs/.sphinx/requirements.txt
@@ -191,7 +191,7 @@ requests==2.28.1
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core @ git+https://github.com/RadeonOpenCompute/rocm-docs-core.git
+rocm-docs-core @ git+https://github.com/RadeonOpenCompute/rocm-docs-core.git@13dca510bccaf1850314886a554fb76cbcad5a08
     # via -r requirements.in
 six==1.16.0
     # via
@@ -214,6 +214,7 @@ sphinx==4.3.1
     #   sphinx-copybutton
     #   sphinx-design
     #   sphinx-external-toc
+    #   sphinx-notfound-page
 sphinx-book-theme==1.0.0rc2
     # via rocm-docs-core
 sphinx-copybutton==0.5.1
@@ -221,6 +222,8 @@ sphinx-copybutton==0.5.1
 sphinx-design==0.3.0
     # via rocm-docs-core
 sphinx-external-toc==0.3.1
+    # via rocm-docs-core
+sphinx-notfound-page==0.8.3
     # via rocm-docs-core
 sphinxcontrib-applehelp==1.0.4
     # via sphinx


### PR DESCRIPTION
Pinning `rocm-docs-core` to a specific version makes the requirements entirely reproducible and keeps a record of the version the docs can be built with.
This also makes sure CI can check when some new features are being used, but the version was not updated.