### PR TITLE
Remove linkcheck step from rtd

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,13 +9,6 @@ sphinx:
 formats: [htmlzip]
 
 python:
+   version: "3.8"
    install:
    - requirements: docs/.sphinx/requirements.txt
-
-build:
-   os: "ubuntu-20.04"
-   tools:
-      python: "3.8"
-   jobs:
-      pre_build:
-         - python -m sphinx -b linkcheck docs/ _build/linkcheck


### PR DESCRIPTION
reason: increases rtd builds drastically and times out on correct links