### PR TITLE
fix RTD build failing on pdflatex and linting deadlock

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,6 +1,12 @@
 name: Linting
 
 on:
+  push:
+    branches: 
+    - develop
+    - main
+    - 'docs/*'
+    - 'roc**'
   pull_request:
     branches: 
     - develop

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -8,10 +8,6 @@ on:
     - 'docs/*'
     - 'roc**'
 
-concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}
-  cancel-in-progress: true
-
 jobs:
   call-workflow-passing-data:
     name: Documentation

--- a/docs/reference/openmp/openmp.md
+++ b/docs/reference/openmp/openmp.md
@@ -16,7 +16,7 @@ The ROCm OpenMP compiler is implemented using LLVM compiler technology.
 
 ```{figure-md} openmp-toolchain
 
-<img src="/data/reference/openmp/openmp_toolchain.svg" alt="">
+<img src="/data/reference/openmp/openmp_toolchain.svg" alt="" width="950" height="768">
 
 OpenMP Toolchain
 ```

--- a/docs/release/gpu_os_support.md
+++ b/docs/release/gpu_os_support.md
@@ -58,7 +58,6 @@ ROCm supports virtualization for select GPUs only as shown below.
 | VMWare         | ESXi 8   | MI210 | Ubuntu 20.04 (`5.15.0-56-generic`), SLES 15 SP4 (`5.14.21-150400.24.18-default`) |
 | VMWare         | ESXi 7   | MI210 | Ubuntu 20.04 (`5.15.0-56-generic`), SLES 15 SP4 (`5.14.21-150400.24.18-default`) |
 
-(supported_gpus)=
 ## Linux Supported GPUs
 
 The table below shows supported GPUs for Instinct™, Radeon Pro™ and Radeon™


### PR DESCRIPTION
specify width and height for openmp toolchain svg to avoid RTD build failing on latexpdf
```
! LaTeX Error: Cannot determine size of graphic in openmp_toolchain.svg (no Bou
ndingBox).

  pdflatex: Command for 'pdflatex' gave return code 36096
```

also reverts linting changes to avoid concurrency error
`Canceling since a deadlock for concurrency group 'refs/pull/2398/merge-Linting' was detected between 'top level workflow' and 'call-workflow-passing-data'`