### PR TITLE
Fix vllm Dockerfile.rocm path in llm-inference-frameworks

### DIFF
--- a/docs/how-to/rocm-for-ai/inference/llm-inference-frameworks.rst
+++ b/docs/how-to/rocm-for-ai/inference/llm-inference-frameworks.rst
@@ -36,7 +36,7 @@ Installing vLLM
 
       git clone https://github.com/vllm-project/vllm.git
       cd vllm
-      docker build -f Dockerfile.rocm -t vllm-rocm .
+      docker build -f docker/Dockerfile.rocm -t vllm-rocm .
 
 .. tab-set::
 


### PR DESCRIPTION
Fixes path to vLLM's Dockerfile.rocm in LLM inference documentation due to file restructure in vLLM repository https://github.com/vllm-project/vllm/commit/e6e3c55ef28f30bca855399419c61bb70af03db2