### PR TITLE
Ex CI: downgrade CMake version in Azure cloud agent images

### DIFF
--- a/.azuredevops/templates/steps/preamble.yml
+++ b/.azuredevops/templates/steps/preamble.yml
@@ -3,17 +3,39 @@
 # also display installed components and packages
 steps:
 - task: Bash@3
-  displayName: 'apt installed list'
+  displayName: List apt packages
   inputs:
     targetType: inline
     script: apt list --installed
 - task: Bash@3
-  displayName: 'python version'
+  displayName: Print Python version
   inputs:
     targetType: inline
     script: python3 --version
-- script: pip list -v
-  displayName: 'list python packages'
+- task: Bash@3
+  displayName: List Python packages
+  inputs:
+    targetType: inline
+    script: pip list -v
+# The "Azure Pipelines" agents install CMake in multiple ways, including a standalone install into /usr/local/bin:
+# https://github.com/actions/runner-images/blob/6d939a3ab352a54a021dd67b071577287b6f14a5/images/ubuntu/scripts/build/install-cmake.sh#L27
+# This standalone CMake does not have a fixed version, and is not the same version as the one installed by the package manager
+# We want to use the CMake installed by the package manager, so just remove any bins from the standalone install
+- task: Bash@3
+  displayName: Remove CMake binaries from /usr/local/bin
+  inputs:
+    targetType: inline
+    script: |
+      sudo rm -f /usr/local/bin/ccmake
+      sudo rm -f /usr/local/bin/cmake
+      sudo rm -f /usr/local/bin/cmake-gui
+- task: Bash@3
+  displayName: Print CMake info
+  inputs:
+    targetType: inline
+    script: |
+      cmake --version
+      which cmake
 - task: DeleteFiles@1
   displayName: 'Cleanup checkout space'
   inputs:


### PR DESCRIPTION
The "Azure Pipelines" cloud agents install CMake in multiple ways, including a standalone install into `/usr/local/bin`: [Reference](https://github.com/actions/runner-images/blob/6d939a3ab352a54a021dd67b071577287b6f14a5/images/ubuntu/scripts/build/install-cmake.sh#L27)

This standalone CMake doesn't have a fixed version and is not the same version as installed by the package manager. The current Ubuntu 22 agent image, `20250330.1.0`, installing CMake 4.0, which is breaking some component builds.

The CMake 3.22 apt package is still being installed under `/usr/bin`, so we can just delete the binaries installed by the standalone script under `/usr/local/bin` and fall back to the CMake 3.22 bins.

Sample run on cloud agent runner:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=26320&view=logs&j=50b3bdbe-86d2-54db-afce-a3fd8fdae30c&t=d9b41853-5526-5a1d-58d5-af897fb642f0&l=12

Sample run on medium pool runner:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=26321&view=logs&j=b901c642-bc97-57fe-5d15-41b962042f88&t=f10fd902-bae3-5d85-21f9-d3d6c7639126&l=12