### PR TITLE
Update Links

### DIFF
--- a/docs/how_to/gpu_aware_mpi.md
+++ b/docs/how_to/gpu_aware_mpi.md
@@ -22,7 +22,7 @@ MPI project is an open source implementation of the Message Passing Interface
 and industry partners.
 
 Several MPI implementations can be made ROCm-aware by compiling them with
-[Unified Communication Framework](http://www.openucx.org/) (UCX) support. One
+[Unified Communication Framework](https://www.openucx.org/) (UCX) support. One
 notable exception is MVAPICH2: It directly supports AMD GPUs without using UCX,
 and you can download it [here](http://mvapich.cse.ohio-state.edu/downloads/).
 Use the latest version of the MVAPICH2-GDR package.
@@ -32,7 +32,7 @@ whose goal is to provide a common set of communication interfaces that targets a
 broad set of network programming models and interfaces. UCX is ROCm-aware, and
 ROCm technologies are used directly to implement various network operation
 primitives. For more details on the UCX design, refer to it's
-[documentation](http://www.openucx.org/documentation).
+[documentation](https://www.openucx.org/documentation).
 
 ## Building UCX
 

--- a/docs/how_to/pytorch_install/pytorch_install.md
+++ b/docs/how_to/pytorch_install/pytorch_install.md
@@ -60,7 +60,7 @@ Follow these steps:
 PyTorch supports the ROCm platform by providing tested wheels packages. To
 access this feature, refer to
 [https://pytorch.org/get-started/locally/](https://pytorch.org/get-started/locally/)
-and choose the "ROCm" compute platform. {numref}`Installation-Matrix-from-Pytorch` is a matrix from <http://pytorch.org/> that illustrates the installation compatibility between ROCm and the PyTorch build.
+and choose the "ROCm" compute platform. {numref}`Installation-Matrix-from-Pytorch` is a matrix from <https://pytorch.org/> that illustrates the installation compatibility between ROCm and the PyTorch build.
 
 ```{figure} ../../data/how_to/magma_install/image.006.png
 :name: Installation-Matrix-from-Pytorch
@@ -83,7 +83,7 @@ To install PyTorch using the wheels package, follow these installation steps:
       installation directions in the section
       [Installation](../../deploy/linux/install.md). ROCm 5.2 is installed in
       this example, as supported by the installation matrix from
-      <http://pytorch.org/>.
+      <https://pytorch.org/>.
 
    or
 

--- a/docs/reference/all.md
+++ b/docs/reference/all.md
@@ -73,8 +73,8 @@ Computer vision related projects.
 :::{grid-item-card} [Management Tools](management_tools)
 
 - AMD SMI
-- [ROCm SMI](https://rocmdocs.amd.com/projects/rocmsmi/en/latest/)
-- {doc}`ROCm Datacenter Tool <rdc:index>`
+- ROCm SMI
+- ROCm Datacenter Tool
 
 :::
 

--- a/docs/reference/all.md
+++ b/docs/reference/all.md
@@ -74,7 +74,7 @@ Computer vision related projects.
 
 - AMD SMI
 - ROCm SMI
-- ROCm Datacenter Tool
+- ROCm Data Center Tool
 
 :::
 

--- a/docs/reference/management_tools.md
+++ b/docs/reference/management_tools.md
@@ -11,19 +11,17 @@ The AMD System Management Interface Library, or AMD SMI library, is a C library 
 
 :::
 
-:::{grid-item-card} [ROCm SMI](https://rocmdocs.amd.com/projects/rocmsmi/en/latest/)
+:::{grid-item-card} ROCm SMI
 This tool acts as a command line interface for manipulating and monitoring the AMD GPU kernel, and is intended to replace and deprecate the existing `rocm_smi.py` CLI tool. It uses `ctypes` to call the `rocm_smi_lib` API.
 
-- [Documentation](https://rocmdocs.amd.com/projects/rocmsmi/en/latest/)
 - [GitHub](https://github.com/RadeonOpenCompute/rocm_smi_lib)
 - [Examples](https://github.com/RadeonOpenCompute/rocm_smi_lib/tree/master/python_smi_tools)
 
 :::
 
-:::{grid-item-card} {doc}`ROCm Datacenter Tool <rdc:index>`
+:::{grid-item-card} ROCm Datacenter Tool
 The ROCm™ Data Center Tool simplifies the administration and addresses key infrastructure challenges in AMD GPUs in cluster and data center environments.
 
-- {doc}`Documentation <rdc:index>`
 - [GitHub](https://github.com/RadeonOpenCompute/rdc)
 - [Examples](https://github.com/RadeonOpenCompute/rdc/tree/master/example)
 

--- a/docs/reference/management_tools.md
+++ b/docs/reference/management_tools.md
@@ -19,7 +19,7 @@ This tool acts as a command line interface for manipulating and monitoring the A
 
 :::
 
-:::{grid-item-card} ROCm Datacenter Tool
+:::{grid-item-card} ROCm Data Center Tool
 The ROCm™ Data Center Tool simplifies the administration and addresses key infrastructure challenges in AMD GPUs in cluster and data center environments.
 
 - [GitHub](https://github.com/RadeonOpenCompute/rdc)

--- a/docs/understand/More-about-how-ROCm-uses-PCIe-Atomics.rst
+++ b/docs/understand/More-about-how-ROCm-uses-PCIe-Atomics.rst
@@ -45,8 +45,8 @@ Other I/O devices with PCIe Atomics support
 
    * `Mellanox ConnectX-5 InfiniBand Card <http://www.mellanox.com/related-docs/prod_adapter_cards/PB_ConnectX-5_VPI_Card.pdf>`_
    * `Cray Aries Interconnect <http://www.hoti.org/hoti20/slides/Bob_Alverson.pdf>`_
-   * `Xilinx PCIe Ultrascale Whitepaper <https://www.xilinx.com/support/documentation/white_papers/wp464-PCIe-ultrascale.pdf>`_
-   * `Xilinx 7 Series Devices <https://www.xilinx.com/support/documentation/ip_documentation/pcie_7x/v3_1/pg054-7series-pcie.pdf>`_
+   * `Xilinx PCIe Ultrascale Whitepaper <https://docs.xilinx.com/v/u/8OZSA2V1b1LLU2rRCDVGQw>`_
+   * `Xilinx 7 Series Devices <https://docs.xilinx.com/v/u/1nfXeFNnGpA0ywyykvWHWQ>`_
 
 Future bus technology with richer I/O Atomics Operation Support
 
@@ -54,8 +54,8 @@ Future bus technology with richer I/O Atomics Operation Support
 
 New PCIe Endpoints with support beyond AMD Ryzen and EPYC CPU; Intel Haswell or newer CPU’s with PCIe Generation 3.0 support.
 
-  * `Mellanox Bluefield SOC <http://www.mellanox.com/related-docs/npu-multicore-processors/PB_Bluefield_SoC.pdf>`_
-  * `Cavium Thunder X2 <http://www.cavium.com/ThunderX2_ARM_Processors.html>`_
+  * `Mellanox Bluefield SOC <https://docs.nvidia.com/networking/display/BlueFieldSWv25111213/BlueField+Software+Overview>`_
+  * `Cavium Thunder X2 <https://en.wikichip.org/wiki/cavium/thunderx2>`_
 
 In ROCm, we also take advantage of PCIe ID based ordering technology for P2P when the GPU originates two writes to two different targets:  
 

--- a/docs/understand/More-about-how-ROCm-uses-PCIe-Atomics.rst
+++ b/docs/understand/More-about-how-ROCm-uses-PCIe-Atomics.rst
@@ -39,7 +39,7 @@ There are also a number of papers which talk about these new capabilities:
   * `Atomic Read Modify Write Primitives by Intel <https://www.intel.es/content/dam/doc/white-paper/atomic-read-modify-write-primitives-i-o-devices-paper.pdf>`_
   * `PCI express 3 Accelerator Whitepaper by Intel <https://www.intel.sg/content/dam/doc/white-paper/pci-express3-accelerator-white-paper.pdf>`_
   * `Intel PCIe Generation 3 Hotchips Paper <https://www.hotchips.org/wp-content/uploads/hc_archives/hc21/1_sun/HC21.23.1.SystemInterconnectTutorial-Epub/HC21.23.131.Ajanovic-Intel-PCIeGen3.pdf>`_
-  * `PCIe Generation 4 Base Specification includes Atomics Operation <http://composter.com.ua/documents/PCI_Express_Base_Specification_Revision_4.0.Ver.0.3.pdf>`_
+  * `PCIe Generation 4 Base Specification includes Atomics Operation <https://astralvx.com/storage/2020/11/PCI_Express_Base_4.0_Rev0.3_February19-2014.pdf>`_
 
 Other I/O devices with PCIe Atomics support
 
@@ -145,5 +145,3 @@ Improve performance by avoiding stalls caused by ordering rules. For example, po
 This only has meaning for memory requests, and is reserved for Configuration or IO requests. Completers are not required to copy this bit into a completion, and only use the bit if their enable bit is set for this operation.
 
 To read more on PCIe Gen 3 new options https://www.mindshare.com/files/resources/PCIe%203-0.pdf
-
-


### PR DESCRIPTION
Remove links to doc sites yet to be built:
	amdsmi
	rdc
	rocm_smi_lib

Fix some links in `docs/understand/More-about-how-ROCm-uses-PCIe-Atomics.rst`