### PR TITLE
External CI: rocprofiler-systems CMake flags to find rocjpeg headers

### DIFF
--- a/.azuredevops/components/rocprofiler-systems.yml
+++ b/.azuredevops/components/rocprofiler-systems.yml
@@ -21,6 +21,7 @@ parameters:
     - bzip2
     - clang
     - cmake
+    - chrpath
     - environment-modules
     - ffmpeg
     - g++-12
@@ -130,6 +131,7 @@ jobs:
           -DDYNINST_BUILD_BOOST=ON
           -DROCPROFSYS_USE_PAPI=ON
           -DROCPROFSYS_USE_MPI=ON
+          -DCMAKE_CXX_FLAGS=-I$(Agent.BuildDirectory)/rocm/include/rocjpeg
           -DGPU_TARGETS=${{ job.target }}
           -GNinja
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
@@ -204,6 +206,7 @@ jobs:
           -DDYNINST_BUILD_BOOST=ON
           -DROCPROFSYS_USE_PAPI=ON
           -DROCPROFSYS_USE_MPI=ON
+          -DCMAKE_CXX_FLAGS=-I$(Agent.BuildDirectory)/rocm/include/rocjpeg
           -DGPU_TARGETS=${{ job.target }}
           -GNinja
     - task: Bash@3


### PR DESCRIPTION
- Also add chrpath dependency
- Test failures still occur but compilation fixed.
- [Build Logs](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=27317&view=results)