### PR TITLE
Replace libpython3.8/3.10 dependency with libpython3-all-dev

### DIFF
--- a/tools/rocm-build/build_rocm-gdb.sh
+++ b/tools/rocm-build/build_rocm-gdb.sh
@@ -137,7 +137,7 @@ Section: utils
 Architecture: amd64
 Essential: no
 Priority: optional
-Depends: libexpat1, libtinfo5, libncurses5, rocm-dbgapi, libpython3.10 | libpython3.8, libbabeltrace-ctf1 (>= 1.2.1), libbabeltrace1 (>= 1.2.1), rocm-core
+Depends: libexpat1, libtinfo5, libncurses5, rocm-dbgapi, libpython3-all-dev, libbabeltrace-ctf1 (>= 1.2.1), libbabeltrace1 (>= 1.2.1), rocm-core
 EOF
 
     mkdir -p "$OUT_DIR/deb/$PROJ_NAME"


### PR DESCRIPTION
There is no clear reason as to why there is an explicit dependency on libpython3.8 or libpython3.10, and having this dependency breaks installation on Debian. 

This would resolve #2524 & #2646