### PR TITLE
Bump rocm-docs-core version and fix dependabot settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,4 @@ updates:
     open-pull-requests-limit: 10
     schedule:
       interval: "daily"
+    versioning-strategy: increase

--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,1 +1,1 @@
-rocm-docs-core>=0.24.0
+rocm-docs-core==0.26.0

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -46,6 +46,10 @@ idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
+importlib-metadata==6.8.0
+    # via sphinx
+importlib-resources==6.1.0
+    # via rocm-docs-core
 jinja2==3.1.2
     # via
     #   myst-parser
@@ -94,7 +98,7 @@ requests==2.31.0
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core>=0.24.0
+rocm-docs-core==0.26.0
     # via -r requirements.in
 smmap==5.0.0
     # via gitdb
@@ -141,3 +145,7 @@ urllib3==1.26.13
     # via requests
 wrapt==1.14.1
     # via deprecated
+zipp==3.17.0
+    # via
+    #   importlib-metadata
+    #   importlib-resources


### PR DESCRIPTION
dependabot mis-detected the repository to be a library (instead of an application) and widened the rocm-docs-core verison instead of increasing it. This basically disabled pinning.

Explicitly specify to increase the version instead of widening it to hopefully prevent this in the future.