### PR TITLE
Specify font package for xelatex engine for pdf

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,13 @@ shutil.copy2('../RELEASE.md','./about/release-notes.md')
 shutil.copy2('../CHANGELOG.md','./CHANGELOG.md')
 
 latex_engine = "xelatex"
+latex_elements = {
+    "fontpkg": r"""
+\usepackage{tgtermes}
+\usepackage{tgheros}
+\renewcommand\ttdefault{txtt}
+"""
+}
 
 # configurations for PDF output by Read the Docs
 project = "ROCm Documentation"


### PR DESCRIPTION
https://www.sphinx-doc.org/en/master/latex.html#module-latex

issue: xelatex uses GNU FreeFont, which was not available