### PR TITLE
Ex CI: properly disable comgr cache for hipSOLVER tests

### DIFF
--- a/.azuredevops/components/hipSOLVER.yml
+++ b/.azuredevops/components/hipSOLVER.yml
@@ -65,8 +65,6 @@ jobs:
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
-    - name: AMD_COMGR_CACHE
-      value: 0
     pool:
       vmImage: ${{ variables.BASE_BUILD_POOL }}
     workspace:
@@ -129,6 +127,8 @@ jobs:
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
+    - name: AMD_COMGR_CACHE
+      value: 0
     pool: ${{ job.target }}_test_pool
     workspace:
       clean: all


### PR DESCRIPTION
`AMD_COMGR_CACHE=0` should be set in the hipSOLVER test job, not the build job.