### PR TITLE
Standardize install instructions

### DIFF
--- a/docs/deploy/linux/installer/install.md
+++ b/docs/deploy/linux/installer/install.md
@@ -220,7 +220,7 @@ required repositories for the latest release.
 :sync: ubuntu-20.04
 
 ```shell
-for ver in 5.0.2 5.1.4 5.2.5 5.3.3; do
+for ver in 5.3.3 5.5.1; do
 echo "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/rocm-keyring.gpg] https://repo.radeon.com/rocm/apt/$ver focal main" | sudo tee /etc/apt/sources.list.d/rocm.list
 done
 echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | sudo tee /etc/apt/preferences.d/rocm-pin-600
@@ -232,7 +232,7 @@ sudo apt update
 :sync: ubuntu-22.04
 
 ```shell
-for ver in 5.0.2 5.1.4 5.2.5 5.3.3; do
+for ver in 5.3.3 5.5.1; do
 echo "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/rocm-keyring.gpg] https://repo.radeon.com/rocm/apt/$ver jammy main" | sudo tee /etc/apt/sources.list.d/rocm.list
 done
 echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | sudo tee /etc/apt/preferences.d/rocm-pin-600
@@ -246,7 +246,7 @@ sudo apt update
 :sync: RHEL
 
 ```shell
-for ver in 5.0.2 5.1.4 5.2.5 5.3.3; do
+for ver in 5.3.3 5.5.1; do
 sudo tee --append /etc/yum.repos.d/rocm.repo <<EOF
 [ROCm-$ver]
 Name=ROCm$ver
@@ -265,7 +265,7 @@ sudo yum clean all
 :sync: SLES15
 
 ```shell
-for ver in 5.0.2 5.1.4 5.2.5 5.3.3; do
+for ver in 5.3.3 5.5.1; do
 sudo tee --append /etc/zypp/repos.d/rocm.repo <<EOF
 name=rocm
 baseurl=https://repo.radeon.com/amdgpu/$ver/sle/15.4/main/x86_64

--- a/docs/deploy/linux/installer/install.md
+++ b/docs/deploy/linux/installer/install.md
@@ -28,8 +28,8 @@ installed.
 
 ```shell
 sudo apt update
-wget https://repo.radeon.com/amdgpu-install/5.4.3/ubuntu/focal/amdgpu-install_5.4.50403-1_all.deb
-sudo apt install ./amdgpu-install_5.4.50403-1_all.deb
+wget https://repo.radeon.com/amdgpu-install/5.5.1/ubuntu/focal/amdgpu-install_5.5.50501-1_all.deb
+sudo apt install ./amdgpu-install_5.5.50501-1_all.deb
 ```
 
 :::
@@ -38,8 +38,8 @@ sudo apt install ./amdgpu-install_5.4.50403-1_all.deb
 
 ```shell
 sudo apt update
-wget https://repo.radeon.com/amdgpu-install/5.4.3/ubuntu/jammy/amdgpu-install_5.4.50403-1_all.deb
-sudo apt install ./amdgpu-install_5.4.50403-1_all.deb
+wget https://repo.radeon.com/amdgpu-install/5.5.1/ubuntu/jammy/amdgpu-install_5.5.50501-1_all.deb
+sudo apt install ./amdgpu-install_5.5.50501-1_all.deb
 ```
 
 :::
@@ -57,7 +57,7 @@ sudo apt install ./amdgpu-install_5.4.50403-1_all.deb
 :sync: RHEL-8.6
 
 ```shell
-sudo yum install https://repo.radeon.com/amdgpu-install/5.4.3/rhel/8.6/amdgpu-install-5.4.50403-1.el8.noarch.rpm
+sudo yum install https://repo.radeon.com/amdgpu-install/5.5.1/rhel/8.6/amdgpu-install-5.5.50501-1.el8.noarch.rpm
 ```
 
 :::
@@ -65,7 +65,15 @@ sudo yum install https://repo.radeon.com/amdgpu-install/5.4.3/rhel/8.6/amdgpu-in
 :sync: RHEL-8.7
 
 ```shell
-sudo yum install https://repo.radeon.com/amdgpu-install/5.4.3/rhel/8.7/amdgpu-install-5.4.50403-1.el8.noarch.rpm
+sudo yum install https://repo.radeon.com/amdgpu-install/5.5.1/rhel/8.7/amdgpu-install-5.5.50501-1.el8.noarch.rpm
+```
+
+:::
+:::{tab-item} RHEL 8.8
+:sync: RHEL-8.8
+
+```shell
+sudo yum install https://repo.radeon.com/amdgpu-install/5.5.1/rhel/8.8/amdgpu-install-5.5.50501-1.el8.noarch.rpm
 ```
 
 :::
@@ -73,7 +81,15 @@ sudo yum install https://repo.radeon.com/amdgpu-install/5.4.3/rhel/8.7/amdgpu-in
 :sync: RHEL-9.1
 
 ```shell
-sudo yum install https://repo.radeon.com/amdgpu-install/5.4.3/rhel/9.1/amdgpu-install-5.4.50403-1.el9.noarch.rpm
+sudo yum install https://repo.radeon.com/amdgpu-install/5.5.1/rhel/9.1/amdgpu-install-5.5.50501-1.el8.noarch.rpm
+```
+
+:::
+:::{tab-item} RHEL 9.2
+:sync: RHEL-9.2
+
+```shell
+sudo yum install https://repo.radeon.com/amdgpu-install/5.5.1/rhel/9.2/amdgpu-install-5.5.50501-1.el8.noarch.rpm
 ```
 
 :::
@@ -91,7 +107,7 @@ sudo yum install https://repo.radeon.com/amdgpu-install/5.4.3/rhel/9.1/amdgpu-in
 :sync: SLES15-SP4
 
 ```shell
-sudo zypper --no-gpg-checks install https://repo.radeon.com/amdgpu-install/5.4.3/sle/15.4/amdgpu-install-5.4.50403-1.noarch.rpm
+sudo zypper --no-gpg-checks install https://repo.radeon.com/amdgpu-install/5.5.1/sle/15.4/amdgpu-install-5.5.50501-1.noarch.rpm
 ```
 
 :::
@@ -188,9 +204,9 @@ The multi-version ROCm installation requires you to download and install the
 latest ROCm release installer from the list of ROCm releases you want to install
 simultaneously on your system.
 
-**Example:** If you want to install ROCm releases 4.5.0, 4.5.1, and 5.4.3
+**Example:** If you want to install ROCm releases 5.3.3 and 5.5.1
 simultaneously, you are required to download the installer from the latest ROCm
-release v5.4.3.
+release v5.5.1.
 
 To download and install the installer, refer to the [Download and Install the
 Installer Script](#download-and-install-the-installer-script) section.
@@ -297,16 +313,15 @@ kernel-mode driver, as shown in the following samples:
 ```
 
 ```none
-sudo amdgpu-install --usecase=rocm --rocmrelease=4.5.0 --no-dkms
-sudo amdgpu-install --usecase=rocm --rocmrelease=5.4.3 --no-dkms
+sudo amdgpu-install --usecase=rocm --rocmrelease=5.3.3 --no-dkms
+sudo amdgpu-install --usecase=rocm --rocmrelease=5.5.1 --no-dkms
 ```
 
 Following are examples of ROCm multi-version installation. The kernel-mode
-driver, associated with the ROCm release v5.4.3, will be installed as its latest
+driver, associated with the ROCm release v5.5.1, will be installed as its latest
 release in the list.
 
 ```none
-sudo amdgpu-install --usecase=rocm --rocmrelease=4.5.0
-sudo amdgpu-install --usecase=rocm --rocmrelease=4.5.2
-sudo amdgpu-install --usecase=rocm --rocmrelease=5.4.3
+sudo amdgpu-install --usecase=rocm --rocmrelease=5.3.3
+sudo amdgpu-install --usecase=rocm --rocmrelease=5.5.1
 ```

--- a/docs/deploy/linux/os-native/install.md
+++ b/docs/deploy/linux/os-native/install.md
@@ -107,7 +107,7 @@ follow these steps:
    :sync: ubuntu-20.04
 
    ```shell
-   echo 'deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/rocm-keyring.gpg] https://repo.radeon.com/amdgpu/5.4.3/ubuntu focal main' | sudo tee /etc/apt/sources.list.d/amdgpu.list
+   echo 'deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/rocm-keyring.gpg] https://repo.radeon.com/amdgpu/5.5.1/ubuntu focal main' | sudo tee /etc/apt/sources.list.d/amdgpu.list
    sudo apt update
    ```
 
@@ -116,7 +116,7 @@ follow these steps:
    :sync: ubuntu-22.04
 
    ```shell
-   echo 'deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/rocm-keyring.gpg] https://repo.radeon.com/amdgpu/5.4.3/ubuntu jammy main' | sudo tee /etc/apt/sources.list.d/amdgpu.list
+   echo 'deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/rocm-keyring.gpg] https://repo.radeon.com/amdgpu/5.5.1/ubuntu jammy main' | sudo tee /etc/apt/sources.list.d/amdgpu.list
    sudo apt update
    ```
 
@@ -183,7 +183,7 @@ follow these steps:
    ```
 
    ```shell
-   sudo apt install rocm-hip-sdk5.4.3 rocm-hip-sdk5.3.3
+   sudo apt install rocm-hip-sdk5.5.1 rocm-hip-sdk5.3.3
    ```
 
 :::::
@@ -249,7 +249,7 @@ follow these steps:
    sudo tee --append /etc/yum.repos.d/amdgpu.repo <<EOF
    [amdgpu]
    Name=amdgpu
-   baseurl=https://repo.radeon.com/amdgpu/5.4.3/rhel/8.6/main/x86_64/
+   baseurl=https://repo.radeon.com/amdgpu/5.5.1/rhel/8.6/main/x86_64/
    enabled=1
    priority=50
    gpgcheck=1
@@ -267,7 +267,7 @@ follow these steps:
    sudo tee --append /etc/yum.repos.d/amdgpu.repo <<EOF
    [amdgpu]
    Name=amdgpu
-   baseurl=https://repo.radeon.com/amdgpu/5.4.3/rhel/8.7/main/x86_64/
+   baseurl=https://repo.radeon.com/amdgpu/5.5.1/rhel/8.7/main/x86_64/
    enabled=1
    priority=50
    gpgcheck=1
@@ -285,7 +285,7 @@ follow these steps:
    sudo tee --append /etc/yum.repos.d/amdgpu.repo <<EOF
    [amdgpu]
    Name=amdgpu
-   baseurl=https://repo.radeon.com/amdgpu/5.4.3/rhel/9.1/main/x86_64/
+   baseurl=https://repo.radeon.com/amdgpu/5.5.1/rhel/9.1/main/x86_64/
    enabled=1
    priority=50
    gpgcheck=1
@@ -345,7 +345,7 @@ follow these steps:
    ```
 
    ```shell
-   sudo yum install rocm-hip-sdk5.4.3 rocm-hip-sdk5.3.3
+   sudo yum install rocm-hip-sdk5.5.1 rocm-hip-sdk5.3.3
    ```
 
 :::::
@@ -402,7 +402,7 @@ these steps:
    sudo tee --append /etc/zypp/repos.d/amdgpu.repo <<EOF
    [amdgpu]
    name=amdgpu
-   baseurl=https://repo.radeon.com/amdgpu/5.4.3/sle/15.4/main/x86_64
+   baseurl=https://repo.radeon.com/amdgpu/5.5.1/sle/15.4/main/x86_64
    enabled=1
    gpgcheck=1
    gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
@@ -456,7 +456,7 @@ these steps:
    ```
 
    ```shell
-   sudo zypper --gpg-auto-import-keys install rocm-hip-sdk5.4.3 rocm-hip-sdk5.3.3
+   sudo zypper --gpg-auto-import-keys install rocm-hip-sdk5.5.1 rocm-hip-sdk5.3.3
    ```
 
 :::::
@@ -493,7 +493,7 @@ but are generally useful. Verification of the install is advised.
 2. Add binary paths to the `PATH` environment variable.
 
    ```shell
-   export PATH=$PATH:/opt/rocm-5.4.3/bin:/opt/rocm-5.4.3/opencl/bin
+   export PATH=$PATH:/opt/rocm-5.5.1/bin:/opt/rocm-5.5.1/opencl/bin
    ```
 
    ```{attention}

--- a/docs/deploy/linux/os-native/install.md
+++ b/docs/deploy/linux/os-native/install.md
@@ -140,7 +140,7 @@ follow these steps:
    :sync: ubuntu-20.04
 
    ```shell
-   for ver in 5.3.3 5.4.3; do
+   for ver in 5.3.3 5.5.1; do
    echo "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/rocm-keyring.gpg] https://repo.radeon.com/rocm/apt/$ver focal main" | sudo tee /etc/apt/sources.list.d/rocm.list
    done
    echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | sudo tee /etc/apt/preferences.d/rocm-pin-600
@@ -152,7 +152,7 @@ follow these steps:
    :sync: ubuntu-22.04
 
    ```shell
-   for ver in 5.5.1 5.4.3 5.3.3 ; do
+   for ver in 5.3.3 5.5.1; do
    echo "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/rocm-keyring.gpg] https://repo.radeon.com/rocm/apt/$ver jammy main" | sudo tee --append /etc/apt/sources.list.d/rocm.list
    done
    echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | sudo tee /etc/apt/preferences.d/rocm-pin-600
@@ -310,7 +310,7 @@ follow these steps:
    To add the ROCm repository, use the following steps:
 
    ```shell
-   for ver in 5.3.3 5.4.3; do
+   for ver in 5.3.3 5.5.1; do
    sudo tee --append /etc/yum.repos.d/rocm.repo <<EOF
    [ROCm-$ver]
    Name=ROCm$ver
@@ -423,7 +423,7 @@ these steps:
    To add the ROCm repository, use the following steps:
 
    ```shell
-   for ver in 5.3.3 5.4.3; do
+   for ver in 5.3.3 5.5.1; do
    sudo tee --append /etc/zypp/repos.d/rocm.repo <<EOF
    name=rocm
    baseurl=https://repo.radeon.com/amdgpu/$ver/sle/15.4/main/x86_64


### PR DESCRIPTION
use the same versions in the install instructions for consistency

update version in instructions: rocm 5.4.3 > rocm 5.5.1