### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,4 @@ updates:
     directory: "/" # Location of package manifests
     open-pull-requests-limit: 10
     schedule:
-      interval: "weekly"
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "weekly"
+    target-branch: "rtd"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,3 @@ updates:
     open-pull-requests-limit: 10
     schedule:
       interval: "weekly"
-    target-branch: "rtd"


### PR DESCRIPTION
Proposed Workflow:
- Dependabot makes up to 10 PRs each week to update requirements
- If CI for PR passes (ie: RTD doc builds), can merge; else ignore or close PR

Next steps:
- Package and upload rocm-docs-core as a PyPi package under ROCm
- GitHub Actions to automate some steps