### PR TITLE
Ex CI: fix Dockerfile PATH creation

### DIFF
--- a/.azuredevops/templates/steps/docker-container.yml
+++ b/.azuredevops/templates/steps/docker-container.yml
@@ -308,7 +308,7 @@ steps:
       inputs:
         workingDirectory: $(Pipeline.Workspace)
         targetType: inline
-        script: echo "ENV PATH='${{ parameters.extraPaths }}:\$PATH'" >> Dockerfile
+        script: echo "ENV PATH='$PATH:${{ parameters.extraPaths }}'" >> Dockerfile
 # set extra environment variables, if applicable to the job
 # use ::: as delimiter to allow for colons to be in the environment variable values
   - ${{ each extraEnvVar in parameters.extraEnvVars }}:


### PR DESCRIPTION
Fixes an issue where the PATH env inside an autogenerated Docker container would include the literal string `$PATH` instead of the value of PATH.

Tested using an image built from: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=24533&view=logs&j=a1cf3924-7251-5656-99ce-ba94dfad1583&t=77d37bcf-bd29-517d-0074-37d6e5c6407d

```
/home/user# echo $PATH
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/home/user/workspace/rocm/llvm/bin:/home/user/workspace/rocm/bin
```