### PR TITLE
Edited the quickstart guide for linux so all commands appear in a single place

### DIFF
--- a/docs/tutorials/quick-start/linux.md
+++ b/docs/tutorials/quick-start/linux.md
@@ -36,7 +36,10 @@ $ sudo reboot
 :sync: ubuntu-22.04-IS
 
 ```console
-$ temp
+$ sudo apt update 
+$ wget https://repo.radeon.com/amdgpu-install/5.7/ubuntu/jammy/amdgpu-install_5.7.50700-1_all.deb 
+$ sudo apt install ./amdgpu-install_5.7.50700-1_all.deb 
+$ sudo amdgpu-install --usecase=graphics,rocm 
 ```
 
 :::
@@ -70,7 +73,10 @@ $ sudo reboot
 :sync: ubuntu-20.04-IS
 
 ```console
-$ temp
+$ sudo apt update 
+$ wget https://repo.radeon.com/amdgpu-install/5.7/ubuntu/focal/amdgpu-install_5.7.50700-1_all.deb 
+$ sudo apt install ./amdgpu-install_5.7.50700-1_all.deb 
+$ sudo amdgpu-install --usecase=graphics,rocm 
 ```
 
 :::
@@ -119,7 +125,8 @@ $ sudo reboot
 :sync: RHEL-9.2
 
 ```console
-$ temp
+$ sudo yum install https://repo.radeon.com/amdgpu-install/5.7/rhel/9.2/amdgpu-install-5.7.50700-1.el9.noarch.rpm 
+$ sudo amdgpu-install --usecase=graphics,rocm 
 ```
 
 :::
@@ -163,7 +170,8 @@ $ sudo reboot
 :sync: RHEL-9.1
 
 ```console
-$ temp
+$ sudo yum install https://repo.radeon.com/amdgpu-install/5.7/rhel/9.1/amdgpu-install-5.7.50700-1.el9.noarch.rpm 
+$ sudo amdgpu-install --usecase=graphics,rocm 
 ```
 
 :::
@@ -205,7 +213,8 @@ $ sudo reboot
 :::{tab-item} Install Script
 :sync: RHEL-8.8
 ```console
-$ temp
+$ sudo yum install https://repo.radeon.com/amdgpu-install/5.7/rhel/8.8/amdgpu-install-5.7.50700-1.el8.noarch.rpm 
+$ sudo amdgpu-install --usecase=graphics,rocm 
 ```
 
 :::
@@ -247,7 +256,8 @@ $ sudo reboot
 :sync: RHEL-8.7
 
 ```console
-$ temp
+$ sudo yum install https://repo.radeon.com/amdgpu-install/5.7/rhel/8.7/amdgpu-install-5.7.50700-1.el8.noarch.rpm 
+$ sudo amdgpu-install --usecase=graphics,rocm 
 ```
 
 :::
@@ -287,7 +297,8 @@ $ sudo reboot
 :::{tab-item} Install Script
 :sync: RHEL-8.6
 ```console
-$ temp
+$ sudo yum install https://repo.radeon.com/amdgpu-install/5.7/rhel/8.6/amdgpu-install-5.7.50700-1.el8.noarch.rpm 
+$ sudo amdgpu-install --usecase=graphics,rocm 
 ```
 
 :::
@@ -337,7 +348,8 @@ $ sudo reboot
 :::{tab-item} Install Script    
 :sync: SLES-15.5          
 ```console                      
-$ temp                         
+$ sudo zypper --no-gpg-checks install https://repo.radeon.com/amdgpu-install/5.7/sle/15.5/amdgpu-install-5.7.50700-1.noarch.rpm 
+$ sudo amdgpu-install --usecase=graphics,rocm                        
 ```                            
 
 :::                             
@@ -377,7 +389,8 @@ $ sudo reboot
 :sync: SLES-15.4
 
 ```console
-$ temp
+$ sudo zypper --no-gpg-checks install https://repo.radeon.com/amdgpu-install/5.7/sle/15.4/amdgpu-install-5.7.50700-1.noarch.rpm 
+$ sudo amdgpu-install --usecase=graphics,rocm 
 ```
 
 :::

--- a/docs/tutorials/quick-start/linux.md
+++ b/docs/tutorials/quick-start/linux.md
@@ -3,156 +3,55 @@
 For a quick summary on installing ROCm on Linux, follow the steps listed on this page. If you
 want a more in-depth installation guide, see [Installing ROCm on Linux](../install/linux/index.md).
 
-## Add repositories
-
 ::::::{tab-set}
 :::::{tab-item} Ubuntu
 :sync: ubuntu
 
-::::{rubric} 1. Download and convert the package signing key
-::::
-
-```shell
-# Make the directory if it doesn't exist yet.
-# This location is recommended by the distribution maintainers.
-sudo mkdir --parents --mode=0755 /etc/apt/keyrings
-# Download the key, convert the signing-key to a full
-# keyring required by apt and store in the keyring directory
-wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | \
-    gpg --dearmor | sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
-```
-
-::::{rubric} 2. Add the repositories
-::::
-
 ::::{tab-set}
-:::{tab-item} Ubuntu 20.04
-:sync: ubuntu-20.04
-
-```shell
-# Kernel driver repository for focal
-sudo tee /etc/apt/sources.list.d/amdgpu.list <<'EOF'
-deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/amdgpu/latest/ubuntu focal main
-EOF
-# ROCm repository for focal
-sudo tee /etc/apt/sources.list.d/rocm.list <<'EOF'
-deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/debian focal main
-EOF
-```
-
-:::
 :::{tab-item} Ubuntu 22.04
 :sync: ubuntu-22.04
 
-```shell
-# Kernel driver repository for jammy
-sudo tee /etc/apt/sources.list.d/amdgpu.list <<'EOF'
-deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/amdgpu/latest/ubuntu jammy main
-EOF
-# ROCm repository for jammy
-sudo tee /etc/apt/sources.list.d/rocm.list <<'EOF'
-deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/debian jammy main
-EOF
-# Prefer packages from the rocm repository over system packages
-echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | sudo tee /etc/apt/preferences.d/rocm-pin-600
+```console
+$ sudo mkdir --parents --mode=0755 /etc/apt/keyrings
+$ wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | \gpg --dearmor | sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
+$ sudo tee /etc/apt/sources.list.d/rocm.list <<<'deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/debian jammy main'
+$ echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | sudo tee /etc/apt/preferences.d/rocm-pin-600
+$ sudo apt update
+$ sudo apt install amdgpu-dkms
+$ sudo apt install rocm-hip-libraries
+$ sudo reboot
 ```
-
 :::
-::::
+:::{tab-item} Ubuntu 20.04
+:sync: ubuntu-20.04
 
-::::{rubric} 3. Update the list of packages
-::::
-
-```shell
-sudo apt update
+```console
+$ sudo mkdir --parents --mode=0755 /etc/apt/keyrings
+$ wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | \gpg --dearmor | sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
+$ sudo tee /etc/apt/sources.list.d/rocm.list <<<'deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/debian focal main'
+$ sudo apt update
+$ sudo apt install amdgpu-dkms
+$ sudo apt install rocm-hip-libraries
+$ sudo reboot
 ```
+::::
 
 :::::
 
 :::::{tab-item} Red Hat Enterprise Linux
 :sync: RHEL
 
-::::{rubric} 1. Add the repositories
-::::
-
 ::::{tab-set}
-:::{tab-item} RHEL 8.6
-:sync: RHEL-8.6
+:::{tab-item} RHEL 9.2
+:sync: RHEL-9.2
 
-```shell
-# Add the amdgpu module repository for RHEL 8.6
-sudo tee /etc/yum.repos.d/amdgpu.repo <<'EOF'
-[amdgpu]
-name=amdgpu
-baseurl=https://repo.radeon.com/amdgpu/latest/rhel/8.6/main/x86_64
-enabled=1
-gpgcheck=1
-gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
-EOF
-# Add the rocm repository for RHEL 8
-sudo tee /etc/yum.repos.d/rocm.repo <<'EOF'
-[rocm]
-name=rocm
-baseurl=https://repo.radeon.com/rocm/rhel8/latest/main
-enabled=1
-priority=50
-gpgcheck=1
-gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
-EOF
-```
-
-:::
-
-:::{tab-item} RHEL 8.7
-:sync: RHEL-8.7
-
-```shell
-# Add the amdgpu module repository for RHEL 8.7
-sudo tee /etc/yum.repos.d/amdgpu.repo <<'EOF'
-[amdgpu]
-name=amdgpu
-baseurl=https://repo.radeon.com/amdgpu/latest/rhel/8.7/main/x86_64
-enabled=1
-gpgcheck=1
-gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
-EOF
-# Add the rocm repository for RHEL 8
-sudo tee /etc/yum.repos.d/rocm.repo <<'EOF'
-[rocm]
-name=rocm
-baseurl=https://repo.radeon.com/rocm/rhel8/latest/main
-enabled=1
-priority=50
-gpgcheck=1
-gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
-EOF
-```
-
-:::
-
-:::{tab-item} RHEL 8.8
-:sync: RHEL-8.8
-
-```shell
-# Add the amdgpu module repository for RHEL 8.8
-sudo tee /etc/yum.repos.d/amdgpu.repo <<'EOF'
-[amdgpu]
-name=amdgpu
-baseurl=https://repo.radeon.com/amdgpu/latest/rhel/8.8/main/x86_64
-enabled=1
-gpgcheck=1
-gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
-EOF
-# Add the rocm repository for RHEL 8
-sudo tee /etc/yum.repos.d/rocm.repo <<'EOF'
-[rocm]
-name=rocm
-baseurl=https://repo.radeon.com/rocm/rhel8/latest/main
-enabled=1
-priority=50
-gpgcheck=1
-gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
-EOF
+```console
+$ sudo tee /etc/yum.repos.d/amdgpu.repo <<< '[amdgpu] name=amdgpu baseurl=https://repo.radeon.com/amdgpu/latest/rhel/9.2/main/x86_64 enabled=1 gpgcheck=1 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key'
+$ sudo tee /etc/yum.repos.d/rocm.repo <<< '[rocm] name=rocm baseurl=https://repo.radeon.com/rocm/rhel8/latest/main enabled=1 priority=50 gpgcheck=1 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key'
+$ sudo yum clean all
+$ sudo yum install amdgpu-dkms
+$ sudo yum install rocm-hip-libraries
+$ sudo reboot
 ```
 
 :::
@@ -160,213 +59,94 @@ EOF
 :::{tab-item} RHEL 9.1
 :sync: RHEL-9.1
 
-```shell
-# Add the amdgpu module repository for RHEL 9.1
-sudo tee /etc/yum.repos.d/amdgpu.repo <<'EOF'
-[amdgpu]
-name=amdgpu
-baseurl=https://repo.radeon.com/amdgpu/latest/rhel/9.1/main/x86_64
-enabled=1
-gpgcheck=1
-gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
-EOF
-# Add the rocm repository for RHEL 9
-sudo tee /etc/yum.repos.d/rocm.repo <<'EOF'
-[rocm]
-name=rocm
-baseurl=https://repo.radeon.com/rocm/rhel9/latest/main
-enabled=1
-priority=50
-gpgcheck=1
-gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
-EOF
+```console
+$ sudo tee /etc/yum.repos.d/amdgpu.repo <<< '[amdgpu] name=amdgpu baseurl=https://repo.radeon.com/amdgpu/latest/rhel/9.1/main/x86_64 enabled=1 gpgcheck=1 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key'
+$ sudo tee /etc/yum.repos.d/rocm.repo <<< '[rocm] name=rocm baseurl=https://repo.radeon.com/rocm/rhel8/latest/main enabled=1 priority=50 gpgcheck=1 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key'
+$ sudo yum clean all
+$ sudo yum install amdgpu-dkms
+$ sudo yum install rocm-hip-libraries
+$ sudo reboot
 ```
-
 :::
 
-:::{tab-item} RHEL 9.2
-:sync: RHEL-9.2
+:::{tab-item} RHEL 8.8
+:sync: RHEL-8.8
 
-```shell
-# Add the amdgpu module repository for RHEL 9.2
-sudo tee /etc/yum.repos.d/amdgpu.repo <<'EOF'
-[amdgpu]
-name=amdgpu
-baseurl=https://repo.radeon.com/amdgpu/latest/rhel/9.2/main/x86_64
-enabled=1
-gpgcheck=1
-gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
-EOF
-# Add the rocm repository for RHEL 9
-sudo tee /etc/yum.repos.d/rocm.repo <<'EOF'
-[rocm]
-name=rocm
-baseurl=https://repo.radeon.com/rocm/rhel9/latest/main
-enabled=1
-priority=50
-gpgcheck=1
-gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
-EOF
+```console
+$ sudo tee /etc/yum.repos.d/amdgpu.repo <<< '[amdgpu] name=amdgpu baseurl=https://repo.radeon.com/amdgpu/latest/rhel/8.8/main/x86_64 enabled=1 gpgcheck=1 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key'
+$ sudo tee /etc/yum.repos.d/rocm.repo <<< '[rocm] name=rocm baseurl=https://repo.radeon.com/rocm/rhel8/latest/main enabled=1 priority=50 gpgcheck=1 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key'
+$ sudo yum clean all
+$ sudo yum install amdgpu-dkms
+$ sudo yum install rocm-hip-libraries
+$ sudo reboot
 ```
+:::
 
+:::{tab-item} RHEL 8.7
+:sync: RHEL-8.7
+
+```console
+$ sudo tee /etc/yum.repos.d/amdgpu.repo <<< '[amdgpu] name=amdgpu baseurl=https://repo.radeon.com/amdgpu/latest/rhel/8.7/main/x86_64 enabled=1 gpgcheck=1 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key'
+$ sudo tee /etc/yum.repos.d/rocm.repo <<< '[rocm] name=rocm baseurl=https://repo.radeon.com/rocm/rhel8/latest/main enabled=1 priority=50 gpgcheck=1 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key'
+$ sudo yum clean all
+$ sudo yum install amdgpu-dkms
+$ sudo yum install rocm-hip-libraries
+$ sudo reboot
+```
+:::
+
+:::{tab-item} RHEL 8.6
+:sync: RHEL-8.6
+
+```console
+$ sudo tee /etc/yum.repos.d/amdgpu.repo <<< '[amdgpu] name=amdgpu baseurl=https://repo.radeon.com/amdgpu/latest/rhel/8.6/main/x86_64 enabled=1 gpgcheck=1 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key'
+$ sudo tee /etc/yum.repos.d/rocm.repo <<< '[rocm] name=rocm baseurl=https://repo.radeon.com/rocm/rhel8/latest/main enabled=1 priority=50 gpgcheck=1 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key'
+$ sudo yum clean all
+$ sudo yum install amdgpu-dkms
+$ sudo yum install rocm-hip-libraries
+$ sudo reboot
+```
 :::
 ::::
 
-::::{rubric} 2. Clean cached files from enabled repositories
 ::::
-
-```shell
-sudo yum clean all
-```
 
 :::::
 
 :::::{tab-item} SUSE Linux Enterprise Server
 :sync: SLES
 
-::::{rubric} 1. Add the repositories
-::::
-
 ::::{tab-set}
-:::{tab-item} SLES 15.4
-:sync: SLES-15.4
-
-```shell
-
-# Add the amdgpu module repository for SLES 15.4
-sudo tee /etc/zypp/repos.d/amdgpu.repo <<'EOF'
-[amdgpu]
-name=amdgpu
-baseurl=https://repo.radeon.com/amdgpu/latest/sle/15.4/main/x86_64
-enabled=1
-gpgcheck=1
-gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
-EOF
-# Add the rocm repository for SLES
-sudo tee /etc/zypp/repos.d/rocm.repo <<'EOF'
-[rocm]
-name=rocm
-baseurl=https://repo.radeon.com/rocm/zyp/zypper
-enabled=1
-priority=50
-gpgcheck=1
-gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
-EOF
-```
-
-:::
 :::{tab-item} SLES 15.5
 :sync: SLES-15.5
 
-```shell
+```console
+$ sudo tee /etc/zypp/repos.d/amdgpu.repo <<<'[amdgpu] name=amdgpu baseurl=https://repo.radeon.com/amdgpu/latest/sle/15.5/main/x86_64 enabled=1 gpgcheck=1 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key'
+$ sudo tee /etc/zypp/repos.d/rocm.repo <<<'[rocm] name=rocm baseurl=https://repo.radeon.com/rocm/zyp/zypper enabled=1 priority=50 gpgcheck=1 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key'
+$ sudo zypper ref
+$ sudo zypper install amdgpu-dkms
+$ sudo zypper install rocm-hip-libraries
+$ sudo reboot
+```
 
-# Add the amdgpu module repository for SLES 15.5
-sudo tee /etc/zypp/repos.d/amdgpu.repo <<'EOF'
-[amdgpu]
-name=amdgpu
-baseurl=https://repo.radeon.com/amdgpu/latest/sle/15.5/main/x86_64
-enabled=1
-gpgcheck=1
-gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
-EOF
-# Add the rocm repository for SLES
-sudo tee /etc/zypp/repos.d/rocm.repo <<'EOF'
-[rocm]
-name=rocm
-baseurl=https://repo.radeon.com/rocm/zyp/zypper
-enabled=1
-priority=50
-gpgcheck=1
-gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
-EOF
+:::
+:::{tab-item} SLES 15.4
+:sync: SLES-15.4
+
+```console
+$ sudo tee /etc/zypp/repos.d/amdgpu.repo <<<'[amdgpu] name=amdgpu baseurl=https://repo.radeon.com/amdgpu/latest/sle/15.4/main/x86_64 enabled=1 gpgcheck=1 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key'
+$ sudo tee /etc/zypp/repos.d/rocm.repo <<<'[rocm] name=rocm baseurl=https://repo.radeon.com/rocm/zyp/zypper enabled=1 priority=50 gpgcheck=1 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key'
+$ sudo zypper ref
+$ sudo zypper install amdgpu-dkms
+$ sudo zypper install rocm-hip-libraries
+$ sudo reboot
 ```
 
 :::
 ::::
 
-::::{rubric} 2. Update the new repository
 ::::
 
-```shell
-sudo zypper ref
-```
 
 :::::
 ::::::
-
-## Install drivers
-
-Install the `amdgpu-dkms` kernel module, aka driver, on your system.
-
-::::{tab-set}
-
-:::{tab-item} Ubuntu
-:sync: ubuntu
-
-```shell
-sudo apt install amdgpu-dkms
-```
-
-:::
-
-:::{tab-item} Red Hat Enterprise Linux
-:sync: RHEL
-
-```shell
-sudo yum install amdgpu-dkms
-```
-
-:::
-
-:::{tab-item} SUSE Linux Enterprise Server
-:sync: SLES
-
-```shell
-sudo zypper install amdgpu-dkms
-```
-
-:::
-
-::::
-
-## Install ROCm runtimes
-
-Install the `rocm-hip-libraries` meta-package. This contains dependencies for most
-common ROCm applications.
-
-::::{tab-set}
-:::{tab-item} Ubuntu
-:sync: ubuntu
-
-```console shell
-sudo apt install rocm-hip-libraries
-```
-
-:::
-
-:::{tab-item} Red Hat Enterprise Linux
-:sync: RHEL
-
-```console shell
-sudo yum install rocm-hip-libraries
-```
-
-:::
-
-:::{tab-item} SUSE Linux Enterprise Server
-:sync: SLES
-
-```console shell
-sudo zypper install rocm-hip-libraries
-```
-
-:::
-::::
-
-## Reboot the system
-
-Loading the new driver requires a reboot of the system.
-
-```shell
-sudo reboot
-```

--- a/docs/tutorials/quick-start/linux.md
+++ b/docs/tutorials/quick-start/linux.md
@@ -14,7 +14,12 @@ want a more in-depth installation guide, see [Installing ROCm on Linux](../insta
 ```console
 $ sudo mkdir --parents --mode=0755 /etc/apt/keyrings
 $ wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | \gpg --dearmor | sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
-$ sudo tee /etc/apt/sources.list.d/rocm.list <<<'deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/debian jammy main'
+$ sudo tee /etc/apt/sources.list.d/amdgpu.list <<'EOF'
+  deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/amdgpu/latest/ubuntu jammy main
+  EOF
+$ sudo tee /etc/apt/sources.list.d/rocm.list <<'EOF'
+  deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/debian jammy main
+  EOF
 $ echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | sudo tee /etc/apt/preferences.d/rocm-pin-600
 $ sudo apt update
 $ sudo apt install amdgpu-dkms
@@ -28,7 +33,12 @@ $ sudo reboot
 ```console
 $ sudo mkdir --parents --mode=0755 /etc/apt/keyrings
 $ wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | \gpg --dearmor | sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
-$ sudo tee /etc/apt/sources.list.d/rocm.list <<<'deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/debian focal main'
+$ sudo tee /etc/apt/sources.list.d/amdgpu.list <<'EOF'
+  deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/amdgpu/latest/ubuntu focal main
+  EOF
+sudo tee /etc/apt/sources.list.d/rocm.list <<'EOF'
+deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/debian focal main
+EOF
 $ sudo apt update
 $ sudo apt install amdgpu-dkms
 $ sudo apt install rocm-hip-libraries
@@ -46,8 +56,23 @@ $ sudo reboot
 :sync: RHEL-9.2
 
 ```console
-$ sudo tee /etc/yum.repos.d/amdgpu.repo <<< '[amdgpu] name=amdgpu baseurl=https://repo.radeon.com/amdgpu/latest/rhel/9.2/main/x86_64 enabled=1 gpgcheck=1 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key'
-$ sudo tee /etc/yum.repos.d/rocm.repo <<< '[rocm] name=rocm baseurl=https://repo.radeon.com/rocm/rhel8/latest/main enabled=1 priority=50 gpgcheck=1 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key'
+$ sudo tee /etc/yum.repos.d/amdgpu.repo <<'EOF' 
+  [amdgpu]
+  name=amdgpu
+  baseurl=https://repo.radeon.com/amdgpu/latest/rhel/9.2/main/x86_64
+  enabled=1
+  gpgcheck=1
+  gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
+  EOF
+$ sudo tee /etc/yum.repos.d/rocm.repo <<'EOF'
+  [rocm]
+  name=rocm
+  baseurl=https://repo.radeon.com/rocm/rhel9/latest/main
+  enabled=1
+  priority=50
+  gpgcheck=1
+  gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
+  EOF
 $ sudo yum clean all
 $ sudo yum install amdgpu-dkms
 $ sudo yum install rocm-hip-libraries
@@ -60,8 +85,23 @@ $ sudo reboot
 :sync: RHEL-9.1
 
 ```console
-$ sudo tee /etc/yum.repos.d/amdgpu.repo <<< '[amdgpu] name=amdgpu baseurl=https://repo.radeon.com/amdgpu/latest/rhel/9.1/main/x86_64 enabled=1 gpgcheck=1 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key'
-$ sudo tee /etc/yum.repos.d/rocm.repo <<< '[rocm] name=rocm baseurl=https://repo.radeon.com/rocm/rhel8/latest/main enabled=1 priority=50 gpgcheck=1 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key'
+$ sudo tee /etc/yum.repos.d/amdgpu.repo <<'EOF' 
+  [amdgpu]
+  name=amdgpu
+  baseurl=https://repo.radeon.com/amdgpu/latest/rhel/9.1/main/x86_64
+  enabled=1
+  gpgcheck=1
+  gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
+  EOF
+$ sudo tee /etc/yum.repos.d/rocm.repo <<'EOF'
+  [rocm]
+  name=rocm
+  baseurl=https://repo.radeon.com/rocm/rhel9/latest/main
+  enabled=1
+  priority=50
+  gpgcheck=1
+  gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
+  EOF
 $ sudo yum clean all
 $ sudo yum install amdgpu-dkms
 $ sudo yum install rocm-hip-libraries
@@ -73,8 +113,23 @@ $ sudo reboot
 :sync: RHEL-8.8
 
 ```console
-$ sudo tee /etc/yum.repos.d/amdgpu.repo <<< '[amdgpu] name=amdgpu baseurl=https://repo.radeon.com/amdgpu/latest/rhel/8.8/main/x86_64 enabled=1 gpgcheck=1 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key'
-$ sudo tee /etc/yum.repos.d/rocm.repo <<< '[rocm] name=rocm baseurl=https://repo.radeon.com/rocm/rhel8/latest/main enabled=1 priority=50 gpgcheck=1 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key'
+$ sudo tee /etc/yum.repos.d/amdgpu.repo <<'EOF' 
+  [amdgpu]
+  name=amdgpu
+  baseurl=https://repo.radeon.com/amdgpu/latest/rhel/8.8/main/x86_64
+  enabled=1
+  gpgcheck=1
+  gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
+  EOF
+$ sudo tee /etc/yum.repos.d/rocm.repo <<'EOF'
+  [rocm]
+  name=rocm
+  baseurl=https://repo.radeon.com/rocm/rhel8/latest/main
+  enabled=1
+  priority=50
+  gpgcheck=1
+  gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
+  EOF
 $ sudo yum clean all
 $ sudo yum install amdgpu-dkms
 $ sudo yum install rocm-hip-libraries
@@ -86,8 +141,23 @@ $ sudo reboot
 :sync: RHEL-8.7
 
 ```console
-$ sudo tee /etc/yum.repos.d/amdgpu.repo <<< '[amdgpu] name=amdgpu baseurl=https://repo.radeon.com/amdgpu/latest/rhel/8.7/main/x86_64 enabled=1 gpgcheck=1 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key'
-$ sudo tee /etc/yum.repos.d/rocm.repo <<< '[rocm] name=rocm baseurl=https://repo.radeon.com/rocm/rhel8/latest/main enabled=1 priority=50 gpgcheck=1 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key'
+$ sudo tee /etc/yum.repos.d/amdgpu.repo <<'EOF' 
+  [amdgpu]
+  name=amdgpu
+  baseurl=https://repo.radeon.com/amdgpu/latest/rhel/8.7/main/x86_64
+  enabled=1
+  gpgcheck=1
+  gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
+  EOF
+$ sudo tee /etc/yum.repos.d/rocm.repo <<'EOF'
+  [rocm]
+  name=rocm
+  baseurl=https://repo.radeon.com/rocm/rhel8/latest/main
+  enabled=1
+  priority=50
+  gpgcheck=1
+  gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
+  EOF
 $ sudo yum clean all
 $ sudo yum install amdgpu-dkms
 $ sudo yum install rocm-hip-libraries
@@ -99,8 +169,23 @@ $ sudo reboot
 :sync: RHEL-8.6
 
 ```console
-$ sudo tee /etc/yum.repos.d/amdgpu.repo <<< '[amdgpu] name=amdgpu baseurl=https://repo.radeon.com/amdgpu/latest/rhel/8.6/main/x86_64 enabled=1 gpgcheck=1 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key'
-$ sudo tee /etc/yum.repos.d/rocm.repo <<< '[rocm] name=rocm baseurl=https://repo.radeon.com/rocm/rhel8/latest/main enabled=1 priority=50 gpgcheck=1 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key'
+$ sudo tee /etc/yum.repos.d/amdgpu.repo <<'EOF' 
+  [amdgpu]
+  name=amdgpu
+  baseurl=https://repo.radeon.com/amdgpu/latest/rhel/8.6/main/x86_64
+  enabled=1
+  gpgcheck=1
+  gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
+  EOF
+$ sudo tee /etc/yum.repos.d/rocm.repo <<'EOF'
+  [rocm]
+  name=rocm
+  baseurl=https://repo.radeon.com/rocm/rhel8/latest/main
+  enabled=1
+  priority=50
+  gpgcheck=1
+  gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
+  EOF
 $ sudo yum clean all
 $ sudo yum install amdgpu-dkms
 $ sudo yum install rocm-hip-libraries
@@ -121,8 +206,23 @@ $ sudo reboot
 :sync: SLES-15.5
 
 ```console
-$ sudo tee /etc/zypp/repos.d/amdgpu.repo <<<'[amdgpu] name=amdgpu baseurl=https://repo.radeon.com/amdgpu/latest/sle/15.5/main/x86_64 enabled=1 gpgcheck=1 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key'
-$ sudo tee /etc/zypp/repos.d/rocm.repo <<<'[rocm] name=rocm baseurl=https://repo.radeon.com/rocm/zyp/zypper enabled=1 priority=50 gpgcheck=1 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key'
+$ sudo tee /etc/zypp/repos.d/amdgpu.repo <<'EOF'
+  [amdgpu]
+  name=amdgpu
+  baseurl=https://repo.radeon.com/amdgpu/latest/sle/15.5/main/x86_64
+  enabled=1
+  gpgcheck=1
+  gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
+  EOF
+$ sudo tee /etc/zypp/repos.d/rocm.repo <<'EOF'
+  [rocm]
+  name=rocm
+  baseurl=https://repo.radeon.com/rocm/zyp/zypper
+  enabled=1
+  priority=50
+  gpgcheck=1
+  gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
+  EOF
 $ sudo zypper ref
 $ sudo zypper install amdgpu-dkms
 $ sudo zypper install rocm-hip-libraries
@@ -134,8 +234,23 @@ $ sudo reboot
 :sync: SLES-15.4
 
 ```console
-$ sudo tee /etc/zypp/repos.d/amdgpu.repo <<<'[amdgpu] name=amdgpu baseurl=https://repo.radeon.com/amdgpu/latest/sle/15.4/main/x86_64 enabled=1 gpgcheck=1 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key'
-$ sudo tee /etc/zypp/repos.d/rocm.repo <<<'[rocm] name=rocm baseurl=https://repo.radeon.com/rocm/zyp/zypper enabled=1 priority=50 gpgcheck=1 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key'
+$ sudo tee /etc/zypp/repos.d/amdgpu.repo <<'EOF'
+  [amdgpu]
+  name=amdgpu
+  baseurl=https://repo.radeon.com/amdgpu/latest/sle/15.4/main/x86_64
+  enabled=1
+  gpgcheck=1
+  gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
+  EOF
+$ sudo tee /etc/zypp/repos.d/rocm.repo <<'EOF'
+  [rocm]
+  name=rocm
+  baseurl=https://repo.radeon.com/rocm/zyp/zypper
+  enabled=1
+  priority=50
+  gpgcheck=1
+  gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
+  EOF
 $ sudo zypper ref
 $ sudo zypper install amdgpu-dkms
 $ sudo zypper install rocm-hip-libraries

--- a/docs/tutorials/quick-start/linux.md
+++ b/docs/tutorials/quick-start/linux.md
@@ -3,13 +3,18 @@
 For a quick summary on installing ROCm on Linux, follow the steps listed on this page. If you
 want a more in-depth installation guide, see [Installing ROCm on Linux](../install/linux/index.md).
 
-::::::{tab-set}
-:::::{tab-item} Ubuntu
+::::::::{tab-set}
+:::::::{tab-item} Ubuntu
 :sync: ubuntu
 
-::::{tab-set}
-:::{tab-item} Ubuntu 22.04
+::::::{tab-set}
+:::::{tab-item} Ubuntu 22.04
 :sync: ubuntu-22.04
+
+::::{tab-set}
+:::{tab-item} Package Manager
+:sync: ubuntu-22.04-PM
+
 
 ```console
 $ sudo mkdir --parents --mode=0755 /etc/apt/keyrings
@@ -27,8 +32,23 @@ $ sudo apt install rocm-hip-libraries
 $ sudo reboot
 ```
 :::
-:::{tab-item} Ubuntu 20.04
+:::{tab-item} Install Script
+:sync: ubuntu-22.04-IS
+
+```console
+$ temp
+```
+
+:::
+::::
+
+:::::
+:::::{tab-item} Ubuntu 20.04
 :sync: ubuntu-20.04
+
+::::{tab-set}
+:::{tab-item} Package Manager
+:sync: ubuntu-20.04-PM
 
 ```console
 $ sudo mkdir --parents --mode=0755 /etc/apt/keyrings
@@ -44,15 +64,31 @@ $ sudo apt install amdgpu-dkms
 $ sudo apt install rocm-hip-libraries
 $ sudo reboot
 ```
+
+:::
+:::{tab-item} Install Script
+:sync: ubuntu-20.04-IS
+
+```console
+$ temp
+```
+
+:::
 ::::
 
-:::::
+::::::
 
-:::::{tab-item} Red Hat Enterprise Linux
+:::::::
+
+:::::::{tab-item} Red Hat Enterprise Linux
 :sync: RHEL
 
+::::::{tab-set}
+:::::{tab-item} RHEL 9.2
+:sync: RHEL-9.2
+
 ::::{tab-set}
-:::{tab-item} RHEL 9.2
+:::{tab-item} Package Manager
 :sync: RHEL-9.2
 
 ```console
@@ -78,10 +114,25 @@ $ sudo yum install amdgpu-dkms
 $ sudo yum install rocm-hip-libraries
 $ sudo reboot
 ```
+:::
+:::{tab-item} Install Script
+:sync: RHEL-9.2
+
+```console
+$ temp
+```
 
 :::
+::::
 
-:::{tab-item} RHEL 9.1
+
+
+:::::
+:::::{tab-item} RHEL 9.1
+:sync: RHEL-9.1
+
+::::{tab-set}
+:::{tab-item} Package Manager
 :sync: RHEL-9.1
 
 ```console
@@ -108,8 +159,23 @@ $ sudo yum install rocm-hip-libraries
 $ sudo reboot
 ```
 :::
+:::{tab-item} Install Script
+:sync: RHEL-9.1
 
-:::{tab-item} RHEL 8.8
+```console
+$ temp
+```
+
+:::
+::::
+
+:::::
+
+:::::{tab-item} RHEL 8.8
+:sync: RHEL-8.8
+
+::::{tab-set}
+:::{tab-item} Package Manager
 :sync: RHEL-8.8
 
 ```console
@@ -136,10 +202,23 @@ $ sudo yum install rocm-hip-libraries
 $ sudo reboot
 ```
 :::
+:::{tab-item} Install Script
+:sync: RHEL-8.8
+```console
+$ temp
+```
 
-:::{tab-item} RHEL 8.7
+:::
+::::
+
+:::::
+
+:::::{tab-item} RHEL 8.7
 :sync: RHEL-8.7
 
+::::{tab-set}
+:::{tab-item} Package Manager
+:sync: RHEL-8.7
 ```console
 $ sudo tee /etc/yum.repos.d/amdgpu.repo <<'EOF' 
   [amdgpu]
@@ -164,10 +243,23 @@ $ sudo yum install rocm-hip-libraries
 $ sudo reboot
 ```
 :::
+:::{tab-item} Install Script
+:sync: RHEL-8.7
 
-:::{tab-item} RHEL 8.6
+```console
+$ temp
+```
+
+:::
+::::
+:::::
+
+:::::{tab-item} RHEL 8.6
 :sync: RHEL-8.6
 
+::::{tab-set}
+:::{tab-item} Package Manager
+:sync: RHEL-8.6
 ```console
 $ sudo tee /etc/yum.repos.d/amdgpu.repo <<'EOF' 
   [amdgpu]
@@ -192,17 +284,30 @@ $ sudo yum install rocm-hip-libraries
 $ sudo reboot
 ```
 :::
-::::
+:::{tab-item} Install Script
+:sync: RHEL-8.6
+```console
+$ temp
+```
 
+:::
 ::::
-
 :::::
+::::::
 
-:::::{tab-item} SUSE Linux Enterprise Server
+::::::
+
+:::::::
+
+:::::::{tab-item} SUSE Linux Enterprise Server
 :sync: SLES
 
-::::{tab-set}
-:::{tab-item} SLES 15.5
+::::::{tab-set}
+:::::{tab-item} SLES 15.5
+:sync: SLES-15.5
+
+::::{tab-set}                   
+:::{tab-item} Package Manager   
 :sync: SLES-15.5
 
 ```console
@@ -228,11 +333,22 @@ $ sudo zypper install amdgpu-dkms
 $ sudo zypper install rocm-hip-libraries
 $ sudo reboot
 ```
+:::                             
+:::{tab-item} Install Script    
+:sync: SLES-15.5          
+```console                      
+$ temp                         
+```                            
 
-:::
-:::{tab-item} SLES 15.4
+:::                             
+::::                            
+:::::
+:::::{tab-item} SLES 15.4
 :sync: SLES-15.4
 
+::::{tab-set}
+:::{tab-item} Package Manager
+:sync: SLES-15.4
 ```console
 $ sudo tee /etc/zypp/repos.d/amdgpu.repo <<'EOF'
   [amdgpu]
@@ -256,12 +372,21 @@ $ sudo zypper install amdgpu-dkms
 $ sudo zypper install rocm-hip-libraries
 $ sudo reboot
 ```
+:::
+:::{tab-item} Install Script
+:sync: SLES-15.4
+
+```console
+$ temp
+```
 
 :::
 ::::
-
-::::
-
-
 :::::
 ::::::
+
+::::::
+
+
+:::::::
+::::::::


### PR DESCRIPTION
Edited the file and moved all commands to a singular console block that can be copy pasted into a terminal to install ROCm.