### PR TITLE
[docs/6.4.0] Fix vllm Dockerfile.rocm path (#4628)

### DIFF
--- a/docs/how-to/rocm-for-ai/inference/llm-inference-frameworks.rst
+++ b/docs/how-to/rocm-for-ai/inference/llm-inference-frameworks.rst
@@ -36,7 +36,7 @@ Installing vLLM
 
       git clone https://github.com/vllm-project/vllm.git
       cd vllm
-      docker build -f Dockerfile.rocm -t vllm-rocm .
+      docker build -f docker/Dockerfile.rocm -t vllm-rocm .
 
 .. tab-set::
 


### PR DESCRIPTION
(cherry picked from commit d057d49af1528047fa0e245b8a3d97c9bead1b75)