### PR TITLE
External CI: Update ROCm magma call in pytorch pipeline

### DIFF
--- a/.azuredevops/nightly/pytorch.yml
+++ b/.azuredevops/nightly/pytorch.yml
@@ -170,11 +170,11 @@ jobs:
   - template: /.azuredevops/variables-global.yml
 # various flags/parameters expected by bash scripts in pytorch repo's .ci directory
   - name: ROCM_VERSION
-    value: 6.4.0
+    value: 6.5.0
   - name: ROCM_PATH
     value: /opt/rocm
   - name: DESIRED_CUDA
-    value: 6.4.0
+    value: 6.5.0
   - name: MKLROOT
     value: /opt/intel
   - name: DESIRED_PYTHON
@@ -254,13 +254,6 @@ jobs:
         sudo bash pytorch/.ci/docker/common/install_patchelf.sh
       workingDirectory: $(Build.SourcesDirectory)
   - task: Bash@3
-    displayName: Install mkl dependency for magma
-    inputs:
-      targetType: inline
-      script: |
-        sudo bash pytorch/.ci/docker/common/install_mkl.sh
-      workingDirectory: $(Build.SourcesDirectory)
-  - task: Bash@3
     displayName: Install rocm drm
     inputs:
       targetType: inline
@@ -272,7 +265,7 @@ jobs:
     inputs:
       targetType: inline
       script: |
-        sudo PYTORCH_ROCM_ARCH=$(JOB_GPU_TARGET) MKLROOT=$(MKLROOT) bash pytorch/.ci/docker/common/install_rocm_magma.sh
+        sudo bash pytorch/.ci/docker/common/install_rocm_magma.sh $(ROCM_VERSION)
       workingDirectory: $(Build.SourcesDirectory)
   - task: Bash@3
     displayName: Run ROCm Build Script

--- a/.azuredevops/nightly/pytorch.yml
+++ b/.azuredevops/nightly/pytorch.yml
@@ -175,8 +175,8 @@ jobs:
     value: /opt/rocm
   - name: DESIRED_CUDA
     value: 6.5.0
-  - name: MKLROOT
-    value: /opt/intel
+  - name: MAGMA_ROCM
+    value: 6.3
   - name: DESIRED_PYTHON
     value: 3.10
   - name: PYTORCH_ROOT
@@ -265,7 +265,7 @@ jobs:
     inputs:
       targetType: inline
       script: |
-        sudo bash pytorch/.ci/docker/common/install_rocm_magma.sh $(ROCM_VERSION)
+        sudo bash pytorch/.ci/docker/common/install_rocm_magma.sh $(MAGMA_ROCM)
       workingDirectory: $(Build.SourcesDirectory)
   - task: Bash@3
     displayName: Run ROCm Build Script


### PR DESCRIPTION
- Update ROCm magma script call to match upstream changes.
- Remove mkl dependency to correspond with upstream changes.
- Full build currently fails now due to known clr change.
- [Pipeline Log](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=26799&view=results)