### PR TITLE
Add hiptensor to list of ROCm libraries

### DIFF
--- a/docs/reference/all.md
+++ b/docs/reference/all.md
@@ -29,6 +29,7 @@ ROCm template libraries for C++ primitives and algorithms are as follows:
 - {doc}`rocPRIM <rocprim:index>`
 - {doc}`rocThrust <rocthrust:index>`
 - {doc}`hipCUB <hipcub:index>`
+- {doc}`hipTensor <hiptensor:index>`
 
 :::
 

--- a/docs/reference/gpu_libraries/c++_primitives.md
+++ b/docs/reference/gpu_libraries/c++_primitives.md
@@ -40,4 +40,14 @@ interface. It's back-end is rocPRIM.
 
 :::
 
+:::{grid-item-card} {doc}`hipTensor <hiptensor:index>`
+hipTensor is AMD's C++ library for accelerating tensor primitives
+based on the composable kernel library,
+through general purpose kernel languages, like HIP C++.
+
+- {doc}`Documentation <hiptensor:index>`
+- [GitHub](https://github.com/ROCmSoftwarePlatform/hipTensor)
+
+:::
+
 :::::


### PR DESCRIPTION
Needs this PR to go in https://github.com/RadeonOpenCompute/rocm-docs-core/pull/365

Then needs an update of rocm-docs-core in requirements.in/txt