### PR TITLE
[docs/6.4.0] Update PyTorch training Docker doc for 25.5 (#4638)

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -76,6 +76,7 @@ Concretized
 Conda
 ConnectX
 CuPy
+da
 Dashboarding
 DBRX
 DDR


### PR DESCRIPTION

(cherry picked from commit 9ff3c2c885faf74650b3bb77aaca5b82f602aa92)