### PR TITLE
Ex CI: fix CK test pool names

### DIFF
--- a/.azuredevops/components/composable_kernel.yml
+++ b/.azuredevops/components/composable_kernel.yml
@@ -124,7 +124,7 @@ jobs:
     - template: /.azuredevops/variables-global.yml
     - name: TEST_LOG_FILE
       value: $(Pipeline.Workspace)/ckTestLog.log
-    pool: ${{ job.target }}
+    pool: ${{ job.target }}_test_pool
     workspace:
       clean: all
     steps:


### PR DESCRIPTION
Missed this test pool name from https://github.com/ROCm/ROCm/pull/4553. I've searched for the same error in all pipeline files and found this was the only instance.