### PR TITLE
Ex CI: add pkg-config to ROCgdb, remove tarball link from Tensile

### DIFF
--- a/.azuredevops/components/ROCgdb.yml
+++ b/.azuredevops/components/ROCgdb.yml
@@ -17,6 +17,7 @@ parameters:
     - libgmp-dev
     - liblzma-dev
     - libmpfr-dev
+    - pkg-config
     - ncurses-dev
     - texinfo
     - zlib1g-dev

--- a/.azuredevops/components/Tensile.yml
+++ b/.azuredevops/components/Tensile.yml
@@ -87,7 +87,6 @@ jobs:
       workingDirectory: $(Pipeline.Workspace)
       targetType: inline
       script: |
-        echo "$(Build.DefinitionName)_$(Build.SourceBranchName)_$(Build.BuildId)_$(Build.BuildNumber)_ubuntu2204_drop_${{ job.target }}.tar.gz" >> pipelineArtifacts.txt
         whlFile=$(find "$(Build.ArtifactStagingDirectory)" -type f -name "*.whl" | head -n 1)
         if [ -n "$whlFile" ]; then
           echo $(basename "$whlFile") >> pipelineArtifacts.txt


### PR DESCRIPTION
Adds `pkg-config` package to help finding `amd-dbgapi` files during the build process.

Successful build:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=25966&view=results

Also removes the tar.gz file link from Tensile, since it doesn't produce such an artifact.
![image](https://github.com/user-attachments/assets/9c99f3bd-a2a3-4ccc-9219-81d918106c5a)