### PR TITLE
Ex CI: rocprof-compute, add dependency on rocprof-sdk

### DIFF
--- a/.azuredevops/components/rocprofiler-compute.yml
+++ b/.azuredevops/components/rocprofiler-compute.yml
@@ -46,6 +46,7 @@ parameters:
     - rocm_smi_lib
     - ROCR-Runtime
     - rocprofiler
+    - rocprofiler-sdk
     - rocprofiler-register
     - roctracer
 


### PR DESCRIPTION
Added rocprofiler-sdk in preparation for using `rocprofv3` for rocprofiler-compute tests.