### PR TITLE
Ex CI: increase CK test time to 3 hours

### DIFF
--- a/.azuredevops/components/composable_kernel.yml
+++ b/.azuredevops/components/composable_kernel.yml
@@ -112,7 +112,7 @@ jobs:
 
 - ${{ each job in parameters.jobMatrix.testJobs }}:
   - job: composable_kernel_test_${{ job.target }}
-    timeoutInMinutes: 90
+    timeoutInMinutes: 180
     dependsOn: composable_kernel_build_${{ job.target }}
     condition:
       and(succeeded(),


### PR DESCRIPTION
Passing run: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=26619&view=results