### PR TITLE
Remove extra line in package manager integration

### DIFF
--- a/docs/tutorials/install/linux/os-native/package-manager-integration.md
+++ b/docs/tutorials/install/linux/os-native/package-manager-integration.md
@@ -12,8 +12,6 @@ following AMD ROCm programming models:
 A meta-package is a grouping of related packages and dependencies used to
 support a specific use case.
 
-**Example:** Running HIP applications
-
 All meta-packages exist in both versioned and non-versioned forms.
 
 * Non-versioned packages – For a single-version installation of the ROCm stack


### PR DESCRIPTION
related to https://github.com/RadeonOpenCompute/ROCm/pull/2510, which targeted 5.7.0

this PR targets develop