### PR TITLE
RX 6700* doc fixes in windows_support.md 

### DIFF
--- a/docs/about/compatibility/windows-support.md
+++ b/docs/about/compatibility/windows-support.md
@@ -41,7 +41,7 @@ on this table, the GPU is not officially supported by AMD.
 |:----:|:------------:|:--------------------------------------------------------------------:|:-------:|:----------------:|
 | AMD Radeon™ RX 7900 XTX | RDNA3  | gfx1100 | ✅ | ✅ |
 | AMD Radeon™ RX 7900 XT  | RDNA3  | gfx1100 | ✅ | ✅ |
-| AMD Radeon™ RX 7600     | RDNA3  | gfx1100 | ✅ | ✅ |
+| AMD Radeon™ RX 7600     | RDNA3  | gfx1102 | ✅ | ✅ |
 | AMD Radeon™ RX 6950 XT  | RDNA2  | gfx1030 | ✅ | ✅ |
 | AMD Radeon™ RX 6900 XT  | RDNA2  | gfx1030 | ✅ | ✅ |
 | AMD Radeon™ RX 6800 XT  | RDNA2  | gfx1030 | ✅ | ✅ |

--- a/docs/about/compatibility/windows-support.md
+++ b/docs/about/compatibility/windows-support.md
@@ -46,9 +46,9 @@ on this table, the GPU is not officially supported by AMD.
 | AMD Radeon™ RX 6900 XT  | RDNA2  | gfx1030 | ✅ | ✅ |
 | AMD Radeon™ RX 6800 XT  | RDNA2  | gfx1030 | ✅ | ✅ |
 | AMD Radeon™ RX 6800     | RDNA2  | gfx1030 | ✅ | ✅ |
-| AMD Radeon™ RX 6750     | RDNA2  | gfx1032 | ✅ | ❌ |
-| AMD Radeon™ RX 6700 XT  | RDNA2  | gfx1032 | ✅ | ❌ |
-| AMD Radeon™ RX 6700     | RDNA2  | gfx1032 | ✅ | ❌ |
+| AMD Radeon™ RX 6750 XT  | RDNA2  | gfx1031 | ✅ | ❌ |
+| AMD Radeon™ RX 6700 XT  | RDNA2  | gfx1031 | ✅ | ❌ |
+| AMD Radeon™ RX 6700     | RDNA2  | gfx1031 | ✅ | ❌ |
 | AMD Radeon™ RX 6650 XT  | RDNA2  | gfx1032 | ✅ | ❌ |
 | AMD Radeon™ RX 6600 XT  | RDNA2  | gfx1032 | ✅ | ❌ |
 | AMD Radeon™ RX 6600     | RDNA2  | gfx1032 | ✅ | ❌ |


### PR DESCRIPTION
Corrected the RX 6700 series LLVM target to "gfx1031" in windows_support.md

Changed name from "RX 6750" to "RX 6750 XT"