### PR TITLE
Error handling for unsupported distros

### DIFF
--- a/tools/rocm-build/ROCm.mk
+++ b/tools/rocm-build/ROCm.mk
@@ -19,6 +19,13 @@ export INFRA_REPO:=ROCm/tools/rocm-build
 
 OUT_DIR:=$(shell . ${INFRA_REPO}/envsetup.sh >/dev/null 2>&1 ; echo $${OUT_DIR})
 ROCM_INSTALL_PATH:=$(shell . ${INFRA_REPO}/envsetup.sh >/dev/null 2>&1 ; echo $${ROCM_INSTALL_PATH})
+PKGTYPE:=$(shell . ${INFRA_REPO}/envsetup.sh >/dev/null 2>&1 ; echo $${PKGTYPE})
+DISTRO_NAME:=$(shell . ${INFRA_REPO}/envsetup.sh >/dev/null 2>&1 ; echo $${DISTRO_NAME})
+
+ifeq (${PKGTYPE},)
+    # PKGTYPE was not set correctly (probably unsupported distro), error out before scripts fail downstream
+    $(error No package type is defined in envsetup.sh for distro name "$(DISTRO_NAME)")
+endif
 
 $(info OUT_DIR=${OUT_DIR})
 $(info ROCM_INSTALL_PATH=${ROCM_INSTALL_PATH})


### PR DESCRIPTION
Currently on unsupported distros envsetup.sh does not define a package type, and the build scripts fail far downstream. Adds error handling for this before progressing with build. Addresses unclear logs as seen in issue #3743.