### PR TITLE
Ex CI: fix miopen-get-ck's artifact filenames

### DIFF
--- a/.azuredevops/templates/steps/miopen-get-ck-build.yml
+++ b/.azuredevops/templates/steps/miopen-get-ck-build.yml
@@ -17,7 +17,7 @@ steps:
     script: |
       AZ_API="https://dev.azure.com/ROCm-CI/ROCm-CI/_apis"
       GH_API="https://api.github.com/repos/ROCm"
-      ARTIFACT_NAME="composablekernel.${{ parameters.gpuTarget }}"
+      ARTIFACT_NAME="composablekernelbuild${{ parameters.gpuTarget }}"
       EXIT_CODE=0
 
       # Try to find an Azure build for the specific CK commit called out in MIOpen's requirements.txt


### PR DESCRIPTION
Fixes the artifact name in miopen-get-ck-build to adjust for new pipeline job names brought by: https://github.com/ROCm/ROCm/pull/4553

Sample run: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=26676&view=logs&j=132ec3a5-51af-5619-91c0-cc7317ecc328&t=7b47df71-81fc-5fe8-eb8a-198099fdf9cc