### PR TITLE
Ex CI: add parallel mainline runs to rocprofiler-compute

### DIFF
--- a/.azuredevops/components/rocprofiler-compute.yml
+++ b/.azuredevops/components/rocprofiler-compute.yml
@@ -54,19 +54,43 @@ parameters:
   type: object
   default:
     buildJobs:
-      - gfx942:
+      - gfx942-staging:
+        name: gfx942_staging
         target: gfx942
-      - gfx90a:
+        dependencySource: staging
+      - gfx942-mainline:
+        name: gfx942_mainline
+        target: gfx942
+        dependencySource: mainline
+      - gfx90a-staging:
+        name: gfx90a_staging
         target: gfx90a
+        dependencySource: staging
+      - gfx90a-mainline:
+        name: gfx90a_mainline
+        target: gfx90a
+        dependencySource: mainline
     testJobs:
-      - gfx942:
+      - gfx942-staging:
+        name: gfx942_staging
         target: gfx942
-      - gfx90a:
+        dependencySource: staging
+      - gfx942-mainline:
+        name: gfx942_mainline
+        target: gfx942
+        dependencySource: mainline
+      - gfx90a-staging:
+        name: gfx90a_staging
         target: gfx90a
+        dependencySource: staging
+      - gfx90a-mainline:
+        name: gfx90a_mainline
+        target: gfx90a
+        dependencySource: mainline
 
 jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
-  - job: rocprofiler_compute_build_${{ job.target }}
+  - job: rocprofiler_compute_build_${{ job.name }}
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
@@ -88,6 +112,7 @@ jobs:
       parameters:
         checkoutRef: ${{ parameters.checkoutRef }}
         dependencyList: ${{ parameters.rocmDependencies }}
+        dependencySource: ${{ job.dependencySource }}
         gpuTarget: ${{ job.target }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
       parameters:
@@ -95,9 +120,11 @@ jobs:
           -GNinja
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
       parameters:
+        artifactName: ${{ job.dependencySource }}
         gpuTarget: ${{ job.target }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
       parameters:
+        artifactName: ${{ job.dependencySource }}
         gpuTarget: ${{ job.target }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml
     # - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/docker-container.yml
@@ -107,9 +134,9 @@ jobs:
     #     gpuTarget: ${{ job.target }}
 
 - ${{ each job in parameters.jobMatrix.testJobs }}:
-  - job: rocprofiler_compute_test_${{ job.target }}
+  - job: rocprofiler_compute_test_${{ job.name }}
     timeoutInMinutes: 120
-    dependsOn: rocprofiler_compute_build_${{ job.target }}
+    dependsOn: rocprofiler_compute_build_${{ job.name }}
     condition:
       and(succeeded(),
         eq(variables['ENABLE_${{ upper(job.target) }}_TESTS'], 'true'),
@@ -141,11 +168,15 @@ jobs:
       parameters:
         checkoutRepo: ${{ parameters.checkoutRepo }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/local-artifact-download.yml
+      parameters:
+        postTargetFilter: ${{ job.dependencySource }}
+        gpuTarget: ${{ job.target }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-aqlprofile.yml
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
       parameters:
         checkoutRef: ${{ parameters.checkoutRef }}
         dependencyList: ${{ parameters.rocmDependencies }}
+        dependencySource: ${{ job.dependencySource }}
         gpuTarget: ${{ job.target }}
     - task: Bash@3
       displayName: Add ROCm binaries to PATH

--- a/.azuredevops/templates/steps/artifact-upload.yml
+++ b/.azuredevops/templates/steps/artifact-upload.yml
@@ -20,7 +20,7 @@ steps:
     includeRootFolder: false
     archiveType: 'tar'
     tarCompression: 'gz'
-    archiveFile: '$(Build.ArtifactStagingDirectory)/$(Build.DefinitionName)_$(Build.SourceBranchName)_$(Build.BuildId)_$(Build.BuildNumber)_ubuntu2204_${{ parameters.artifactName }}_${{ parameters.gpuTarget }}.tar.gz'
+    archiveFile: '$(Build.ArtifactStagingDirectory)/$(Build.DefinitionName)_$(Build.BuildId)_$(Build.BuildNumber)_ubuntu2204_${{ parameters.gpuTarget }}_${{ parameters.artifactName }}.tar.gz'
 - task: DeleteFiles@1
   displayName: 'Cleanup Staging Area'
   inputs:
@@ -32,7 +32,7 @@ steps:
   inputs:
     workingDirectory: $(Pipeline.Workspace)
     targetType: inline
-    script: echo "$(Build.DefinitionName)_$(Build.SourceBranchName)_$(Build.BuildId)_$(Build.BuildNumber)_ubuntu2204_${{ parameters.artifactName }}_${{ parameters.gpuTarget }}.tar.gz" >> pipelineArtifacts.txt
+    script: echo "$(Build.DefinitionName)_$(Build.BuildId)_$(Build.BuildNumber)_ubuntu2204_${{ parameters.gpuTarget }}_${{ parameters.artifactName }}.tar.gz" >> pipelineArtifacts.txt
 # then publish it
 - ${{ if parameters.publish }}:
   - task: PublishPipelineArtifact@1

--- a/.azuredevops/templates/steps/local-artifact-download.yml
+++ b/.azuredevops/templates/steps/local-artifact-download.yml
@@ -1,5 +1,14 @@
+# The default behaviour of this template is to download artifacts from previous jobs in the current pipeline
+# It can be overridden to download any artifact from any pipeline, given the appropriate build/pipeline IDs
+
 parameters:
   - name: gpuTarget
+    type: string
+    default: ''
+  - name: preTargetFilter
+    type: string
+    default: ''
+  - name: postTargetFilter
     type: string
     default: ''
   # Set buildType to specific to download artifacts from previous builds, useful for saving time when debugging
@@ -9,8 +18,8 @@ parameters:
     values:
       - current
       - specific
-  # Must be set if buildType == specific
-  # Set definitionId to the pipeline ID and buildId to the specific build ID
+  # One of the below params must be set if buildType == specific
+  # Set definitionId to the pipeline ID or buildId to the specific build ID
   - name: definitionId
     type: string
     default: 0
@@ -28,7 +37,7 @@ steps:
         project: ROCm-CI
         definition: ${{ parameters.definitionId }}
         buildId: ${{ parameters.buildId }}
-      itemPattern: '**/*${{ parameters.gpuTarget }}*'
+      itemPattern: '**/*${{ parameters.preTargetFilter }}*${{ parameters.gpuTarget }}*${{ parameters.postTargetFilter }}*'
       targetPath: $(Pipeline.Workspace)/d
   - task: ExtractFiles@1
     displayName: 'Extract Pipeline Build'

--- a/.azuredevops/templates/steps/manifest.yml
+++ b/.azuredevops/templates/steps/manifest.yml
@@ -55,7 +55,7 @@ steps:
         )
       ' resources.repositories)
 
-      manifest_json=$(Build.ArtifactStagingDirectory)/manifest_$(Build.DefinitionName)_$(Build.SourceBranchName)_$(Build.BuildId)_$(Build.BuildNumber)_ubuntu2204_${{ parameters.artifactName }}_${{ parameters.gpuTarget }}.json
+      manifest_json=$(Build.ArtifactStagingDirectory)/manifest_$(Build.DefinitionName)_$(Build.BuildId)_$(Build.BuildNumber)_ubuntu2204_${{ parameters.gpuTarget }}_${{ parameters.artifactName }}.json
 
       dependencies=()
       for manifest_file in $(Pipeline.Workspace)/d/**/manifest_*.json; do
@@ -107,7 +107,7 @@ steps:
   inputs:
     targetType: inline
     script: |
-      manifest_html=$(Build.ArtifactStagingDirectory)/manifest_$(Build.DefinitionName)_$(Build.SourceBranchName)_$(Build.BuildId)_$(Build.BuildNumber)_ubuntu2204_${{ parameters.artifactName }}_${{ parameters.gpuTarget }}.html
+      manifest_html=$(Build.ArtifactStagingDirectory)/manifest_$(Build.DefinitionName)_$(Build.BuildId)_$(Build.BuildNumber)_ubuntu2204_${{ parameters.gpuTarget }}_${{ parameters.artifactName }}.html
       cat <<EOF > $manifest_html
       <html>
       <h1>Manifest</h1>
@@ -148,7 +148,7 @@ steps:
   continueOnError: true
   inputs:
     tabName: Manifest
-    reportDir: $(Build.ArtifactStagingDirectory)/manifest_$(Build.DefinitionName)_$(Build.SourceBranchName)_$(Build.BuildId)_$(Build.BuildNumber)_ubuntu2204_${{ parameters.artifactName }}_${{ parameters.gpuTarget }}.html
+    reportDir: $(Build.ArtifactStagingDirectory)/manifest_$(Build.DefinitionName)_$(Build.BuildId)_$(Build.BuildNumber)_ubuntu2204_${{ parameters.gpuTarget }}_${{ parameters.artifactName }}.html
 - task: Bash@3
   displayName: Save manifest artifact file name
   condition: always()
@@ -157,5 +157,5 @@ steps:
     workingDirectory: $(Pipeline.Workspace)
     targetType: inline
     script: |
-      echo "manifest_$(Build.DefinitionName)_$(Build.SourceBranchName)_$(Build.BuildId)_$(Build.BuildNumber)_ubuntu2204_${{ parameters.artifactName }}_${{ parameters.gpuTarget }}.html" >> pipelineArtifacts.txt
-      echo "manifest_$(Build.DefinitionName)_$(Build.SourceBranchName)_$(Build.BuildId)_$(Build.BuildNumber)_ubuntu2204_${{ parameters.artifactName }}_${{ parameters.gpuTarget }}.json" >> pipelineArtifacts.txt
+      echo "manifest_$(Build.DefinitionName)_$(Build.BuildId)_$(Build.BuildNumber)_ubuntu2204_${{ parameters.gpuTarget }}_${{ parameters.artifactName }}.html" >> pipelineArtifacts.txt
+      echo "manifest_$(Build.DefinitionName)_$(Build.BuildId)_$(Build.BuildNumber)_ubuntu2204_${{ parameters.gpuTarget }}_${{ parameters.artifactName }}.json" >> pipelineArtifacts.txt


### PR DESCRIPTION
Depends on https://github.com/ROCm/ROCm/pull/4569

Adds extra job definitions in rocprofiler-compute's job matrix to build and test against our mainline ROCm in parallel with the regular staging builds.

Sample run staging+mainline run:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=26402&view=results

Sample mainline run:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=26401&view=results