### PR TITLE
Ex CI: fix snap latest cmake version to 3.31

### DIFF
--- a/.azuredevops/templates/steps/dependencies-cmake-latest.yml
+++ b/.azuredevops/templates/steps/dependencies-cmake-latest.yml
@@ -6,5 +6,5 @@ steps:
     targetType: inline
     script: |
       sudo apt purge cmake -y
-      sudo snap install cmake --classic
+      sudo snap install cmake --classic --channel=3.31/stable
       hash -r


### PR DESCRIPTION
CMake 4.0 is breaking a number of pipelines that use the `dependencies-cmake-latest` template, so fix the CMake version to `3.31/stable`.