### PR TITLE
[docs/6.4.0] Blog link update to 6.4.0 release notes #4596

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -167,6 +167,8 @@ ROCm documentation continues to be updated to provide clearer and more comprehen
     - The [Math API](https://rocm.docs.amd.com/projects/HIP/en/latest/reference/math_api.html) topic has been reorganized, and the ULP difference of maximum absolute error information has been added.
     - The new [Low precision floating point types](https://rocm.docs.amd.com/projects/HIP/en/latest/reference/low_fp_types.html) topic includes information about FP8 (Quarter Precision) and FP16 (Half Precision).
 
+* In addition to these Release Notes, see the blog [Breaking Barriers in AI, HPC, and Modular GPU Software blog](https://rocm.blogs.amd.com/ecosystems-and-partners/rocm-6.4-blog/README.html) for a wide-ranging discussion of the key advancements and highlights of ROCm 6.4.
+
 ## Operating system and hardware support changes
 
 ROCm 6.4.0 adds support for Oracle Linux 9 operating system. Oracle Linux is supported only on AMD Instinct accelerators. For more information, see [Oracle Linux installation](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/install-methods/package-manager/package-manager-ol.html).


### PR DESCRIPTION
Blog link update to 6.4.0 release notes

(cherry picked from commit af18a170bcc93745e4242ce61be7b02819cc3c0d)