### PR TITLE
Update workload.rst with small export fix

### DIFF
--- a/docs/how-to/rocm-for-ai/inference-optimization/workload.rst
+++ b/docs/how-to/rocm-for-ai/inference-optimization/workload.rst
@@ -945,9 +945,9 @@ for details.
 
   .. code-block:: shell
 
-     export HIP_FORCE_DEV_KERNARG=1  hipblaslt-bench --alpha 1 --beta 0 -r \
-     f16_r --a_type f16_r --b_type f8_r --compute_type f32_f16_r \
-     --initialization trig_float  --cold_iters 100 -i 1000 --rotating 256
+     HIP_FORCE_DEV_KERNARG=1  hipblaslt-bench --alpha 1 --beta 0 -r f16_r \
+     --a_type f16_r --b_type f8_r --compute_type f32_f16_r \
+     --initialization trig_float  --cold_iters 100 --iters 1000 --rotating 256
 
 * Example 2: Benchmark forward epilogues and backward epilogues
 


### PR DESCRIPTION
Tiny fix that removes the "export" directive. 
` export HIP_FORCE_DEV_KERNARG=1  hipblaslt-bench ...` leads to 
bash: export: `hipblaslt-bench': not a valid identifier

whereas just starting with HIP_FORCE_DEV_KERNARG=1 passes this env var to the hipblaslt-bench process, which I think is the intention here.