### PR TITLE
Roc 5.6.x to docs/5.6.1

### DIFF
--- a/docs/deploy/linux/installer/install.md
+++ b/docs/deploy/linux/installer/install.md
@@ -71,7 +71,7 @@ sudo yum install https://repo.radeon.com/amdgpu-install/5.6/rhel/8.8/amdgpu-inst
 :sync: RHEL-9
 
 ```shell
-sudo yum install https://repo.radeon.com/amdgpu-install/5.6/rhel/9.1/amdgpu-install-5.6.50600-1.el8.noarch.rpm
+sudo yum install https://repo.radeon.com/amdgpu-install/5.6/rhel/9.1/amdgpu-install-5.6.50600-1.el9.noarch.rpm
 ```
 
 :::
@@ -80,7 +80,7 @@ sudo yum install https://repo.radeon.com/amdgpu-install/5.6/rhel/9.1/amdgpu-inst
 :sync: RHEL-9
 
 ```shell
-sudo yum install https://repo.radeon.com/amdgpu-install/5.6/rhel/9.2/amdgpu-install-5.6.50600-1.el8.noarch.rpm
+sudo yum install https://repo.radeon.com/amdgpu-install/5.6/rhel/9.2/amdgpu-install-5.6.50600-1.el9.noarch.rpm
 ```
 
 :::

--- a/docs/deploy/linux/installer/install.md
+++ b/docs/deploy/linux/installer/install.md
@@ -18,8 +18,8 @@ following commands based on your distribution.
 
 ```shell
 sudo apt update
-wget https://repo.radeon.com/amdgpu-install/5.6/ubuntu/focal/amdgpu-install_5.6.50600-1_all.deb
-sudo apt install ./amdgpu-install_5.6.50600-1_all.deb
+wget https://repo.radeon.com/amdgpu-install/5.6.1/ubuntu/focal/amdgpu-install_5.6.50601-1_all.deb
+sudo apt install ./amdgpu-install_5.6.50601-1_all.deb
 ```
 
 :::
@@ -28,8 +28,8 @@ sudo apt install ./amdgpu-install_5.6.50600-1_all.deb
 
 ```shell
 sudo apt update
-wget https://repo.radeon.com/amdgpu-install/5.6/ubuntu/jammy/amdgpu-install_5.6.50600-1_all.deb
-sudo apt install ./amdgpu-install_5.6.50600-1_all.deb
+wget https://repo.radeon.com/amdgpu-install/5.6.1/ubuntu/jammy/amdgpu-install_5.6.50601-1_all.deb
+sudo apt install ./amdgpu-install_5.6.50601-1_all.deb
 ```
 
 :::
@@ -44,7 +44,7 @@ sudo apt install ./amdgpu-install_5.6.50600-1_all.deb
 :sync: RHEL-8
 
 ```shell
-sudo yum install https://repo.radeon.com/amdgpu-install/5.6/rhel/8.6/amdgpu-install-5.6.50600-1.el8.noarch.rpm
+sudo yum install https://repo.radeon.com/amdgpu-install/5.6.1/rhel/8.6/amdgpu-install-5.6.50601-1.el8.noarch.rpm
 ```
 
 :::
@@ -53,7 +53,7 @@ sudo yum install https://repo.radeon.com/amdgpu-install/5.6/rhel/8.6/amdgpu-inst
 :sync: RHEL-8
 
 ```shell
-sudo yum install https://repo.radeon.com/amdgpu-install/5.6/rhel/8.7/amdgpu-install-5.6.50600-1.el8.noarch.rpm
+sudo yum install https://repo.radeon.com/amdgpu-install/5.6.1/rhel/8.7/amdgpu-install-5.6.50601-1.el8.noarch.rpm
 ```
 
 :::
@@ -62,7 +62,7 @@ sudo yum install https://repo.radeon.com/amdgpu-install/5.6/rhel/8.7/amdgpu-inst
 :sync: RHEL-8
 
 ```shell
-sudo yum install https://repo.radeon.com/amdgpu-install/5.6/rhel/8.8/amdgpu-install-5.6.50600-1.el8.noarch.rpm
+sudo yum install https://repo.radeon.com/amdgpu-install/5.6.1/rhel/8.8/amdgpu-install-5.6.50601-1.el8.noarch.rpm
 ```
 
 :::
@@ -71,7 +71,7 @@ sudo yum install https://repo.radeon.com/amdgpu-install/5.6/rhel/8.8/amdgpu-inst
 :sync: RHEL-9
 
 ```shell
-sudo yum install https://repo.radeon.com/amdgpu-install/5.6/rhel/9.1/amdgpu-install-5.6.50600-1.el9.noarch.rpm
+sudo yum install https://repo.radeon.com/amdgpu-install/5.6.1/rhel/9.1/amdgpu-install-5.6.50601-1.el9.noarch.rpm
 ```
 
 :::
@@ -80,7 +80,7 @@ sudo yum install https://repo.radeon.com/amdgpu-install/5.6/rhel/9.1/amdgpu-inst
 :sync: RHEL-9
 
 ```shell
-sudo yum install https://repo.radeon.com/amdgpu-install/5.6/rhel/9.2/amdgpu-install-5.6.50600-1.el9.noarch.rpm
+sudo yum install https://repo.radeon.com/amdgpu-install/5.6.1/rhel/9.2/amdgpu-install-5.6.50601-1.el9.noarch.rpm
 ```
 
 :::
@@ -94,7 +94,7 @@ sudo yum install https://repo.radeon.com/amdgpu-install/5.6/rhel/9.2/amdgpu-inst
 :sync: SLES-15.4
 
 ```shell
-sudo zypper --no-gpg-checks install https://repo.radeon.com/amdgpu-install/5.6/sle/15.4/amdgpu-install-5.6.50600-1.noarch.rpm
+sudo zypper --no-gpg-checks install https://repo.radeon.com/amdgpu-install/5.6.1/sle/15.4/amdgpu-install-5.6.50601-1.noarch.rpm
 ```
 
 :::
@@ -102,7 +102,7 @@ sudo zypper --no-gpg-checks install https://repo.radeon.com/amdgpu-install/5.6/s
 :sync: SLES-15.5
 
 ```shell
-sudo zypper --no-gpg-checks install https://repo.radeon.com/amdgpu-install/5.6/sle/15.5/amdgpu-install-5.6.50600-1.noarch.rpm
+sudo zypper --no-gpg-checks install https://repo.radeon.com/amdgpu-install/5.6.1/sle/15.5/amdgpu-install-5.6.50601-1.noarch.rpm
 ```
 
 :::
@@ -202,7 +202,7 @@ Run the following commands based on your distribution to add the repositories:
 :sync: ubuntu-20.04
 
 ```shell
-for ver in 5.3.3 5.4.3; do
+for ver in 5.4.3 5.5.1; do
 echo "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/rocm-keyring.gpg] https://repo.radeon.com/rocm/apt/$ver focal main" | sudo tee --append /etc/apt/sources.list.d/rocm.list
 done
 echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | sudo tee /etc/apt/preferences.d/rocm-pin-600
@@ -214,7 +214,7 @@ sudo apt update
 :sync: ubuntu-22.04
 
 ```shell
-for ver in 5.3.3 5.4.3; do
+for ver in 5.4.3 5.5.1; do
 echo "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/rocm-keyring.gpg] https://repo.radeon.com/rocm/apt/$ver jammy main" | sudo tee --append /etc/apt/sources.list.d/rocm.list
 done
 echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | sudo tee /etc/apt/preferences.d/rocm-pin-600
@@ -232,7 +232,7 @@ sudo apt update
 :sync: RHEL-8
 
 ```shell
-for ver in 5.3.3 5.4.3; do
+for ver in 5.4.3 5.5.1; do
 sudo tee --append /etc/yum.repos.d/rocm.repo <<EOF
 [ROCm-$ver]
 name=ROCm$ver
@@ -251,7 +251,7 @@ sudo yum clean all
 :sync: RHEL-9
 
 ```shell
-for ver in 5.3.3 5.4.3; do
+for ver in 5.4.3 5.5.1; do
 sudo tee --append /etc/yum.repos.d/rocm.repo <<EOF
 [ROCm-$ver]
 name=ROCm$ver
@@ -272,7 +272,7 @@ sudo yum clean all
 :sync: SLES
 
 ```shell
-for ver in 5.3.3 5.4.3; do
+for ver in 5.4.3 5.5.1; do
 sudo tee --append /etc/zypp/repos.d/rocm.repo <<EOF
 name=rocm
 baseurl=https://repo.radeon.com/rocm/zyp/$ver/main
@@ -302,8 +302,8 @@ driver, associated with the ROCm release v5.4.3, will be installed as its latest
 release in the list.
 
 ```none
-sudo amdgpu-install --usecase=rocm --rocmrelease=5.3.3
 sudo amdgpu-install --usecase=rocm --rocmrelease=5.4.3
+sudo amdgpu-install --usecase=rocm --rocmrelease=5.5.1
 ```
 
 ## Additional options


### PR DESCRIPTION
Fix RHEL9 instructions

Update 5.6.0 to 5.6.1 instructions

5.4.6 and 5.5.3 do not exist