### PR TITLE
Ex CI: add Ninja build gen for 12 components

### DIFF
--- a/.azuredevops/components/HIP.yml
+++ b/.azuredevops/components/HIP.yml
@@ -11,6 +11,7 @@ parameters:
     - cmake
     - libnuma-dev
     - mesa-common-dev
+    - ninja-build
     - ocl-icd-libopencl1
     - ocl-icd-opencl-dev
     - opencl-headers
@@ -79,6 +80,7 @@ jobs:
         -DHIPCC_BIN_DIR=$(Agent.BuildDirectory)/rocm/bin
         -DCLR_BUILD_HIP=ON
         -DCLR_BUILD_OCL=ON
+        -GNinja
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
     parameters:
       artifactName: amd
@@ -137,6 +139,7 @@ jobs:
         -DCLR_BUILD_HIP=ON
         -DCLR_BUILD_OCL=OFF
         -DHIPNV_DIR=$(Build.SourcesDirectory)/hipother/hipnv
+        -GNinja
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
     parameters:
       artifactName: nvidia

--- a/.azuredevops/components/ROCR-Runtime.yml
+++ b/.azuredevops/components/ROCR-Runtime.yml
@@ -13,6 +13,7 @@ parameters:
     - libdrm-dev
     - libelf-dev
     - libnuma-dev
+    - ninja-build
     - pkg-config
     - python3-pip
 - name: rocmDependencies
@@ -54,6 +55,7 @@ jobs:
         -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm
         -DBUILD_SHARED_LIBS=ON
         -DCMAKE_BUILD_TYPE=Release
+        -GNinja
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml

--- a/.azuredevops/components/amdsmi.yml
+++ b/.azuredevops/components/amdsmi.yml
@@ -10,6 +10,7 @@ parameters:
   default:
     - cmake
     - libdrm-dev
+    - ninja-build
     - python3-pip
     - pkg-config
 
@@ -34,6 +35,7 @@ jobs:
     parameters:
       extraBuildFlags: >-
         -DBUILD_TESTS=ON
+        -GNinja
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml

--- a/.azuredevops/components/hipTensor.yml
+++ b/.azuredevops/components/hipTensor.yml
@@ -66,7 +66,7 @@ jobs:
         -DCMAKE_BUILD_TYPE=Release
         -DHIPTENSOR_BUILD_TESTS=ON
         -DAMDGPU_TARGETS=$(JOB_GPU_TARGET)
-      multithreadFlag: -- -j32
+        -GNinja
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
     parameters:
       gpuTarget: $(JOB_GPU_TARGET)

--- a/.azuredevops/components/rocm-core.yml
+++ b/.azuredevops/components/rocm-core.yml
@@ -9,6 +9,7 @@ parameters:
   type: object
   default:
     - cmake
+    - ninja-build
     - python3-pip
 
 jobs:
@@ -38,6 +39,7 @@ jobs:
         -DCPACK_DEBIAN_PACKAGE_RELEASE="local.9999~99.99"
         -DCPACK_RPM_PACKAGE_RELEASE="local.9999"
         -DROCM_VERSION="$(NEXT_RELEASE_VERSION)"
+        -GNinja
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml

--- a/.azuredevops/components/rocm-examples.yml
+++ b/.azuredevops/components/rocm-examples.yml
@@ -11,6 +11,7 @@ parameters:
     - cmake
     - libglfw3-dev
     - libtbb-dev
+    - ninja-build
     - python3-pip
 - name: rocmDependencies
   type: object
@@ -100,6 +101,7 @@ jobs:
         -DAMDGPU_TARGETS=$(JOB_GPU_TARGET)
         -DCMAKE_HIP_ARCHITECTURES=$(JOB_GPU_TARGET)
         -DCMAKE_EXE_LINKER_FLAGS=-fgpu-rdc
+        -GNinja
   - task: Bash@3
     displayName: Move rocm-examples binaries to rocm/examples
     inputs:
@@ -162,6 +164,7 @@ jobs:
         -DAMDGPU_TARGETS=$(JOB_GPU_TARGET)
         -DCMAKE_HIP_ARCHITECTURES=$(JOB_GPU_TARGET)
         -DCMAKE_EXE_LINKER_FLAGS=-fgpu-rdc
+        -GNinja
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/gpu-diagnostics.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
     parameters:

--- a/.azuredevops/components/rocm_smi_lib.yml
+++ b/.azuredevops/components/rocm_smi_lib.yml
@@ -10,6 +10,7 @@ parameters:
   default:
     - cmake
     - libdrm-dev
+    - ninja-build
     - pkg-config
     - python3-pip
 
@@ -35,6 +36,7 @@ jobs:
       extraBuildFlags: >-
         -DBUILD_TESTS=ON
         -DROCM_DEP_ROCMCORE=ON
+        -GNinja
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml

--- a/.azuredevops/components/rocminfo.yml
+++ b/.azuredevops/components/rocminfo.yml
@@ -11,6 +11,7 @@ parameters:
     - cmake
     - libdrm-amdgpu-dev
     - libdrm-dev
+    - ninja-build
     - python3-pip
 - name: rocmDependencies
   type: object
@@ -51,6 +52,7 @@ jobs:
       extraBuildFlags: >-
         -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm
         -DROCRTST_BLD_TYPE=release
+        -GNinja
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml
@@ -80,6 +82,7 @@ jobs:
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
     parameters:
       aptPackages: ${{ parameters.aptPackages }}
+      registerROCmPackages: true
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/local-artifact-download.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml

--- a/.azuredevops/components/rocprofiler-compute.yml
+++ b/.azuredevops/components/rocprofiler-compute.yml
@@ -10,6 +10,7 @@ parameters:
   default:
     - cmake
     - locales
+    - ninja-build
     - python3-pip
 - name: pipModules
   type: object
@@ -79,6 +80,9 @@ jobs:
       dependencyList: ${{ parameters.rocmDependencies }}
       gpuTarget: $(JOB_GPU_TARGET)
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+    parameters:
+      extraBuildFlags: >-
+        -GNinja
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
     parameters:
       gpuTarget: $(JOB_GPU_TARGET)
@@ -157,6 +161,7 @@ jobs:
         -DCMAKE_BUILD_TYPE=Release
         -DENABLE_TESTS=ON
         -DINSTALL_TESTS=ON
+        -GNinja
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/gpu-diagnostics.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
     parameters:

--- a/.azuredevops/components/rocprofiler-register.yml
+++ b/.azuredevops/components/rocprofiler-register.yml
@@ -9,6 +9,7 @@ parameters:
   type: object
   default:
     - cmake
+    - ninja-build
     - python3-pip
 
 jobs:
@@ -31,11 +32,14 @@ jobs:
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
     parameters:
       componentName: rocprofiler-register
+      extraBuildFlags: >-
+        -GNinja
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
     parameters:
       componentName: rocprofiler-register-tests
       extraBuildFlags: >-
         -DCMAKE_PREFIX_PATH=$(Build.BinariesDirectory)
+        -GNinja
       cmakeBuildDir: 'tests/build'
       installEnabled: false
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml

--- a/.azuredevops/components/rocprofiler-sdk.yml
+++ b/.azuredevops/components/rocprofiler-sdk.yml
@@ -14,6 +14,7 @@ parameters:
     - libdw-dev
     - libelf-dev
     - libva-dev
+    - ninja-build
     - pkg-config
     - python3-pip
 - name: pipModules
@@ -94,7 +95,7 @@ jobs:
         -DROCPROFILER_BUILD_SAMPLES=ON
         -DROCPROFILER_BUILD_RELEASE=ON
         -DGPU_TARGETS=$(JOB_GPU_TARGET)
-      multithreadFlag: -- -j4
+        -GNinja
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
     parameters:
       gpuTarget: $(JOB_GPU_TARGET)
@@ -158,7 +159,7 @@ jobs:
         -DROCPROFILER_BUILD_SAMPLES=ON
         -DROCPROFILER_BUILD_RELEASE=ON
         -DGPU_TARGETS=$(JOB_GPU_TARGET)
-      multithreadFlag: -- -j16
+        -GNinja
   - template: ${{ variables.CI_TEMPLATE_PATH}}/steps/gpu-diagnostics.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
     parameters:

--- a/.azuredevops/components/rocprofiler-systems.yml
+++ b/.azuredevops/components/rocprofiler-systems.yml
@@ -24,6 +24,7 @@ parameters:
     - libavutil-dev
     - libdrm-amdgpu-dev
     - libdrm-dev
+    - libdw-dev
     - libfabric-dev
     - libiberty-dev
     - libpapi-dev
@@ -31,6 +32,7 @@ parameters:
     - libtool
     - libopenmpi-dev
     - m4
+    - ninja-build
     - openmpi-bin
     - pkg-config
     - python3-pip
@@ -114,7 +116,7 @@ jobs:
         -DROCPROFSYS_USE_PAPI=ON
         -DROCPROFSYS_USE_MPI=ON
         -DGPU_TARGETS=$(JOB_GPU_TARGET)
-      multithreadFlag: -- -j32
+        -GNinja
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
     parameters:
       gpuTarget: $(JOB_GPU_TARGET)
@@ -190,7 +192,7 @@ jobs:
         -DROCPROFSYS_USE_PAPI=ON
         -DROCPROFSYS_USE_MPI=ON
         -DGPU_TARGETS=$(JOB_GPU_TARGET)
-      multithreadFlag: -- -j32
+        -GNinja
   - task: Bash@3
     displayName: Set up rocprofiler-systems env
     inputs:


### PR DESCRIPTION
Adds Ninja to:
- HIP
- amdsmi
- ROCR-Runtime
- rocm-core
- rocm_smi_lib
- rocprofiler-register
- rocminfo
- hipTensor
- rocprofiler-compute
- rocprofiler-systems
- rocprofiler-sdk
- rocm-examples

Components that currently do not work with Ninja are:
- ROCgdb
  - Uses autotools
- HIPIFY
  - Will use `multithreadFlag` parameter instead
- rocprofiler
  - Will use `multithreadFlag` parameter instead

Sample build times:
rocm-examples: 5 min -> 21 sec
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=25504&view=results

rocprof-sys: 6 min -> 5 min
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=25517&view=results