### PR TITLE
Ex CI: fixes for rocWMMA, rocprof-sdk, roctracer, AOMP

### DIFF
--- a/.azuredevops/ci-builds/aomp-staging.yml
+++ b/.azuredevops/ci-builds/aomp-staging.yml
@@ -8,17 +8,17 @@ resources:
     type: github
     endpoint: ROCm
     name: ROCm/aomp
-    ref: amd-staging
+    ref: aomp-dev
   - repository: aomp-extras_repo
     type: github
     endpoint: ROCm
     name: ROCm/aomp-extras
-    ref: amd-staging
+    ref: aomp-dev
   - repository: flang_repo
     type: github
     endpoint: ROCm
     name: ROCm/flang
-    ref: amd-staging
+    ref: aomp-dev
   - repository: llvm-project_repo
     type: github
     endpoint: ROCm

--- a/.azuredevops/components/rocWMMA.yml
+++ b/.azuredevops/components/rocWMMA.yml
@@ -98,7 +98,7 @@ jobs:
       gpuTarget: $(JOB_GPU_TARGET)
 
 - job: rocWMMA_testing
-  timeoutInMinutes: 120
+  timeoutInMinutes: 270
   dependsOn: rocWMMA
   condition: and(succeeded(), eq(variables.ENABLE_GFX942_TESTS, 'true'), not(containsValue(split(variables.DISABLED_GFX942_TESTS, ','), variables['Build.DefinitionName'])))
   variables:

--- a/.azuredevops/components/rocprofiler-sdk.yml
+++ b/.azuredevops/components/rocprofiler-sdk.yml
@@ -35,6 +35,7 @@ parameters:
 - name: rocmDependencies
   type: object
   default:
+    - aomp
     - clr
     - llvm-project
     - rccl

--- a/.azuredevops/tag-builds/aomp.yml
+++ b/.azuredevops/tag-builds/aomp.yml
@@ -3,7 +3,16 @@ variables:
 - template: /.azuredevops/variables-global.yml
 
 parameters:
-- name: checkoutRef
+- name: aompRef
+  type: string
+  default: refs/tags/$(LATEST_RELEASE_TAG)
+- name: extrasRef
+  type: string
+  default: refs/tags/$(LATEST_RELEASE_TAG)
+- name: flangRef
+  type: string
+  default: refs/tags/$(LATEST_RELEASE_TAG)
+- name: llvmRef
   type: string
   default: refs/tags/$(LATEST_RELEASE_TAG)
 
@@ -13,22 +22,22 @@ resources:
     type: github
     endpoint: ROCm
     name: ROCm/aomp
-    ref: ${{ parameters.checkoutRef }}
+    ref: ${{ parameters.aompRef }}
   - repository: aomp-extras_repo
     type: github
     endpoint: ROCm
     name: ROCm/aomp-extras
-    ref: ${{ parameters.checkoutRef }}
+    ref: ${{ parameters.extrasRef }}
   - repository: flang_repo
     type: github
     endpoint: ROCm
     name: ROCm/flang
-    ref: ${{ parameters.checkoutRef }}
+    ref: ${{ parameters.flangRef }}
   - repository: llvm-project_repo
     type: github
     endpoint: ROCm
     name: ROCm/llvm-project
-    ref: amd-staging
+    ref: ${{ parameters.llvmRef }}
 
 trigger: none
 pr: none
@@ -37,4 +46,4 @@ jobs:
   - template: ${{ variables.CI_COMPONENT_PATH }}/aomp.yml
     parameters:
       checkoutRepo: aomp_repo
-      checkoutRef: ${{ parameters.checkoutRef }}
+      checkoutRef: ${{ parameters.aompRef }}

--- a/.azuredevops/templates/steps/dependencies-rocm.yml
+++ b/.azuredevops/templates/steps/dependencies-rocm.yml
@@ -323,7 +323,7 @@ parameters:
     roctracer:
       pipelineId: $(ROCTRACER_PIPELINE_ID)
       stagingBranch: amd-staging
-      mainlineBranch: amd-master
+      mainlineBranch: amd-mainline
       hasGpuTarget: true
     rocWMMA:
       pipelineId: $(ROCWMMA_PIPELINE_ID)


### PR DESCRIPTION
- Changes AOMP trigger files to pull `aomp-dev` branches where applicable
- Added extra runtime parameters to AOMP tag-builds file to allow manual control of source versions
  - AOMP builds are currently failing, this should make debugging a bit easier
- Added AOMP to rocprofiler-sdk dependencies
- Increased rocWMMA test timeout to 4.5 hours
  - https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=24779&view=results
- Changed roctracer mainline branch from `amd-master` to `amd-mainline`