### PR TITLE
Ex CI: reenable comgr cache for affected mathlibs

### DIFF
--- a/.azuredevops/components/hipBLAS.yml
+++ b/.azuredevops/components/hipBLAS.yml
@@ -133,8 +133,6 @@ jobs:
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
-    - name: AMD_COMGR_CACHE
-      value: 0
     pool: ${{ job.target }}_test_pool
     workspace:
       clean: all

--- a/.azuredevops/components/hipBLASLt.yml
+++ b/.azuredevops/components/hipBLASLt.yml
@@ -193,8 +193,6 @@ jobs:
     - template: /.azuredevops/variables-global.yml
     - name: ROCM_PATH
       value: $(Agent.BuildDirectory)/rocm
-    - name: AMD_COMGR_CACHE
-      value: 0
     pool: ${{ job.target }}_test_pool
     workspace:
       clean: all

--- a/.azuredevops/components/hipSOLVER.yml
+++ b/.azuredevops/components/hipSOLVER.yml
@@ -134,8 +134,6 @@ jobs:
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
-    - name: AMD_COMGR_CACHE
-      value: 0
     pool: ${{ job.target }}_test_pool
     workspace:
       clean: all

--- a/.azuredevops/components/hipSPARSE.yml
+++ b/.azuredevops/components/hipSPARSE.yml
@@ -128,8 +128,6 @@ jobs:
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
-    - name: AMD_COMGR_CACHE
-      value: 0
     pool: ${{ job.target }}_test_pool
     workspace:
       clean: all

--- a/.azuredevops/components/hipTensor.yml
+++ b/.azuredevops/components/hipTensor.yml
@@ -107,8 +107,6 @@ jobs:
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
-    - name: AMD_COMGR_CACHE
-      value: 0
     pool: ${{ job.target }}_test_pool
     workspace:
       clean: all

--- a/.azuredevops/components/rocBLAS.yml
+++ b/.azuredevops/components/rocBLAS.yml
@@ -157,8 +157,6 @@ jobs:
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
-    - name: AMD_COMGR_CACHE
-      value: 0
     pool: ${{ job.target }}_test_pool
     workspace:
       clean: all

--- a/.azuredevops/components/rocSOLVER.yml
+++ b/.azuredevops/components/rocSOLVER.yml
@@ -143,8 +143,6 @@ jobs:
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
-    - name: AMD_COMGR_CACHE
-      value: 0
     pool: ${{ job.target }}_test_pool
     workspace:
       clean: all

--- a/.azuredevops/components/rocSPARSE.yml
+++ b/.azuredevops/components/rocSPARSE.yml
@@ -34,6 +34,7 @@ parameters:
     - rocminfo
     - rocPRIM
     - rocprofiler-register
+    - roctracer
 - name: rocmTestDependencies
   type: object
   default:
@@ -138,8 +139,6 @@ jobs:
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
-    - name: AMD_COMGR_CACHE
-      value: 0
     pool: ${{ job.target }}_test_pool
     workspace:
       clean: all

--- a/.azuredevops/components/rocWMMA.yml
+++ b/.azuredevops/components/rocWMMA.yml
@@ -125,8 +125,6 @@ jobs:
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
-    - name: AMD_COMGR_CACHE
-      value: 0
     pool: ${{ job.target }}_test_pool
     workspace:
       clean: all


### PR DESCRIPTION
Removes `AMD_COMGR_CACHE=0` from all affected mathlib pipelines, the caching issue is fixed in https://github.com/ROCm/llvm-project/commit/7271c2f8f92f7ea4f5da02cd249fab5cf24920ec

Also adds roctracer as a dep for rocSPARSE builds.

rocSOLVER run: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=27192&view=results
hipBLAS run: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=27191&view=results