### PR TITLE
Disable epub format in rtd yaml config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 sphinx:
    configuration: docs/conf.py
 
-formats: [htmlzip, pdf, epub]
+formats: [htmlzip, pdf]
 
 python:
    install:


### PR DESCRIPTION
Because rubric is not supported

ValueError: <container: <rubric...><container...>> is not in list