### PR TITLE
Ignore markdown linting in autotag template folder

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -14,4 +14,4 @@ jobs:
     - name: Use markdownlint
       uses: actionshub/markdownlint@v3.1.3
       with:
-        filesToIgnoreRegex: CHANGELOG.md
+        filesToIgnoreRegex: "CHANGELOG.md|tools\\/autotag\\/templates\\/."


### PR DESCRIPTION
Fixes checks not passing due to stricter markdown linting.