### PR TITLE
Ex CI: add double quotes to pip packages with min versions

### DIFF
--- a/.azuredevops/components/AMDMIGraphX.yml
+++ b/.azuredevops/components/AMDMIGraphX.yml
@@ -32,12 +32,12 @@ parameters:
   type: object
   default:
     - https://github.com/RadeonOpenCompute/rbuild/archive/master.tar.gz
-    - onnx>=1.14.1
-    - numpy>=1.21.6
-    - typing>=3.7.4
-    - pytest>=6.0.1
-    - packaging>=23.0
-    - protobuf>=3.20.2
+    - "onnx>=1.14.1"
+    - "numpy>=1.21.6"
+    - "typing>=3.7.4"
+    - "pytest>=6.0.1"
+    - "packaging>=23.0"
+    - "protobuf>=3.20.2"
 - name: rocmDependencies
   type: object
   default:

--- a/.azuredevops/components/hipBLASLt.yml
+++ b/.azuredevops/components/hipBLASLt.yml
@@ -27,7 +27,7 @@ parameters:
   type: object
   default:
     - joblib
-    - packaging>=22.0
+    - "packaging>=22.0"
     - --upgrade
 - name: rocmDependencies
   type: object

--- a/.azuredevops/components/rocprofiler-compute.yml
+++ b/.azuredevops/components/rocprofiler-compute.yml
@@ -22,10 +22,10 @@ parameters:
   default:
     - astunparse==1.6.2
     - colorlover
-    - dash>=1.12.0
+    - "dash>=1.12.0"
     - matplotlib
-    - numpy>=1.17.5
-    - pandas>=1.4.3
+    - "numpy>=1.17.5"
+    - "pandas>=1.4.3"
     - pymongo
     - pyyaml
     - tabulate

--- a/.azuredevops/components/rocprofiler-sdk.yml
+++ b/.azuredevops/components/rocprofiler-sdk.yml
@@ -36,7 +36,7 @@ parameters:
     - pandas
     - perfetto
     - pycobertura
-    - pytest>=6.2.5
+    - "pytest>=6.2.5"
     - pyyaml
 - name: rocmDependencies
   type: object

--- a/.azuredevops/nightly/pytorch.yml
+++ b/.azuredevops/nightly/pytorch.yml
@@ -68,7 +68,7 @@ parameters:
   default:
     - cmake
     - astunparse
-    - expecttest>=0.2.1
+    - "expecttest>=0.2.1"
     - hypothesis
     - numpy
     - psutil
@@ -76,8 +76,8 @@ parameters:
     - requests
     - setuptools==75.8.0
     - types-dataclasses
-    - typing-extensions>=4.8.0
-    - sympy>=1.13.0
+    - "typing-extensions>=4.8.0"
+    - "sympy>=1.13.0"
     - filelock
     - networkx
     - jinja2
@@ -85,8 +85,8 @@ parameters:
     - lintrunner
     - ninja
     - packaging
-    - optree>=0.13.0
-    - click>=8.0.3
+    - "optree>=0.13.0"
+    - "click>=8.0.3"
   # list for vision
     - auditwheel
     - future


### PR DESCRIPTION
Official python docs say to surround packages with double quotes when you are specifying a minimum version. Without them, the output of `pip install` is empty, probably being eaten up by a redirection.

Example empty pip install output: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=27535&view=logs&j=9c6b3386-0a01-5a91-f5b9-93bc3a008529&t=fa48d566-01c8-52f9-f2dc-44ab4dcaa1eb

Ref: https://docs.python.org/3/installing/index.html#basic-usage