### PR TITLE
Update GPU Support on Linux for GPU name typo and issue close out

### DIFF
--- a/docs/release/gpu_os_support.md
+++ b/docs/release/gpu_os_support.md
@@ -92,6 +92,7 @@ Use Driver Shipped with ROCm
 
 | Name | Architecture |[LLVM Target](https://www.llvm.org/docs/AMDGPUUsage.html#processors) | Support|
 |:----:|:------------:|:--------------------------------------------------------------------:|:-------:|
+| AMD Radeon™ Pro W7900   | RDNA3  | gfx1100 | ✅ |
 | AMD Radeon™ Pro W6800   | RDNA2  | gfx1030 | ✅ |
 | AMD Radeon™ Pro V620    | RDNA2  | gfx1030 | ✅ |
 | AMD Radeon™ Pro VII     | GCN5.1 | gfx906  | ✅ |
@@ -104,7 +105,8 @@ Use Driver Shipped with ROCm
 
 | Name | Architecture    |[LLVM Target](https://www.llvm.org/docs/AMDGPUUsage.html#processors) | Support|
 |:----:|:---------------:|:--------------------------------------------------------------------:|:-------:|
-| AMD Radeon™ VII        | GCN5.1 | gfx906  | ✅ |
+| AMD Radeon™ RX 7900 XTX    | RDNA3  | gfx1100 | ✅ |
+| AMD Radeon™ VII            | GCN5.1 | gfx906  | ✅ |
 
 :::
 


### PR DESCRIPTION
Update docs with information in the [AMD blog post](https://community.amd.com/t5/ai/amd-extends-support-for-pytorch-machine-learning-development-on/ba-p/637756) announcing support for the Radeon™ RX 7900 XTX and the Radeon™ PRO W7900 on Linux.

The discrepancy between the blog post and docs is causing some confusion for those of us who have been asking for and keeping an eye on ROCm support for RDNA3 consumer GPUs on Linux. Speaking of which, there are already plenty of open issues and discussions on the topic, this will help give a more definitive answer to the inquirers.

- https://github.com/RadeonOpenCompute/ROCm/discussions/1891#discussioncomment-7300715_
- https://github.com/RadeonOpenCompute/ROCm/discussions/2559#discussioncomment-7303462_

- https://github.com/RadeonOpenCompute/ROCm/issues/2312
- https://github.com/RadeonOpenCompute/ROCm/issues/2308#issuecomment-1614296146_
- https://github.com/RadeonOpenCompute/ROCm/issues/2302#issuecomment-1613448305_
- https://github.com/RadeonOpenCompute/ROCm/issues/2098
- https://github.com/RadeonOpenCompute/ROCm/issues/1875
- https://github.com/RadeonOpenCompute/ROCm/issues/1813
- https://github.com/RadeonOpenCompute/ROCm/issues/1714

- https://github.com/ROCmSoftwarePlatform/MIOpen/issues/2342