### PR TITLE
Test add myst-parser html metadata

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -29,6 +29,9 @@ MMA
 backends
 cuSOLVER
 cuSPARSE
+# metadata
+html
+myst
 # mi200_performance_counters
 ALU
 Arb

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,9 +15,9 @@ shutil.copy2('../RELEASE.md','./release.md')
 shutil.copy2('../CHANGELOG.md','./CHANGELOG.md')
 
 myst_html_meta = {
-    "SoftwareFamily": "ROCm",
+    "Software_Family": "ROCm",
     "keywords": "GPU, AI",
-    "DocumentStatus": "Preview"
+    "Document_Status": "Preview"
 }
 
 # for PDF output on Read the Docs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,12 @@ shutil.copy2('../RELEASE.md','./release.md')
 # Keep capitalization due to similar linking on GitHub's markdown preview.
 shutil.copy2('../CHANGELOG.md','./CHANGELOG.md')
 
+myst_html_meta = {
+    "SoftwareFamily": "ROCm",
+    "keywords": "GPU, AI",
+    "DocumentStatus": "Preview"
+}
+
 # for PDF output on Read the Docs
 project = "ROCm Documentation"
 author = "Advanced Micro Devices, Inc."

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,5 @@
 ---
+<!-- spellcheck-disable -->
 myst:
   html_meta:
     "SoftwareFamily": "ROCm"
@@ -7,6 +8,7 @@ myst:
     "DocUserGroup": "User"
     "OSFamily": "Windows, Linux"
     "DocumentStatus": "Preview"
+<!-- spellcheck-enable -->
 ---
 
 # AMD ROCm™ Documentation

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,16 +1,15 @@
+---
 <!-- markdownlint-disable -->
 <!-- spellcheck-disable -->
----
 myst:
   html_meta:
     "DocGroup": "Reference"
     "DocUserGroup": "User"
     "OSFamily": "Windows, Linux"
----
 <!-- spellcheck-enable -->
 <!-- markdownlint-enable -->
+---
 
-<!-- markdownlint-disable header-style -->
 # AMD ROCm™ Documentation
 
 :::::{grid} 1 1 3 3

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,9 @@
 ---
 myst:
   html_meta:
-    "DocGroup": "Reference"
-    "DocUserGroup": "User"
-    "OSFamily": "Windows, Linux"
+    "Doc_Group": "Reference"
+    "Doc_User_Group": "User"
+    "OS_Family": "Windows, Linux"
 ---
 
 # AMD ROCm™ Documentation

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,12 @@
 ---
-html_meta:
-  "SoftwareFamily": "ROCm"
-  "keywords": ["GPU", "AI"]
-  "DocGroup": "Reference"
-  "DocUserGroup": "User"
-  "OSFamily": ["Windows", "Linux"]
-  "DocumentStatus": "Preview"
+myst:
+  html_meta:
+    "SoftwareFamily": "ROCm"
+    "keywords": "GPU, AI"
+    "DocGroup": "Reference"
+    "DocUserGroup": "User"
+    "OSFamily": "Windows, Linux"
+    "DocumentStatus": "Preview"
 ---
 
 # AMD ROCm™ Documentation

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,12 +2,9 @@
 <!-- spellcheck-disable -->
 myst:
   html_meta:
-    "SoftwareFamily": "ROCm"
-    "keywords": "GPU, AI"
     "DocGroup": "Reference"
     "DocUserGroup": "User"
     "OSFamily": "Windows, Linux"
-    "DocumentStatus": "Preview"
 <!-- spellcheck-enable -->
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,13 @@
+---
+html_meta:
+  "SoftwareFamily": "ROCm"
+  "keywords": ["GPU", "AI"]
+  "DocGroup": "Reference"
+  "DocUserGroup": "User"
+  "OSFamily": ["Windows", "Linux"]
+  "DocumentStatus": "Preview"
+---
+
 # AMD ROCm™ Documentation
 
 :::::{grid} 1 1 3 3

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,16 @@
----
+<!-- markdownlint-disable -->
 <!-- spellcheck-disable -->
+---
 myst:
   html_meta:
     "DocGroup": "Reference"
     "DocUserGroup": "User"
     "OSFamily": "Windows, Linux"
-<!-- spellcheck-enable -->
 ---
+<!-- spellcheck-enable -->
+<!-- markdownlint-enable -->
 
+<!-- markdownlint-disable header-style -->
 # AMD ROCm™ Documentation
 
 :::::{grid} 1 1 3 3

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,9 @@
 ---
-<!-- markdownlint-disable -->
-<!-- spellcheck-disable -->
 myst:
   html_meta:
     "DocGroup": "Reference"
     "DocUserGroup": "User"
     "OSFamily": "Windows, Linux"
-<!-- spellcheck-enable -->
-<!-- markdownlint-enable -->
 ---
 
 # AMD ROCm™ Documentation


### PR DESCRIPTION
global metadata (all files) - conf.py

local metadata (per file) - markdown file (index.md)

re: https://myst-parser.readthedocs.io/en/latest/configuration.html#setting-html-metadata

![image](https://github.com/RadeonOpenCompute/ROCm/assets/22262939/e6a5ced8-a385-4004-8f78-0fd2592fc4d1)
