### PR TITLE
fix issue of ROCm docs/5.5.0  quick start  for ubuntu22.04

### DIFF
--- a/docs/deploy/linux/quick_start.md
+++ b/docs/deploy/linux/quick_start.md
@@ -49,8 +49,10 @@ EOF
 # ROCm repository for jammy
 sudo tee /etc/apt/sources.list.d/rocm.list <<'EOF'
 deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/debian jammy main
-echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | sudo tee /etc/apt/preferences.d/rocm-pin-600
 EOF
+
+# Prefer packages from the rocm repository over system packages
+echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | sudo tee /etc/apt/preferences.d/rocm-pin-600
 ```
 
 :::


### PR DESCRIPTION
The current instruction would mess apt update for rocm repo updates. just had a check, this error has been fixed from docs/5.5.1 onwards. 