### PR TITLE
Ex CI: add manifest artifact download template

### DIFF
--- a/.azuredevops/scripts/download-manifest-artifacts/download-manifest-artifacts.py
+++ b/.azuredevops/scripts/download-manifest-artifacts/download-manifest-artifacts.py
@@ -17,34 +17,46 @@ def _get_builds(entry, gpu_target, already_downloaded, output):
         print('Skipping, already downloaded from build ' + entry['buildId'])
         return already_downloaded
 
-    artifacts_url = f"https://dev.azure.com/ROCm-CI/ROCm-CI/_apis/build/builds/{entry['buildId']}/artifacts?api-version=7.1"
-    artifacts = requests.get(artifacts_url).json()
-    for artifact in artifacts['value']:
-        if 'gfx' in artifact['name'] and gpu_target not in artifact['name']:
-            continue
+    retries = 3
+    for i in range(retries):
+        try:
+            artifacts_url = f"https://dev.azure.com/ROCm-CI/ROCm-CI/_apis/build/builds/{entry['buildId']}/artifacts?api-version=7.1"
+            artifacts = requests.get(artifacts_url).json()
+            for artifact in artifacts['value']:
+                if 'gfx' in artifact['name'] and gpu_target not in artifact['name']:
+                    continue
 
-        print('Artifact name: ' + artifact['name'])
-        print('File size: ~' +
-              str(round(int(artifact['resource']['properties']['artifactsize'])/1000000, 2)) + ' MB')
-        download_url = f"{artifact['resource']['downloadUrl']}"
-        download = requests.get(download_url)
+                print('Artifact name: ' + artifact['name'])
+                print('File size: ~' +
+                    str(round(int(artifact['resource']['properties']['artifactsize'])/1000000, 2)) + ' MB')
+                download_url = f"{artifact['resource']['downloadUrl']}"
+                download = requests.get(download_url)
 
-        zip_file = Path(output) / f"{artifact['name']}.zip"
-        with open(zip_file, 'wb') as f:
-            f.write(download.content)
-        already_downloaded[entry['buildId']] = True
-
-    return already_downloaded
+                zip_file = Path(output) / f"{artifact['name']}.zip"
+                with open(zip_file, 'wb') as f:
+                    f.write(download.content)
+                already_downloaded[entry['buildId']] = True
+            return already_downloaded
+        except requests.exceptions.RequestException as e:
+            print(f"Error downloading artifacts: {e}")
+            if i < retries - 1:
+                print("Retrying...")
+            else:
+                print(f"Failed to download after {retries} attempts.")
+        except Exception as e:
+            print(f"An unexpected error occurred: {e}")
+            break
 
 def main():
     parser = argparse.ArgumentParser(description="Command line tool for downloading external ci artifacts")
-    parser.add_argument('--target', type=str, dest="target", choices=["gfx90a", "gfx942"], help="Target gfx")
+    parser.add_argument('--target', type=str, dest="target", choices=["gfx90a", "gfx942", "no_target"], help="Target gfx")
     parser.add_argument('--manifest', type=str, dest="manifest", help='JSON manifest url or path to local manifest')
     parser.add_argument('--output_dir', type=str, dest="output", help='Path to download directory')
     args = parser.parse_args()
 
     manifest = args.manifest
     gpu_target = args.target
+    output = args.output
 
     if not gpu_target:
         print("Enter the GPU target (gfx942, gfx90a)")
@@ -62,7 +74,7 @@ def main():
 
     entries = [e for e in data['current']]
     entries.extend([e for e in data['dependencies']])
-    get_builds(entries, gpu_target, args.output)
+    get_builds(entries, gpu_target, output)
 
 if __name__ == "__main__":
     main()

--- a/.azuredevops/templates/steps/manifest-artifact-download.yml
+++ b/.azuredevops/templates/steps/manifest-artifact-download.yml
@@ -1,0 +1,63 @@
+parameters:
+  - name: scriptBranch
+    type: string
+    default: 'develop'
+  - name: gpuTarget
+    type: string
+    default: no_target
+    values:
+      - no_target
+      - gfx90a
+      - gfx942
+  - name: manifestUrl
+    type: string
+    default: ''
+  - name: downloadDir
+    type: string
+    default: $(Pipeline.Workspace)/d
+
+steps:
+  - task: Bash@3
+    displayName: Set up manifest artifact script
+    inputs:
+      targetType: 'inline'
+      script: |
+        mkdir -p ${{ parameters.downloadDir }}
+        wget https://raw.githubusercontent.com/ROCm/ROCm/refs/heads/${{ parameters.scriptBranch }}/.azuredevops/scripts/download-manifest-artifacts/requirements.txt
+        wget https://raw.githubusercontent.com/ROCm/ROCm/refs/heads/${{ parameters.scriptBranch }}/.azuredevops/scripts/download-manifest-artifacts/download-manifest-artifacts.py
+        python3 -m pip install -r ./requirements.txt
+  - task: Bash@3
+    displayName: Download manifest artifacts
+    inputs:
+      targetType: 'inline'
+      script: |
+        python3 ./download-manifest-artifacts.py \
+          --target="${{ parameters.gpuTarget }}" \
+          --manifest="${{ parameters.manifestUrl }}" \
+          --output_dir="${{ parameters.downloadDir }}"
+  - task: ExtractFiles@1
+    displayName: Extract manifest artifacts 1/2
+    inputs:
+      archiveFilePatterns: ${{ parameters.downloadDir }}/**/*.zip
+      destinationFolder: ${{ parameters.downloadDir }}
+      cleanDestinationFolder: false
+      overwriteExistingFiles: true
+  - task: ExtractFiles@1
+    displayName: Extract manifest artifacts 2/2
+    inputs:
+      archiveFilePatterns: ${{ parameters.downloadDir }}/**/*.tar.gz
+      destinationFolder: $(Agent.BuildDirectory)/rocm
+      cleanDestinationFolder: false
+      overwriteExistingFiles: true
+  - task: DeleteFiles@1
+    displayName: Clean up manifest artifacts 1/2
+    inputs:
+      SourceFolder: ${{ parameters.downloadDir }}
+      Contents: '/**/*.zip'
+      RemoveDotFiles: true
+  - task: DeleteFiles@1
+    displayName: Clean up manifest artifacts 2/2
+    inputs:
+      SourceFolder: ${{ parameters.downloadDir }}
+      Contents: '/**/*.tar.gz'
+      RemoveDotFiles: true


### PR DESCRIPTION
Adds a new manifest-artifact-download template that wraps around the `download-manifest-artifacts.py` script and extracts the downloaded artifacts.

Adds "no target" option to the download script, also gives it 3 retries for downloading an artifact before erroring out.