### PR TITLE
Ex CI: add template to create Docker images with `docker commit`

### DIFF
--- a/.azuredevops/templates/steps/docker-container-commit.yml
+++ b/.azuredevops/templates/steps/docker-container-commit.yml
@@ -63,7 +63,7 @@ steps:
     displayName: Build and upload Docker image
     condition: or(and(failed(), not(contains(variables['DOCKER_SKIP_GFX'], variables['JOB_GPU_TARGET']))), ${{ eq(parameters.forceDockerCreation, true) }})
     inputs:
-      containerRegistry: 'ContainerService'
+      containerRegistry: 'ContainerService3'
       ${{ if ne(parameters.gpuTarget, '') }}:
         repository: '$(Build.DefinitionName)-${{ parameters.environment }}-${{ parameters.gpuTarget }}'
       ${{ else }}:

--- a/.azuredevops/templates/steps/docker-container-commit.yml
+++ b/.azuredevops/templates/steps/docker-container-commit.yml
@@ -1,0 +1,82 @@
+# This template creates and uploads a Docker image from the current environment
+# It uses `docker commit` to do so, which can provide more accurate images than the standard template
+# It requires the following conditions:
+# - Job must be run inside a Docker container
+# - The container's external name must be the same as the container's internal hostname
+# - Docker must be installed inside said container and given sufficient permissions
+# Currently, it is only usable for test jobs run on our self-managed systems
+# Jobs run on Azure VMs will not be able to use this template (most if not all build jobs)
+
+parameters:
+- name: gpuTarget
+  type: string
+  default: ''
+- name: environment
+  type: string
+  default: build
+  values:
+    - build
+    - test
+    - combined
+    - amd
+    - nvidia
+- name: extraPaths
+  type: string
+  default: ''
+- name: extraEnvVars
+  type: object
+  default: []
+- name: forceDockerCreation
+  type: boolean
+  default: false
+
+steps:
+  - task: Bash@3
+    displayName: Commit container and initialize Dockerfile
+    condition: or(and(failed(), not(contains(variables['DOCKER_SKIP_GFX'], variables['JOB_GPU_TARGET']))), ${{ eq(parameters.forceDockerCreation, true) }})
+    inputs:
+      workingDirectory: $(Pipeline.Workspace)
+      targetType: inline
+      script: |
+        docker commit $(hostname) az-ci-temp-image:latest
+        echo "FROM az-ci-temp-image:latest" > Dockerfile
+        echo "RUN sudo groupmod -g $(getent group render | awk -F: '{print $3}') render" >> Dockerfile
+        echo "RUN sudo groupmod -g $(getent group docker | awk -F: '{print $3}') docker" >> Dockerfile
+        echo "ENV PATH='$PATH:${{ parameters.extraPaths }}'" >> Dockerfile
+        echo "ENTRYPOINT [\"/bin/bash\"]" >> Dockerfile
+  - ${{ each extraEnvVar in parameters.extraEnvVars }}:
+    - task: Bash@3
+      displayName: Add extra environment variables
+      condition: or(and(failed(), not(contains(variables['DOCKER_SKIP_GFX'], variables['JOB_GPU_TARGET']))), ${{ eq(parameters.forceDockerCreation, true) }})
+      inputs:
+        workingDirectory: $(Pipeline.Workspace)
+        targetType: inline
+        script: echo "ENV ${{ split(extraEnvVar, ':::')[0] }}='${{ split(extraEnvVar, ':::')[1] }}'" >> Dockerfile
+  - task: Bash@3
+    displayName: Print Dockerfile
+    condition: or(and(failed(), not(contains(variables['DOCKER_SKIP_GFX'], variables['JOB_GPU_TARGET']))), ${{ eq(parameters.forceDockerCreation, true) }})
+    inputs:
+      workingDirectory: $(Pipeline.Workspace)
+      targetType: inline
+      script: cat Dockerfile
+  - task: Docker@2
+    displayName: Build and upload Docker image
+    condition: or(and(failed(), not(contains(variables['DOCKER_SKIP_GFX'], variables['JOB_GPU_TARGET']))), ${{ eq(parameters.forceDockerCreation, true) }})
+    inputs:
+      containerRegistry: 'ContainerService'
+      ${{ if ne(parameters.gpuTarget, '') }}:
+        repository: '$(Build.DefinitionName)-${{ parameters.environment }}-${{ parameters.gpuTarget }}'
+      ${{ else }}:
+        repository: '$(Build.DefinitionName)-${{ parameters.environment }}'
+      Dockerfile: '$(Pipeline.Workspace)/Dockerfile'
+      buildContext: '$(Pipeline.Workspace)'
+  - task: Bash@3
+    condition: or(and(failed(), not(contains(variables['DOCKER_SKIP_GFX'], variables['JOB_GPU_TARGET']))), ${{ eq(parameters.forceDockerCreation, true) }})
+    displayName: "!! Docker Image URL !!"
+    inputs:
+      workingDirectory: $(Pipeline.Workspace)
+      targetType: inline
+      ${{ if ne(parameters.gpuTarget, '') }}:
+        script: echo "rocmexternalcicd.azurecr.io/$(Build.DefinitionName)-${{ parameters.environment }}-${{ parameters.gpuTarget }}:$(Build.BuildId)"
+      ${{ else }}:
+        script: echo "rocmexternalcicd.azurecr.io/$(Build.DefinitionName)-${{ parameters.environment }}:$(Build.BuildId)"

--- a/.azuredevops/templates/steps/docker-container-commit.yml
+++ b/.azuredevops/templates/steps/docker-container-commit.yml
@@ -77,6 +77,6 @@ steps:
       workingDirectory: $(Pipeline.Workspace)
       targetType: inline
       ${{ if ne(parameters.gpuTarget, '') }}:
-        script: echo "rocmexternalcicd.azurecr.io/$(Build.DefinitionName)-${{ parameters.environment }}-${{ parameters.gpuTarget }}:$(Build.BuildId)"
+        script: echo "rocmexternalcicd.azurecr.io/$(Build.DefinitionName)-${{ parameters.environment }}-${{ parameters.gpuTarget }}:$(Build.BuildId)" | tr '[:upper:]' '[:lower:]'
       ${{ else }}:
-        script: echo "rocmexternalcicd.azurecr.io/$(Build.DefinitionName)-${{ parameters.environment }}:$(Build.BuildId)"
+        script: echo "rocmexternalcicd.azurecr.io/$(Build.DefinitionName)-${{ parameters.environment }}:$(Build.BuildId)" | tr '[:upper:]' '[:lower:]'


### PR DESCRIPTION
This is a new template to create Docker images with `docker commit`. This allows for an almost perfect recreation of the CI environment, but it must be run inside a Docker container to work. Jobs run on Azure VMs will not be able to use this, but jobs run on our GPU test systems can.

Adding this in for future use, since I think it'll be useful at least for manual debugging component test failures.

Sample run for rocm-examples:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=25524&view=logs&j=644fd87e-dd9d-506e-a6e1-9813a7569c27&t=eeee5e53-3af8-500c-a8ff-72d426a3f0c7