### PR TITLE
AutoTag: Fix MIGraphX change log not being parsed

### DIFF
--- a/tools/autotag/util/defaults.py
+++ b/tools/autotag/util/defaults.py
@@ -36,9 +36,6 @@ def processor_factory():
             lib_version  = match["lib_version"]
             rocm_version = match["rocm_version"]
 
-            if lib_name.lower() != data.name.lower():
-                continue
-
             if not rocm_version:
                 print(match[0])
                 if ignore_unreleased:


### PR DESCRIPTION
Since the repository name (AMDMIGraphX) and the indicated name of the changed library in the change log (MIGraphX) are not identical, AutoTag normally rejects the entry. This change removes that check since it's not really needed and resolves this issue.

CC: @samjwu 