### PR TITLE
Ex CI: fixes for RVS, Tensile, hipBLASLt, rocMLIR, CK

### DIFF
--- a/.azuredevops/components/ROCmValidationSuite.yml
+++ b/.azuredevops/components/ROCmValidationSuite.yml
@@ -21,6 +21,7 @@ parameters:
 - name: rocmDependencies
   type: object
   default:
+    - amdsmi
     - clr
     - hipBLAS-common
     - hipBLASLt
@@ -36,6 +37,7 @@ parameters:
 - name: rocmTestDependencies
   type: object
   default:
+    - amdsmi
     - clr
     - hipBLAS-common
     - hipBLASLt

--- a/.azuredevops/components/Tensile.yml
+++ b/.azuredevops/components/Tensile.yml
@@ -90,7 +90,7 @@ jobs:
   #     pipModules: ${{ parameters.pipModules }}
 
 - job: Tensile_testing
-  timeoutInMinutes: 120
+  timeoutInMinutes: 180
   dependsOn: Tensile
   condition: and(succeeded(), eq(variables.ENABLE_GFX942_TESTS, 'true'), not(containsValue(split(variables.DISABLED_GFX942_TESTS, ','), variables['Build.DefinitionName'])))
   variables:

--- a/.azuredevops/components/composable_kernel.yml
+++ b/.azuredevops/components/composable_kernel.yml
@@ -27,7 +27,6 @@ parameters:
   type: object
   default:
     - clr
-    - composable_kernel
     - llvm-project
     - rocminfo
     - rocprofiler-register

--- a/.azuredevops/components/hipBLASLt.yml
+++ b/.azuredevops/components/hipBLASLt.yml
@@ -156,7 +156,7 @@ jobs:
         - deps
 
 - job: hipBLASLt_testing
-  timeoutInMinutes: 180
+  timeoutInMinutes: 300
   dependsOn: hipBLASLt
   condition: and(succeeded(), eq(variables.ENABLE_GFX942_TESTS, 'true'), not(containsValue(split(variables.DISABLED_GFX942_TESTS, ','), variables['Build.DefinitionName'])))
   variables:

--- a/.azuredevops/components/hipSPARSELt.yml
+++ b/.azuredevops/components/hipSPARSELt.yml
@@ -28,6 +28,7 @@ parameters:
     - hipSPARSE
     - llvm-project
     - rocBLAS
+    - rocm_smi_lib
     - rocminfo
     - rocprofiler-register
     - ROCR-Runtime

--- a/.azuredevops/components/rocMLIR.yml
+++ b/.azuredevops/components/rocMLIR.yml
@@ -119,7 +119,8 @@ jobs:
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_CXX_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/clang++
         -DCMAKE_C_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/clang
-        -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm
+        -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm;$(Agent.BuildDirectory)/rocm/lib
+        -DCMAKE_INCLUDE_PATH=$(Agent.BuildDirectory)/rocm/lib
         -DROCM_PATH=$(Agent.BuildDirectory)/rocm
         -DAMDGPU_TARGETS=$(JOB_GPU_TARGET)
         -DROCM_TEST_CHIPSET=$(JOB_GPU_TARGET)

--- a/.azuredevops/components/rocMLIR.yml
+++ b/.azuredevops/components/rocMLIR.yml
@@ -132,6 +132,7 @@ jobs:
       testDir: $(Build.SourcesDirectory)/build
       testExecutable: ninja
       testParameters: check-rocmlir
+      testPublishResults: false
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/docker-container.yml
     parameters:
       aptPackages: ${{ parameters.aptPackages }}

--- a/.azuredevops/templates/steps/dependencies-rocm.yml
+++ b/.azuredevops/templates/steps/dependencies-rocm.yml
@@ -148,12 +148,12 @@ parameters:
     MIOpen:
       pipelineId: $(MIOpen_PIPELINE_ID)
       stagingBranch: develop
-      mainlineBranch: mainline
+      mainlineBranch: amd-master
       hasGpuTarget: true
     MIVisionX:
       pipelineId: $(MIVISIONX_PIPELINE_ID)
       stagingBranch: develop
-      mainlineBranch: mainline
+      mainlineBranch: master
       hasGpuTarget: true
     omnitrace: # deprecated
       pipelineId: $(OMNITRACE_PIPELINE_ID)
@@ -173,7 +173,7 @@ parameters:
     rocAL:
       pipelineId: $(ROCAL_PIPELINE_ID)
       stagingBranch: develop
-      mainlineBranch: master
+      mainlineBranch: mainline
       hasGpuTarget: true
     rocALUTION:
       pipelineId: $(ROCALUTION_PIPELINE_ID)
@@ -238,7 +238,7 @@ parameters:
     ROCmValidationSuite:
       pipelineId: $(ROCMVALIDATIONSUITE_PIPELINE_ID)
       stagingBranch: master
-      mainlineBranch: mainline
+      mainlineBranch: master
       hasGpuTarget: true
     rocm_bandwidth_test:
       pipelineId: $(ROCM_BANDWIDTH_TEST_PIPELINE_ID)


### PR DESCRIPTION
- Increased Tensile test timeout to 3 hours
- Increased hipBLASLt test timeout to 5 hours
- Added amdsmi as a dependency for RVS
- Fixed rocMLIR tests by setting CMake vars for `./rocm/lib` paths
  - https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=25144&view=results
- Removed a self-dependency from composable_kernel tests
  - https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=25176&view=results
- Fixed some component's mainline branch names
- Added rocm-smi to hipSPARSELt
  - https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=25298&view=results