### PR TITLE
Initial Markdown linting

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,14 @@
+
+name: Markdownlint Action
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+    - name: Use markdownlint
+      uses: actionshub/markdownlint@v3.1.3
+      with:
+        filesToIgnoreRegex: "CHANGELOG.md|README.md|docs/packaging_guidelines.md|docs/about.md|docs/quick_start.md|docs/index.md|docs/release/gpu_os_support.md|docs/how_to/magma_install/magma_install.md|docs/reference/gpu_libraries/math.md|docs/reference/rocmcc/rocmcc.md|docs/reference/docker.md|docs/reference/hip.md|docs/hip_sdk_install_win/hip_sdk_install_win.md|docs/all_deploy_options.md"

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,1 @@
+style "mdlrc-style.rb"

--- a/mdlrc-style.rb
+++ b/mdlrc-style.rb
@@ -1,0 +1,6 @@
+all
+# Extend line length
+rule 'MD013', :line_length => 99999
+
+# Allow in-line HTML
+exclude_rule 'MD033'


### PR DESCRIPTION
Closes #1946

## Notes

- This PR enables all the warnings the Ruby version of Markdownlint supports with mostly default values (except for line length, which is escaped by giving it an extreme value).
- All violating files have been exempted from checks.
- Expectation is that files are removed from exclusion one-by-one and errors are resolved either via fixing up the content _or_ the style file if it's decided that some Markdown recommendation doesn't apply to us or it's too much work for too little value.