### PR TITLE
Quick start comment triage

### DIFF
--- a/docs/install/linux/install-quick.md
+++ b/docs/install/linux/install-quick.md
@@ -1,7 +1,8 @@
 # Linux quick-start installation guide
 
-For a quick summary on installing ROCm on Linux, follow the steps listed on this page. If you
-want a more in-depth installation guide, see [Installing ROCm on Linux](./install.md).
+For a quick summary on installing ROCm on Linux, follow the steps listed on this
+page. If you want a more in-depth installation guide, see
+[Installing ROCm on Linux](./install.md).
 
 ## Add repositories
 

--- a/docs/install/linux/install-quick.md
+++ b/docs/install/linux/install-quick.md
@@ -372,3 +372,8 @@ Loading the new driver requires a system reboot.
 ```shell
 sudo reboot
 ```
+
+## Verify
+
+To verify the install, refer to
+{ref}`verifying-kernel-mode-driver-installation`.

--- a/docs/install/linux/install-quick.md
+++ b/docs/install/linux/install-quick.md
@@ -331,8 +331,9 @@ sudo zypper install amdgpu-dkms
 
 ## Install ROCm runtimes
 
-Install the `rocm-hip-libraries` meta-package. This contains dependencies for most
-common ROCm applications.
+Install the `rocm-hip-libraries` meta-package. This contains dependencies for
+most common ROCm applications. (Refer to {ref}`meta-package-desc` for more
+details on metapackages.)
 
 ::::{tab-set}
 :::{tab-item} Ubuntu

--- a/docs/install/linux/package-manager-integration.md
+++ b/docs/install/linux/package-manager-integration.md
@@ -66,20 +66,20 @@ clang compiler files.
 
 ```{table} Meta-packages and Their Descriptions
 :name: meta-package-desc
-| **Meta-packages**          | **Description**                                                                                                                           |
-|:---------------------------|-----------------------------------------------------------------------------------------------------------------------------------------:|
-| `rocm-language-runtime`  | The ROCm runtime                                                                                                                 |
-| `rocm-hip-runtime`       | Run HIP applications written for the AMD platform                                                     |
-| `rocm-opencl-runtime`    | Run OpenCL-based applications on the AMD platform                                                           |
-| `rocm-hip-runtime-devel` | Develop applications on HIP or port from CUDA                                                                   |
-| `rocm-opencl-sdk`        | Develop applications in OpenCL for the AMD platform                                                         |
-| `rocm-hip-libraries`     | HIP libraries optimized for the AMD platform                                                                                        |
-| `rocm-hip-sdk`           | Develop or port HIP applications and libraries for the AMD platform                                        |
-| `rocm-developer-tools`   | Debug and profile HIP applications                                                                    |
+| **Meta-packages**        | **Description**                                                      |
+|:-------------------------|---------------------------------------------------------------------:|
+| `rocm-language-runtime`  | The ROCm runtime                                                     |
+| `rocm-hip-runtime`       | Run HIP applications written for the AMD platform                    |
+| `rocm-opencl-runtime`    | Run OpenCL-based applications on the AMD platform                    |
+| `rocm-hip-runtime-devel` | Develop applications on HIP or port from CUDA                        |
+| `rocm-opencl-sdk`        | Develop applications in OpenCL for the AMD platform                  |
+| `rocm-hip-libraries`     | HIP libraries optimized for the AMD platform                         |
+| `rocm-hip-sdk`           | Develop or port HIP applications and libraries for the AMD platform  |
+| `rocm-developer-tools`   | Debug and profile HIP applications                                   |
 | `rocm-ml-sdk`            | Develop and run machine-learning applications with optimized for AMD |
-| `rocm-ml-libraries`      | Key machine-learning libraries, specifically MIOpen                                                                 |
-| `rocm-openmp-sdk`        | Develop OpenMP-based applications for the AMD platform                                                        |
-| `rocm-openmp-runtime`    | Run OpenMP-based applications for the AMD platform                                                            |
+| `rocm-ml-libraries`      | Key machine-learning libraries, specifically MIOpen                  |
+| `rocm-openmp-sdk`        | Develop OpenMP-based applications for the AMD platform               |
+| `rocm-openmp-runtime`    | Run OpenMP-based applications for the AMD platform                   |
 ```
 
 ## Packages in ROCm programming models


### PR DESCRIPTION
Fixes #2036

Some of the comments are left unfixed, for eg. aligning the structure of the Windows and Linux install is impossible due to how different software distribution is on these platforms. Others have either refer to non-existing code sections since and some have gotten automatic fix with a working right-hand-side navigation panel.