### PR TITLE
Ex CI: dynamically set rocrtst include directory

### DIFF
--- a/.azuredevops/components/ROCR-Runtime.yml
+++ b/.azuredevops/components/ROCR-Runtime.yml
@@ -127,13 +127,15 @@ jobs:
       targetType: 'inline'
       workingDirectory: $(Build.SourcesDirectory)/rocrtst/suites/test_common
       script: |
+        BASE_CLANG_DIR=$(Agent.BuildDirectory)/rocm/llvm/lib/clang
+        export NEWEST_CLANG_VER=$(ls -1 $BASE_CLANG_DIR | sort -V | tail -n 1)
         mkdir build && cd build
         cmake .. \
           -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm \
           -DTARGET_DEVICES=$(JOB_GPU_TARGET) \
           -DROCM_DIR=$(Agent.BuildDirectory)/rocm \
           -DLLVM_DIR=$(Agent.BuildDirectory)/rocm/llvm/bin \
-          -DOPENCL_INC_DIR=$(Agent.BuildDirectory)/rocm/llvm/lib/clang/21/include
+          -DOPENCL_INC_DIR=$BASE_CLANG_DIR/$NEWEST_CLANG_VER/include
         make
         make rocrtst_kernels
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml


### PR DESCRIPTION
rocrtst's `OPENCL_INC_DIR` was being hardcoded for Clang 21, which was causing failures on mainline as mainline is still on Clang 19. 
Adds a script to dynamically get the latest available Clang directory and use that instead.

Staging build:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=24738&view=results

Mainline build:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=24737&view=results