### PR TITLE
Replace links to subprojects docs with intersphinx links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,5 +58,7 @@ external_toc_path = "./sphinx/_toc.yml"
 docs_core = ROCmDocs("ROCm Documentation")
 docs_core.setup()
 
+external_projects_current_project = "rocm"
+
 for sphinx_var in ROCmDocs.SPHINX_VARS:
     globals()[sphinx_var] = getattr(docs_core, sphinx_var)

--- a/docs/deploy/linux/index.md
+++ b/docs/deploy/linux/index.md
@@ -1,6 +1,7 @@
 # Deploy ROCm on Linux
 
-Please start with the [Quick Start Linux](quick_start) or follow the detailed instructions below.
+Please start with {doc}`/deploy/linux/quick_start` or follow the detailed
+instructions below.
 
 ::::{grid} 2 3 3 3
 :gutter: 1
@@ -52,4 +53,4 @@ Information about (meta-)packages in the ROCm ecosystem.
 
 ## See Also
 
-- [GPU and OS Support Linux](../../release/gpu_os_support.md)
+- {doc}`/release/gpu_os_support`

--- a/docs/how_to/system_debugging.md
+++ b/docs/how_to/system_debugging.md
@@ -65,4 +65,4 @@ Debug messages when developing/debugging base ROCm driver. You could enable the 
 ## PCIe-Debug
 
 Refer to ROCm PCIe Debug, <a href="https://rocmdocs.amd.com/en/latest/Other_Solutions/PCIe-Debug.html#pcie-debug" target="_blank">https://rocmdocs.amd.com/en/latest/Other_Solutions/PCIe-Debug.html#pcie-debug</a>.
-For information on how to debug and profile HIP applications, see <a href="https://rocmdocs.amd.com/projects/HIP/en/latest/how_to_guides/debugging.html" target="_blank">https://rocmdocs.amd.com/projects/HIP/en/latest/how_to_guides/debugging.html</a>
+For information on how to debug and profile HIP applications, see {doc}`hip:how_to_guides/debugging`

--- a/docs/reference/ai_tools.md
+++ b/docs/reference/ai_tools.md
@@ -3,24 +3,24 @@
 ::::{grid} 1 1 2 2
 :gutter: 1
 
-:::{grid-item-card} [MIOpen](https://rocmdocs.amd.com/projects/MIOpen/en/latest/)
+:::{grid-item-card} {doc}`MIOpen <miopen:index>`
 AMD's library for high performance machine learning primitives.
 
-- [Documentation](https://rocmdocs.amd.com/projects/MIOpen/en/latest/)
+- {doc}`Documentation <miopen:index>`
 
 :::
 
-:::{grid-item-card} [Composable Kernel](https://rocmdocs.amd.com/projects/composable_kernel/en/latest/)
+:::{grid-item-card} {doc}`Composable Kernel <composable-kernel:index>`
 Composable Kernel: Performance Portable Programming Model for Machine Learning Tensor Operators
 
-- [Documentation](https://rocmdocs.amd.com/projects/composable_kernel/en/latest/)
+- {doc}`Documentation <composable-kernel:index>`
 
 :::
 
-:::{grid-item-card} [MIGraphX](https://rocmdocs.amd.com/projects/MIGraphX/en/latest/)
+:::{grid-item-card} {doc}`MIGraphX <migraphx:index>`
 AMD MIGraphX is AMD's graph inference engine that accelerates machine learning model inference.
 
-- [Documentation](https://rocmdocs.amd.com/projects/MIGraphX/en/latest/)
+- {doc}`Documentation <migraphx:index>`
 
 :::
 

--- a/docs/reference/all.md
+++ b/docs/reference/all.md
@@ -8,7 +8,7 @@
 :::{grid-item-card} [HIP](./hip)
 HIP is both AMD's GPU programming language extension and the GPU runtime.
 
-- [HIP Runtime API Manual](https://rocmdocs.amd.com/projects/hipBLAS/en/latest/)
+- {doc}`hip:.doxygen/docBin/html/index`
 - [Examples](https://github.com/amd/rocm-examples/tree/develop/HIP-Basic)
 
 :::
@@ -25,33 +25,33 @@ HIP Math Libraries support the following domains:
 :::{grid-item-card} [C++ Primitive Libraries](./gpu_libraries/c++_primitives)
 ROCm template libraries for C++ primitives and algorithms are as follows:
 
-- [rocPRIM](https://rocprim.readthedocs.io/en/latest/)
-- [rocThrust](https://rocthrust.readthedocs.io/en/latest/)
-- [hipCUB](https://hipcub.readthedocs.io/en/latest/)
+- {doc}`rocPRIM <rocprim:index>`
+- {doc}`rocThrust <rocthrust:index>`
+- {doc}`hipCUB <hipcub:index>`
 
 :::
 
 :::{grid-item-card} [Communication Libraries](gpu_libraries/communication)
 Inter and intra-node communication is supported by the following projects:
 
-- [RCCL](https://rocmdocs.amd.com/projects/rccl/en/latest/)
+- {doc}`RCCL <rccl:index>`
 
 :::
 
 :::{grid-item-card} [AI Libraries](./ai_tools)
 Libraries related to AI.
 
-- [MIOpen](https://rocmdocs.amd.com/projects/MIOpen/en/latest/)
-- [Composable Kernel](https://rocmdocs.amd.com/projects/composable_kernel/en/latest/)
-- [MIGraphX](https://rocmdocs.amd.com/projects/MIGraphX/en/latest/)
+- {doc}`MIOpen <miopen:index>`
+- {doc}`Composable Kernel <composable-kernel:index>`
+- {doc}`MIGraphX <migraphx:index>`
 
 :::
 
 :::{grid-item-card} [Computer Vision](./computer_vision)
 Computer vision related projects.
 
-- [MIVisionX](https://rocmdocs.amd.com/projects/MIVisionX/en/latest)
-- [rocAL](https://rocmdocs.amd.com/projects/rocAL/en/latest)
+- {doc}`MIVisionX <mivisionx:README>`
+- {doc}`rocAL <rocal:README>`
 
 :::
 
@@ -63,10 +63,10 @@ Computer vision related projects.
 
 :::{grid-item-card} [Compilers and Tools](compilers)
 
-- [ROCmCC](https://rocmdocs.amd.com/projects/ROCmCC/en/latest/)
-- [ROCgdb](https://rocmdocs.amd.com/projects/ROCgdb/en/latest/)
-- [ROCProfiler](https://rocmdocs.amd.com/projects/rocprofiler/en/latest/)
-- [ROCTracer](https://rocmdocs.amd.com/projects/roctracer/en/latest/)
+- [ROCmCC](/reference/rocmcc/rocmcc)
+- {doc}`ROCgdb <rocgdb:index>`
+- {doc}`ROCProfiler <rocprofiler:rocprof>`
+- {doc}`ROCTracer <roctracer:index>`
 
 :::
 
@@ -74,14 +74,14 @@ Computer vision related projects.
 
 - AMD SMI
 - [ROCm SMI](https://rocmdocs.amd.com/projects/rocmsmi/en/latest/)
-- [ROCm Datacenter Tool](https://rocmdocs.amd.com/projects/rdc/en/latest/)
+- {doc}`ROCm Datacenter Tool <rdc:index>`
 
 :::
 
 :::{grid-item-card} [Validation Tools](validation_tools)
 
-- [ROCm Validation Suite](https://rocm.docs.amd.com/projects/ROCmValidationSuite/en/latest/)
-- [TransferBench](https://rocmdocs.amd.com/projects/TransferBench/en/latest/)
+- {doc}`ROCm Validation Suite <rocm-validation-suite:index>`
+- {doc}`TransferBench <transferbench:index>`
 
 :::
 

--- a/docs/reference/compilers.md
+++ b/docs/reference/compilers.md
@@ -4,7 +4,8 @@
 :gutter: 1
 
 :::{grid-item-card} ROCmCC
-:link: rocmcc/rocmcc.html
+:link: /reference/rocmcc/rocmcc
+:link-type: doc
 ROCmCC is a Clang/LLVM-based compiler. It is optimized for high-performance
 computing on AMD GPUs and CPUs and supports various heterogeneous programming
 models such as HIP, OpenMP, and OpenCL.
@@ -12,29 +13,29 @@ models such as HIP, OpenMP, and OpenCL.
 :::
 
 :::{grid-item-card} ROCgdb
-:link: https://rocmdocs.amd.com/projects/ROCgdb/en/latest/
-This is ROCgdb, the ROCm source-level debugger for Linux, based on GDB, the GNU
-source-level debugger.
+:link: rocgdb:index
+:link-type: doc
+This is ROCgdb, the ROCm source-level debugger for Linux, based on GDB, the GNU source-level debugger.
 
 :::
 
 :::{grid-item-card} ROCProfiler
-:link: https://rocmdocs.amd.com/projects/rocprofiler/en/latest/
-ROC profiler library. Profiling with performance counters and derived metrics.
-Library supports GFX8/GFX9. Hardware specific low-level performance analysis
-interface for profiling of GPU compute applications. The profiling includes
-hardware performance counters with complex performance metrics.
+:link: rocprofiler:rocprof
+:link-type: doc
+ROC profiler library. Profiling with performance counters and derived metrics. Library supports GFX8/GFX9. Hardware specific low-level performance analysis interface for profiling of GPU compute applications. The profiling includes hardware performance counters with complex performance metrics.
 
 :::
 
 :::{grid-item-card} ROCTracer
-:link: https://rocmdocs.amd.com/projects/roctracer/en/latest/
+:link: roctracer:index
+:link-type: doc
 Callback/Activity Library for Performance tracing AMD GPU's
 
 :::
 
 :::{grid-item-card} ROCdbgapi
-:link: https://rocmdocs.amd.com/projects/ROCdbgapi/en/latest/
+:link: rocdbgapi:index
+:link-type: doc
 The AMD Debugger API is a library that provides all the support necessary for a
 debugger and other tools to perform low level control of the execution and
 inspection of execution state of AMD's commercially available GPU architectures.

--- a/docs/reference/computer_vision.md
+++ b/docs/reference/computer_vision.md
@@ -3,17 +3,17 @@
 ::::{grid} 1 1 2 2
 :gutter: 1
 
-:::{grid-item-card} [MIVisionX](https://rocmdocs.amd.com/projects/MIVisionX/en/latest/)
+:::{grid-item-card} {doc}`MIVisionX <mivisionx:README>`
 MIVisionX toolkit is a set of comprehensive computer vision and machine intelligence libraries, utilities, and applications bundled into a single toolkit. AMD MIVisionX also delivers a highly optimized open-source implementation of the Khronos OpenVX™ and OpenVX™ Extensions.
 
-- [Documentation](https://rocmdocs.amd.com/projects/MIVisionX/en/latest/)
+- {doc}`Documentation <mivisionx:README>`
 
 :::
 
-:::{grid-item-card} [rocAL](https://rocmdocs.amd.com/projects/rocAL/en/latest/)
+:::{grid-item-card} {doc}`rocAL <rocal:README>`
 The AMD ROCm Augmentation Library (rocAL) is designed to efficiently decode and process images and videos from a variety of storage formats and modify them through a processing graph programmable by the user. rocAL currently provides C API.
 
-- [Documentation](https://rocmdocs.amd.com/projects/rocAL/en/latest/)
+- {doc}`Documentation <rocal:README>`
 
 :::
 

--- a/docs/reference/gpu_libraries/c++_primitives.md
+++ b/docs/reference/gpu_libraries/c++_primitives.md
@@ -5,33 +5,33 @@ ROCm template libraries for algorithms are as follows:
 :::::{grid} 1 1 3 3
 :gutter: 1
 
-:::{grid-item-card} [rocPRIM](https://rocmdocs.amd.com/projects/rocPRIM/en/latest/)
+:::{grid-item-card} {doc}`rocPRIM <rocprim:index>`
 rocPRIM is an AMD GPU optimized template library of algorithm primitives, like
 transforms, reductions, scans, etc. It also serves as a common back-end for
 similar libraries found inside ROCm.
 
-- [Documentation](https://rocmdocs.amd.com/projects/rocPRIM/en/latest/)
+- {doc}`Documentation <rocprim:index>`
 - [Changelog](https://github.com/ROCmSoftwarePlatform/rocPRIM/blob/develop/CHANGELOG.md)
 - [Examples](https://github.com/amd/rocm-examples/tree/develop/Libraries/rocPRIM)
 
 :::
 
-:::{grid-item-card} [rocThrust](https://rocmdocs.amd.com/projects/rocThrust/en/latest/)
+:::{grid-item-card} {doc}`rocThrust <rocthrust:index>`
 rocThrust is a template library of algorithm primitives with a Thrust-compatible
 interface. Their CPU back-ends are identical, while the GPU back-end calls into
 rocPRIM.
 
-- [Documentation](https://rocmdocs.amd.com/projects/rocThrust/en/latest/)
+- {doc}`Documentation <rocthrust:index>`
 - [Changelog](https://github.com/ROCmSoftwarePlatform/rocThrust/blob/develop/CHANGELOG.md)
 - [Examples](https://github.com/amd/rocm-examples/tree/develop/Libraries/rocThrust)
 
 :::
 
-:::{grid-item-card} [hipCUB](https://rocmdocs.amd.com/projects/hipCUB/en/latest/)
+:::{grid-item-card} {doc}`hipCUB <hipcub:index>`
 hipCUB is a template library of algorithm primitives with a CUB-compatible
 interface. It's back-end is rocPRIM.
 
-- [Documentation](https://rocmdocs.amd.com/projects/hipCUB/en/latest/)
+- {doc}`Documentation <hipcub:index>`
 - [Changelog](https://github.com/ROCmSoftwarePlatform/hipCUB/blob/develop/CHANGELOG.md)
 - [Examples](https://github.com/amd/rocm-examples/tree/develop/Libraries/hipCUB)
 

--- a/docs/reference/gpu_libraries/communication.md
+++ b/docs/reference/gpu_libraries/communication.md
@@ -3,13 +3,13 @@
 :::::{grid} 1 1 1 1
 :gutter: 1
 
-:::{grid-item-card} [RCCL](https://rocmdocs.amd.com/projects/rccl/en/latest/)
+:::{grid-item-card} {doc}`RCCL <rccl:index>`
 RCCL (pronounced "Rickle") is a stand-alone library of standard collective communication routines for GPUs,
 implementing all-reduce, all-gather, reduce, broadcast, reduce-scatter, gather, scatter, and all-to-all.
 The collective operations are implemented using ring and tree algorithms and have been optimized for
 throughput and latency.
 
-- [Documentation](https://rocmdocs.amd.com/projects/rccl/en/latest/)
+- {doc}`Documentation <rccl:index>`
 - [Changelog](https://github.com/ROCmSoftwarePlatform/rocFFT/blob/develop/CHANGELOG.md)
 - [Examples](https://github.com/ROCmSoftwarePlatform/rccl/tree/develop/tools)
 

--- a/docs/reference/gpu_libraries/fft.md
+++ b/docs/reference/gpu_libraries/fft.md
@@ -5,20 +5,20 @@ ROCm libraries for FFT are as follows:
 :::::{grid} 1 1 2 2
 :gutter: 1
 
-:::{grid-item-card} [rocFFT](https://rocmdocs.amd.com/projects/rocFFT/en/latest/)
+:::{grid-item-card} {doc}`rocFFT <rocfft:index>`
 rocFFT is an AMD GPU optimized library for FFT.
 
-- [Documentation](https://rocmdocs.amd.com/projects/rocFFT/en/latest/)
+- {doc}`Documentation <rocfft:index>`
 - [Changelog](https://github.com/ROCmSoftwarePlatform/rocFFT/blob/develop/CHANGELOG.md)
 
 :::
 
-:::{grid-item-card} [hipFFT](https://rocmdocs.amd.com/projects/hipFFT/en/latest/)
+:::{grid-item-card} {doc}`hipFFT <hipfft:index>`
 hipFFT is a compatibility layer for GPU accelerated FFT optimized for AMD GPUs
 using rocFFT. hipFFT allows for a common interface for other non AMD GPU
 FFT libraries.
 
-- [Documentation](https://rocmdocs.amd.com/projects/hipFFT/en/latest/)
+- {doc}`Documentation <hipfft:index>`
 - [Changelog](https://github.com/ROCmSoftwarePlatform/hipFFT/blob/develop/CHANGELOG.md)
 
 :::

--- a/docs/reference/gpu_libraries/linear_algebra.md
+++ b/docs/reference/gpu_libraries/linear_algebra.md
@@ -5,85 +5,85 @@ ROCm libraries for linear algebra are as follows:
 :::::{grid} 1 1 2 2
 :gutter: 1
 
-:::{grid-item-card} [rocBLAS](https://rocmdocs.amd.com/projects/rocBLAS/en/develop/)
+:::{grid-item-card} {doc}`rocBLAS <rocblas:index>`
 `rocBLAS` is an AMD GPU optimized library for BLAS (Basic Linear Algebra Subprograms).
 
-- [Documentation](https://rocmdocs.amd.com/projects/rocBLAS/en/develop/)
+- {doc}`Documentation <rocblas:index>`
 - [Changelog](https://github.com/ROCmSoftwarePlatform/rocBLAS/blob/develop/CHANGELOG.md)
 - [Examples](https://github.com/amd/rocm-examples/tree/develop/Libraries/rocBLAS)
 
 :::
 
-:::{grid-item-card} [hipBLAS](https://rocmdocs.amd.com/projects/hipBLAS/en/develop/)
+:::{grid-item-card} {doc}`hipBLAS <hipblas:index>`
 `hipBLAS` is a compatibility layer for GPU accelerated BLAS optimized for AMD GPUs
 via `rocBLAS` and `rocSOLVER`. `hipBLAS` allows for a common interface for other GPU
 BLAS libraries.
 
-- [Documentation](https://rocmdocs.amd.com/projects/hipBLAS/en/develop/)
+- {doc}`Documentation <hipblas:index>`
 - [Changelog](https://github.com/ROCmSoftwarePlatform/hipBLAS/blob/develop/CHANGELOG.md)
 
 :::
 
-:::{grid-item-card} [hipBLASLt](https://rocmdocs.amd.com/projects/hipBLASLt/en/develop/)
+:::{grid-item-card} {doc}`hipBLASLt <hipblaslt:index>`
 `hipBLASLt` is a library that provides general matrix-matrix operations with a
 flexible API and extends functionalities beyond traditional BLAS library.
 `hipBLASLt` is exposed APIs in HIP programming language with an underlying
 optimized generator as a back-end kernel provider.
 
-- [Documentation](https://rocmdocs.amd.com/projects/hipBLASLt/en/develop/)
+- {doc}`Documentation <hipblaslt:index>`
 - [Changelog](https://github.com/ROCmSoftwarePlatform/hipBLASLt/blob/develop/CHANGELOG.md)
 
 :::
 
-:::{grid-item-card} [rocALUTION](https://rocmdocs.amd.com/projects/rocALUTION/en/develop/)
+:::{grid-item-card} {doc}`rocALUTION <rocalution:index>`
 `rocALUTION` is a sparse linear algebra library with focus on exploring
 fine-grained parallelism on top of AMD's ROCm runtime and toolchains, targeting
 modern CPU and GPU platforms.
 
-- [Documentation](https://rocmdocs.amd.com/projects/rocALUTION/en/develop/)
+- {doc}`Documentation <rocalution:index>`
 - [Changelog](https://github.com/ROCmSoftwarePlatform/rocALUTION/blob/develop/CHANGELOG.md)
 
 :::
 
-:::{grid-item-card} [rocWMMA](https://rocmdocs.amd.com/projects/rocWMMA/en/develop/)
+:::{grid-item-card} {doc}`rocWMMA <rocwmma:index>`
 `rocWMMA` provides an API to break down mixed precision matrix multiply-accumulate
 (MMA) problems into fragments and distributes these over GPU wavefronts.
 
-- [Documentation](https://rocmdocs.amd.com/projects/rocWMMA/en/develop/)
+- {doc}`Documentation <rocwmma:index>`
 - [Changelog](https://github.com/ROCmSoftwarePlatform/rocWMMA/blob/develop/CHANGELOG.md)
 
 :::
 
-:::{grid-item-card} [rocSOLVER](https://rocmdocs.amd.com/projects/rocSOLVER/en/develop/)
+:::{grid-item-card} {doc}`rocSOLVER <rocsolver:index>`
 `rocSOLVER` provides a subset of LAPACK (Linear Algebra Package) functionality on the ROCm platform.
 
-- [Documentation](https://rocmdocs.amd.com/projects/rocSOLVER/en/develop/)
+- {doc}`Documentation <rocsolver:index>`
 - [Changelog](https://github.com/ROCmSoftwarePlatform/rocSOLVER/blob/develop/CHANGELOG.md)
 
 :::
 
-:::{grid-item-card} [hipSOLVER](https://rocmdocs.amd.com/projects/hipSOLVER/en/develop/)
+:::{grid-item-card} {doc}`hipSOLVER <hipsolver:index>`
 `hipSOLVER` is a LAPACK marshalling library supporting both `rocSOLVER` and `cuSOLVER`
 as backends whilst exporting a unified interface.
 
-- [Documentation](https://rocmdocs.amd.com/projects/hipSOLVER/en/develop/)
+- {doc}`Documentation <hipsolver:index>`
 - [Changelog](https://github.com/ROCmSoftwarePlatform/hipSOLVER/blob/develop/CHANGELOG.md)
 
 :::
 
-:::{grid-item-card} [rocSPARSE](https://rocmdocs.amd.com/projects/rocSOLVER/en/develop/)
+:::{grid-item-card} {doc}`rocSPARSE <rocsparse:index>`
 `rocSPARSE` is a library to provide BLAS for sparse computations.
 
-- [Documentation](https://rocmdocs.amd.com/projects/rocSOLVER/en/develop/)
+- {doc}`Documentation <rocsparse:index>`
 - [Changelog](https://github.com/ROCmSoftwarePlatform/rocSOLVER/blob/develop/CHANGELOG.md)
 
 :::
 
-:::{grid-item-card} [hipSPARSE](https://rocmdocs.amd.com/projects/hipSOLVER/en/develop/)
+:::{grid-item-card} {doc}`hipSPARSE <hipsparse:index>`
 `hipSPARSE` is a marshalling library to provide sparse BLAS functionality,
 supporting both `rocSPARSE` and `cuSPARSE` as backends.
 
-- [Documentation](https://rocmdocs.amd.com/projects/hipSOLVER/en/develop/)
+- {doc}`Documentation <hipsparse:index>`
 - [Changelog](https://github.com/ROCmSoftwarePlatform/hipSOLVER/blob/develop/CHANGELOG.md)
 
 :::

--- a/docs/reference/gpu_libraries/math.md
+++ b/docs/reference/gpu_libraries/math.md
@@ -12,30 +12,35 @@ vendor libraries as their back-ends. Due to their static dispatch nature, suppor
 at compile-time of the hipLIB in question. For dynamic dispatch between vendor implementations, refer to the
 [Orochi](https://github.com/GPUOpen-LibrariesAndSDKs/Orochi) library.
 
+::::{grid} 1 2 3 3
+:gutter: 1
+
 :::{grid-item-card} [Linear Algebra Libraries](linear_algebra)
 
-- [rocBLAS](https://rocmdocs.amd.com/projects/rocBLAS/en/develop/)
-- [hipBLAS](https://rocmdocs.amd.com/projects/hipBLAS/en/develop/)
-- [hipBLASLt](https://rocmdocs.amd.com/projects/hipBLASLt/en/develop/)
-- [rocALUTION](https://rocmdocs.amd.com/projects/rocALUTION/en/develop/)
-- [rocWMMA](https://rocmdocs.amd.com/projects/rocWMMA/en/develop/)
-- [rocSOLVER](https://rocmdocs.amd.com/projects/rocSOLVER/en/develop/)
-- [hipSOLVER](https://rocmdocs.amd.com/projects/hipSOLVER/en/develop/)
-- [rocSPARSE](https://rocmdocs.amd.com/projects/rocSPARSE/en/develop/)
-- [hipSPARSE](https://rocmdocs.amd.com/projects/hipSPARSE/en/develop/)
+- {doc}`rocBLAS <rocblas:index>`
+- {doc}`hipBLAS <hipblas:index>`
+- {doc}`hipBLASLt <hipblaslt:index>`
+- {doc}`rocALUTION <rocalution:index>`
+- {doc}`rocWMMA <rocwmma:index>`
+- {doc}`rocSOLVER <rocsolver:index>`
+- {doc}`hipSOLVER <hipsolver:index>`
+- {doc}`rocSPARSE <rocsparse:index>`
+- {doc}`hipSPARSE <hipsparse:index>`
 
 :::
 
 :::{grid-item-card} [Fast Fourier Transforms](fft)
 
-- [rocFFT](https://rocmdocs.amd.com/projects/rocFFT/en/develop/)
-- [hipFFT](https://rocmdocs.amd.com/projects/hipFFT/en/develop/)
+- {doc}`rocFFT <rocfft:index>`
+- {doc}`hipFFT <hipfft:index>`
 
 :::
 
 :::{grid-item-card} [Random Numbers](rand)
 
-- [rocRAND](https://rocmdocs.amd.com/projects/rocRAND/en/develop/)
-- [hipRAND](https://rocmdocs.amd.com/projects/hipRAND/en/develop/)
+- {doc}`rocRAND <rocrand:index>`
+- {doc}`hipRAND <hiprand:index>`
 
 :::
+
+::::

--- a/docs/reference/gpu_libraries/rand.md
+++ b/docs/reference/gpu_libraries/rand.md
@@ -3,21 +3,21 @@
 :::::{grid} 1 1 2 2
 :gutter: 1
 
-:::{grid-item-card} [rocRAND](https://rocmdocs.amd.com/projects/rocRAND/en/latest/)
+:::{grid-item-card} {doc}`rocRAND <rocrand:index>`
 rocRAND is an AMD GPU optimized library for pseudo-random number generators (PRNG).
 
-- [Documentation](https://rocmdocs.amd.com/projects/rocRAND/en/latest/)
+- {doc}`Documentation <rocrand:index>`
 - [Changelog](https://github.com/ROCmSoftwarePlatform/rocRAND/blob/develop/CHANGELOG.md)
 - [Examples](https://github.com/amd/rocm-examples/tree/develop/Libraries/rocRAND)
 
 :::
 
-:::{grid-item-card} [hipRAND](https://rocmdocs.amd.com/projects/hipRAND/en/latest/)
+:::{grid-item-card} {doc}`hipRAND <hiprand:index>`
 hipRAND is a compatibility layer for GPU accelerated FFT optimized for AMD GPUs
 using rocFFT. hipFFT allows for a common interface for other non AMD GPU
 FFT libraries.
 
-- [Documentation](https://rocmdocs.amd.com/projects/hipRAND/en/latest/)
+- {doc}`Documentation <hiprand:index>`
 - [Changelog](https://github.com/ROCmSoftwarePlatform/hipRAND/blob/develop/CHANGELOG.md)
 
 :::

--- a/docs/reference/hip.md
+++ b/docs/reference/hip.md
@@ -8,11 +8,11 @@ page introduces the HIP runtime and other HIP libraries and tools.
 :::::{grid} 1 1 2 2
 :gutter: 1
 
-:::{grid-item-card} [HIP Runtime](https://rocmdocs.amd.com/projects/HIP/en/develop/)
+:::{grid-item-card} {doc}`HIP Runtime <hip:index>`
 The HIP Runtime is used to enable GPU acceleration for all HIP language based
 products.
 
-- [HIP Runtime API Manual](https://rocmdocs.amd.com/projects/HIP/en/develop/)
+- {doc}`hip:.doxygen/docBin/html/index`
 - [Examples](https://github.com/amd/rocm-examples/tree/develop/HIP-Basic)
 
 :::
@@ -24,11 +24,11 @@ products.
 :::::{grid} 1 1 2 2
 :gutter: 1
 
-:::{grid-item-card} [HIPIFY](https://rocm.docs.amd.com/projects/HIPIFY/en/latest/)
+:::{grid-item-card} {doc}`HIPIFY <hipify:index>`
 HIPIFY assists with porting applications from based on CUDA to the HIP Runtime.
 Supported CUDA APIs are documented here as well.
 
-- [Reference Manual](https://rocm.docs.amd.com/projects/HIPIFY/en/latest/)
+- {doc}`Reference Manual <hipify:index>`
 
 :::
 

--- a/docs/reference/management_tools.md
+++ b/docs/reference/management_tools.md
@@ -20,10 +20,10 @@ This tool acts as a command line interface for manipulating and monitoring the A
 
 :::
 
-:::{grid-item-card} [ROCm Datacenter Tool](https://rocmdocs.amd.com/projects/rdc/en/latest/)
+:::{grid-item-card} {doc}`ROCm Datacenter Tool <rdc:index>`
 The ROCm™ Data Center Tool simplifies the administration and addresses key infrastructure challenges in AMD GPUs in cluster and data center environments.
 
-- [Documentation](https://rocmdocs.amd.com/projects/rdc/en/latest/)
+- {doc}`Documentation <rdc:index>`
 - [GitHub](https://github.com/RadeonOpenCompute/rdc)
 - [Examples](https://github.com/RadeonOpenCompute/rdc/tree/master/example)
 

--- a/docs/reference/openmp/openmp.md
+++ b/docs/reference/openmp/openmp.md
@@ -9,7 +9,7 @@ Along with host APIs, the OpenMP compilers support offloading code and data onto
 GPU devices. This document briefly describes the installation location of the
 OpenMP toolchain, example usage of device offloading, and usage of `rocprof`
 with OpenMP applications. The GPUs supported are the same as those supported by
-this ROCm release. See the list of [supported GPUs](../../release/gpu_os_support.md#gpu-support-table).
+this ROCm release. See the list of supported GPUs in {doc}`/release/gpu_os_support`.
 
 ### Installation
 
@@ -109,7 +109,7 @@ code compiled with AOMP:
    an XML file as an input.
 
 For more details on `rocprof`, refer to the ROCm Profiling Tools document on
-<https://docs.amd.com>.
+{doc}`rocprofiler:rocprof`.
 
 ### Using Tracing Options
 
@@ -136,7 +136,7 @@ Navigate to Chrome or Perfetto and load the JSON file to see the timeline of the
 HSA calls.
 
 For more details on tracing, refer to the ROCm Profiling Tools document on
-<https://docs.amd.com>.
+{doc}`rocprofiler:rocprof`.
 
 ### Environment Variables
 

--- a/docs/reference/validation_tools.md
+++ b/docs/reference/validation_tools.md
@@ -3,19 +3,19 @@
 :::::{grid} 1 1 2 2
 :gutter: 1
 
-:::{grid-item-card} [RVS](https://rocm.docs.amd.com/projects/ROCmValidationSuite/en/latest/)
+:::{grid-item-card} {doc}`RVS <rocm-validation-suite:index>`
 The ROCm Validation Suite is a system administrator’s and cluster manager's tool for detecting and troubleshooting common problems affecting AMD GPU(s) running in a high-performance computing environment, enabled using the ROCm software stack on a compatible platform.
 
-- [Documentation](https://rocm.docs.amd.com/projects/ROCmValidationSuite/en/latest/)
+- {doc}`Documentation <rocm-validation-suite:index>`
 
 :::
 
-:::{grid-item-card} [TransferBench](https://rocmdocs.amd.com/projects/TransferBench/en/latest/)
+:::{grid-item-card} {doc}`TransferBench <transferbench:index>`
 TransferBench is a simple utility capable of benchmarking simultaneous transfers between user-specified devices (CPUs/GPUs).
 
-- [Documentation](https://rocmdocs.amd.com/projects/TransferBench/en/latest/)
+- {doc}`Documentation <transferbench:index>`
 - [Changelog](https://github.com/ROCmSoftwarePlatform/TransferBench/blob/develop/CHANGELOG.md)
-- [Examples](https://rocmdocs.amd.com/projects/TransferBench/en/develop/examples/index.html#examples)
+- {doc}`transferbench:examples/index`
 
 :::
 

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -48,26 +48,26 @@ subtrees:
   entries:
     - file: reference/all
     - file: reference/compilers
-      title: Compilers and Development Tools
+      title: Compilers and Tools
       subtrees:
         - entries:
           - file: reference/rocmcc/rocmcc
             title: ROCmCC
-          - url: https://rocmdocs.amd.com/projects/ROCgdb/en/hybrid/
+          - url: ${project:rocgdb}
             title: ROCgdb
-          - url: https://rocmdocs.amd.com/projects/rocprofiler/en/{branch}/
+          - url: ${project:rocprofiler}
             title: rocprofiler
-          - url: https://rocmdocs.amd.com/projects/roctracer/en/{branch}/
+          - url: ${project:roctracer}
             title: roctracer
-          - url: https://rocmdocs.amd.com/projects/ROCdbgapi/en/{branch}/
+          - url: ${project:rocdbgapi}
             title: ROCdbgapi
     - file: reference/hip
       subtrees:
         - entries:
             - title: HIP Runtime API
-              url: https://rocmdocs.amd.com/projects/HIP/en/{branch}/
+              url: ${project:hip}
             - title: HIPify - Port Your Code
-              url: https://advanced-micro-devices-demo--737.com.readthedocs.build/projects/HIPIFY/en/737/
+              url: ${project:hipify}
     - file: reference/openmp/openmp
       title: OpenMP
     - file: reference/gpu_libraries/math
@@ -78,72 +78,72 @@ subtrees:
             subtrees:
             - entries: 
               - title: rocBLAS
-                url: https://rocmdocs.amd.com/projects/rocBLAS/en/{branch}/
+                url: ${project:rocblas}
               - title: hipBLAS
-                url: https://rocmdocs.amd.com/projects/hipBLAS/en/{branch}/
+                url: ${project:hipblas}
               - title: hipBLASLt
-                url: https://rocm.docs.amd.com/projects/hipBLASLt/en/{branch}/
+                url: ${project:hipblaslt}
               - title: rocALUTION
-                url: https://rocm.docs.amd.com/projects/rocALUTION/en/{branch}/
+                url: ${project:rocalution}
               - title: rocWMMA
-                url: https://rocm.docs.amd.com/projects/rocWMMA/en/{branch}/
+                url: ${project:rocwmma}
               - title: rocSOLVER
-                url: https://rocm.docs.amd.com/projects/rocSOLVER/en/{branch}/
+                url: ${project:rocsolver}
               - title: hipSOLVER
-                url: https://rocm.docs.amd.com/projects/hipSOLVER/en/{branch}/
+                url: ${project:hipsolver}
               - title: rocSPARSE
-                url: https://rocm.docs.amd.com/projects/rocSPARSE/en/{branch}/
+                url: ${project:rocsparse}
               - title: hipSPARSE
-                url: https://rocm.docs.amd.com/projects/hipSPARSE/en/{branch}/
+                url: ${project:hipsparse}
           - file: reference/gpu_libraries/fft
             subtrees:
             - entries: 
               - title: rocFFT
-                url: https://rocm.docs.amd.com/projects/rocFFT/en/{branch}/
+                url: ${project:rocfft}
               - title: hipFFT
-                url: https://rocm.docs.amd.com/projects/hipFFT/en/{branch}/
+                url: ${project:hipfft}
           - file: reference/gpu_libraries/rand
             subtrees:
             - entries: 
               - title: rocRAND
-                url: https://rocm.docs.amd.com/projects/rocRAND/en/{branch}/
+                url: ${project:rocrand}
               - title: hipRAND
-                url: https://rocm.docs.amd.com/projects/hipRAND/en/{branch}/
+                url: ${project:hiprand}
     - file: reference/gpu_libraries/c++_primitives
       title: C++ Primitive Libraries
       subtrees:
         - entries:
           - title: rocPRIM
-            url: https://rocm.docs.amd.com/projects/rocPRIM/en/{branch}/
+            url: ${project:rocprim}
         - entries:
           - title: hipCUB 
-            url: https://rocm.docs.amd.com/projects/hipCUB/en/{branch}/
+            url: ${project:hipcub}
         - entries:
           - title: rocThrust
-            url: https://rocm.docs.amd.com/projects/rocThrust/en/{branch}/
+            url: ${project:rocthrust}
     - file: reference/gpu_libraries/communication
       title: Communication Libraries
       subtrees:
         - entries:
           - title: RCCL
-            url: https://rocm.docs.amd.com/projects/rccl/en/{branch}/
+            url: ${project:rccl}
     - file: reference/ai_tools
       title: AI Libraries
       subtrees:
         - entries:
           - title: MIOpen - Machine Intelligence
-            url: https://rocm.docs.amd.com/projects/MIOpen/en/{branch}/
+            url: ${project:miopen}
           - title: Composable Kernel
-            url: https://rocm.docs.amd.com/projects/composable_kernel/en/{branch}/
+            url: ${project:composable-kernel}
           - title: MIGraphX - Graph Optimization
-            url: https://rocm.docs.amd.com/projects/AMDMIGraphX/en/{branch}/
+            url: ${project:migraphx}
     - file: reference/computer_vision
       subtrees:
         - entries:
-          - url: https://rocm.docs.amd.com/projects/MIVisionX/en/{branch}/
+          - url: ${project:mivisionx}
             title: MIVisionX
         - entries:
-          - url: https://rocm.docs.amd.com/projects/rocAL/en/{branch}/
+          - url: ${project:rocal}
             title: rocAL 
     - file: reference/management_tools
       title: Management Tools
@@ -153,15 +153,15 @@ subtrees:
             title: AMD SMI
           - url: https://rocm.docs.amd.com/projects/rocmsmi/en/{branch}/
             title: ROCm SMI
-          - url: https://rocm.docs.amd.com/projects/rdc/en/{branch}/
+          - url: ${project:rdc}
             title: ROCm Datacenter Tool
     - file: reference/validation_tools
       title: Validation Tools
       subtrees:
         - entries:
-          - url: https://rocm.docs.amd.com/projects/rvs/en/{branch}/
+          - url: ${project:rocm-validation-suite}
             title: RVS
-          - url: https://rocm.docs.amd.com/projects/TransferBench/en/{branch}/
+          - url: ${project:transferbench}
             title: TransferBench
 - caption: Understand ROCm
   entries:


### PR DESCRIPTION
Requires: https://github.com/RadeonOpenCompute/rocm-docs-core/pull/213