### PR TITLE
Ex CI: add targets to rocJPEG artifact names

### DIFF
--- a/.azuredevops/components/rocJPEG.yml
+++ b/.azuredevops/components/rocJPEG.yml
@@ -89,6 +89,8 @@ jobs:
           -GNinja
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
+      parameters:
+        gpuTarget: ${{ job.target }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml
     # - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/docker-container.yml
     #   parameters:
@@ -122,6 +124,8 @@ jobs:
         registerROCmPackages: true
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/local-artifact-download.yml
+      parameters:
+        gpuTarget: ${{ job.target }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-aqlprofile.yml
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
       parameters:
@@ -147,4 +151,3 @@ jobs:
         environment: test
         gpuTarget: ${{ job.target }}
         registerROCmPackages: true
-        optSymLink: true


### PR DESCRIPTION
Adds gfx targets to rocJPEG, such that test jobs can correctly filter out the artifacts they should be downloading. Fixes failing gfx90a tests caused by erroneously pulling artifacts built for gfx942.

Sample run:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=27968&view=results