### PR TITLE
Use standard CMake options for hipfort build

### DIFF
--- a/.azuredevops/components/hipfort.yml
+++ b/.azuredevops/components/hipfort.yml
@@ -88,13 +88,11 @@ jobs:
           -DROCM_PATH=$(Agent.BuildDirectory)/rocm
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm;$(Agent.BuildDirectory)/rocm/llvm
-          -DHIPFORT_INSTALL_DIR=$(Build.BinariesDirectory)
-          -DHIPFORT_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/flang
-          -DCMAKE_Fortran_FLAGS="-Mfree -fPIC"
-          -DCMAKE_Fortran_FLAGS_DEBUG=""
-          -DHIPFORT_COMPILER_FLAGS="-cpp"
-          -DHIPFORT_AR=$(Agent.BuildDirectory)/rocm/llvm/bin/llvm-ar
-          -DHIPFORT_RANLIB=$(Agent.BuildDirectory)/rocm/llvm/bin/llvm-ranlib
+          -DCMAKE_INSTALL_PREFIX=$(Build.BinariesDirectory)
+          -DCMAKE_Fortran_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/flang
+          -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+          -DCMAKE_AR=$(Agent.BuildDirectory)/rocm/llvm/bin/llvm-ar
+          -DCMAKE_RANLIB=$(Agent.BuildDirectory)/rocm/llvm/bin/llvm-ranlib
           -DAMDGPU_TARGETS=${{ job.target }}
           -DBUILD_TESTING=ON
           -GNinja

--- a/tools/rocm-build/build_hipfort.sh
+++ b/tools/rocm-build/build_hipfort.sh
@@ -20,20 +20,17 @@ build_hipfort() {
     mkdir -p "$BUILD_DIR" && cd "$BUILD_DIR"
     cmake \
         -DCPACK_PACKAGING_INSTALL_PREFIX=${ROCM_PATH}\
-        -DHIPFORT_INSTALL_DIR="${ROCM_PATH}" \
         -DCMAKE_PREFIX_PATH="${ROCM_PATH}/llvm;${ROCM_PATH}" \
         -DCMAKE_BUILD_TYPE=Release \
         -DCPACK_SET_DESTDIR="OFF" \
         -DCPACK_RPM_PACKAGE_RELOCATABLE="ON" \
-        -DHIPFORT_COMPILER="${ROCM_PATH}/${ROCM_LLVMDIR}/bin/flang" \
-        -DCMAKE_Fortran_FLAGS="-Mfree" \
-        -DHIPFORT_COMPILER_FLAGS="-cpp" \
+        -DCMAKE_Fortran_COMPILER="${ROCM_PATH}/${ROCM_LLVMDIR}/bin/flang" \
         -DCMAKE_Fortran_FLAGS_DEBUG="" \
         ${LAUNCHER_FLAGS} \
         -DROCM_SYMLINK_LIBS=OFF \
         -DCMAKE_INSTALL_PREFIX=${ROCM_PATH} \
-        -DHIPFORT_AR="${ROCM_PATH}/${ROCM_LLVMDIR}/bin/llvm-ar" \
-        -DHIPFORT_RANLIB="${ROCM_PATH}/${ROCM_LLVMDIR}/bin/llvm-ranlib" \
+        -DCMAKE_AR="${ROCM_PATH}/${ROCM_LLVMDIR}/bin/llvm-ar" \
+        -DCMAKE_RANLIB="${ROCM_PATH}/${ROCM_LLVMDIR}/bin/llvm-ranlib" \
         "$COMPONENT_SRC"
 
     cmake --build "$BUILD_DIR" -- -j${PROC}


### PR DESCRIPTION
Update the hipfort build to use standard CMake options. To be enable once support is enabled in hipfort. https://github.com/ROCm/hipfort/pull/222