### PR TITLE
Removed reference /opt/rocm/opencl/bin/clinfo

### DIFF
--- a/docs/tutorials/install/linux/os-native/install.md
+++ b/docs/tutorials/install/linux/os-native/install.md
@@ -520,8 +520,6 @@ by both commands, the installation is considered successful:
 
 ```shell
 /opt/rocm/bin/rocminfo
-# OR
-/opt/rocm/opencl/bin/clinfo
 ```
 
 ### Verifying package installation


### PR DESCRIPTION
Since we are not installing the ROCm OpenCL packages.  We are not able to test ROCm withg this command.