### PR TITLE
Initial ReST linting

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,0 +1,22 @@
+name: Linting
+
+on:
+  push:
+  pull_request:
+    branches: [develop, main]
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Restructured text
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Install rst-lint
+        run: pip install restructuredtext-lint
+      - name: Lint ResT files
+        run: rst-lint ${{ join(github.workspace, '/docs') }}


### PR DESCRIPTION
Closes #1947

## Notes

- This PR adds basic ReST linting. The module supports no configuration beyond setting a linting level. Default warning is used.
  - One document doesn't pass information level diagnostics.