### PR TITLE
gpu-aware MPI udpates

### DIFF
--- a/docs/how_to/gpu_aware_mpi.md
+++ b/docs/how_to/gpu_aware_mpi.md
@@ -66,11 +66,8 @@ cd ucx
 ./autogen.sh
 mkdir build
 cd build
-../contrib/configure-release -prefix=$UCX_DIR \
-    --with-rocm=/opt/rocm \
-    --without-cuda -enable-optimizations -disable-logging \
-    --disable-debug -disable-assertions \
-    --disable-params-check -without-java
+../configure -prefix=$UCX_DIR \
+    --with-rocm=/opt/rocm
 make -j $(nproc)
 make -j $(nproc) install
 ```
@@ -93,9 +90,7 @@ cd ompi
 mkdir build
 cd build
 ../configure --prefix=$OMPI_DIR --with-ucx=$UCX_DIR \
-    --with-rocm=/opt/rocm \
-    --enable-mca-no-build=btl-uct --enable-mpi1-compatibility \
-    CC=clang CXX=clang++ FC=flang
+    --with-rocm=/opt/rocm
 make -j $(nproc)
 make -j $(nproc) install
 ```
@@ -165,7 +160,12 @@ Inter-GPU bandwidth with various payload sizes.
 Collective Operations on GPU buffers are best handled through the
 Unified Collective Communication Library (UCC) component in Open MPI.
 For this, the UCC library has to be configured and compiled with ROCm
-support. An example for configuring UCC and Open MPI with ROCm support
+support.
+
+Please note the compatibility [table](../release/3rd_party_support_matrix.md#communication-libraries)
+for UCC versions with the various ROCm versions.
+
+An example for configuring UCC and Open MPI with ROCm support
 is shown below:
 
 ```shell

--- a/docs/release/3rd_party_support_matrix.md
+++ b/docs/release/3rd_party_support_matrix.md
@@ -31,6 +31,14 @@ UCX version | ROCm 5.4 and older | ROCm 5.5 and newer |
 | -1.14.0   | COMPATIBLE         | INCOMPATIBLE       |
 |  1.14.1+  | COMPATIBLE         | COMPATIBLE         |
 
+The Unified Collective Communication Library [UCC](https://https://github.com/openucx/ucc)
+also has support for ROCm devices.
+
+UCC version | ROCm 5.5 and older | ROCm 5.6 and newer |
+|:----------|:------------------:|:------------------:|
+| -1.1.0    | COMPATIBLE         | INCOMPATIBLE       |
+|  1.2.0+   | COMPATIBLE         | COMPATIBLE         |
+
 ## Algorithm libraries
 
 ROCm releases provide algorithm libraries with interfaces compatible with


### PR DESCRIPTION
- simplify the configure arguments of UCX to only use flags absolutely required for ROCm
- add the UCC compatibility matrix to the docs