### PR TITLE
Ex CI: set AMD_COMGR_CACHE=0 for certain math libraries

### DIFF
--- a/.azuredevops/components/hipSOLVER.yml
+++ b/.azuredevops/components/hipSOLVER.yml
@@ -65,6 +65,8 @@ jobs:
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
+    - name: AMD_COMGR_CACHE
+      value: 0
     pool:
       vmImage: ${{ variables.BASE_BUILD_POOL }}
     workspace:

--- a/.azuredevops/components/hipSPARSE.yml
+++ b/.azuredevops/components/hipSPARSE.yml
@@ -121,6 +121,8 @@ jobs:
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
+    - name: AMD_COMGR_CACHE
+      value: 0
     pool: ${{ job.target }}_test_pool
     workspace:
       clean: all

--- a/.azuredevops/components/hipTensor.yml
+++ b/.azuredevops/components/hipTensor.yml
@@ -100,6 +100,8 @@ jobs:
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
+    - name: AMD_COMGR_CACHE
+      value: 0
     pool: ${{ job.target }}_test_pool
     workspace:
       clean: all

--- a/.azuredevops/components/rocSOLVER.yml
+++ b/.azuredevops/components/rocSOLVER.yml
@@ -136,6 +136,8 @@ jobs:
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
+    - name: AMD_COMGR_CACHE
+      value: 0
     pool: ${{ job.target }}_test_pool
     workspace:
       clean: all

--- a/.azuredevops/components/rocSPARSE.yml
+++ b/.azuredevops/components/rocSPARSE.yml
@@ -131,6 +131,8 @@ jobs:
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
+    - name: AMD_COMGR_CACHE
+      value: 0
     pool: ${{ job.target }}_test_pool
     workspace:
       clean: all

--- a/.azuredevops/components/rocWMMA.yml
+++ b/.azuredevops/components/rocWMMA.yml
@@ -118,6 +118,8 @@ jobs:
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
+    - name: AMD_COMGR_CACHE
+      value: 0
     pool: ${{ job.target }}_test_pool
     workspace:
       clean: all


### PR DESCRIPTION
Some mathlibs were seeing a `Cannot find Symbol with name: ...` error when running tests. [Example](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=26211&view=logs&j=fcff73f0-d944-5a68-e6e5-9bab16ae482b&t=0820cb7b-ab3e-567d-4705-d13217c9c4a5&l=67944)

As a workaround, set `AMD_COMGR_CACHE=0` for those failing component pipelines. [Reference](https://rocm.docs.amd.com/projects/HIP/en/docs-develop/how-to/hip_rtc.html#kernel-compilation-cache)
- rocSPARSE
- hipSPARSE
- rocSOLVER
- hipSOLVER
- hipTensor
- rocWMMA

Sample rocSOLVER run:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=26282