### PR TITLE
build: concurrency for linting to prevent deadlock

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [develop, main]
 
+concurrency:
+  group: ${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   call-workflow-passing-data:
     name: Documentation


### PR DESCRIPTION
RE: https://github.com/RadeonOpenCompute/ROCm/actions/runs/5931515287?pr=2392

`Canceling since a deadlock for concurrency group 'refs/pull/2392/merge-Linting' was detected between 'top level workflow' and 'call-workflow-passing-data'`

https://docs.github.com/en/actions/using-jobs/using-concurrency
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions