### PR TITLE
Ex CI: fix copyHIP incorrectly packaging symlinked files

### DIFF
--- a/.azuredevops/components/copyHIP.yml
+++ b/.azuredevops/components/copyHIP.yml
@@ -26,9 +26,11 @@ jobs:
     parameters:
       componentName: HIP
       pipelineId: $(HIP_PIPELINE_ID)
-  - template:  ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-prepare-package.yml
-    parameters:
-      sourceDir: $(Agent.BuildDirectory)/rocm
+  - task: Bash@3
+    displayName: Copy HIP artifacts
+    inputs:
+      targetType: inline
+      script: cp -a $(Agent.BuildDirectory)/rocm/* $(Build.BinariesDirectory)/
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml

--- a/.azuredevops/templates/steps/dependencies-rocm.yml
+++ b/.azuredevops/templates/steps/dependencies-rocm.yml
@@ -463,7 +463,7 @@ steps:
   displayName: 'List downloaded ROCm files'
   inputs:
     targetType: inline
-    script: ls -1R $(Agent.BuildDirectory)/rocm
+    script: ls -la1R $(Agent.BuildDirectory)/rocm
 - ${{ if eq(parameters.skipLibraryLinking, false) }}:
   - task: Bash@3
     displayName: 'Link ROCm shared libraries'


### PR DESCRIPTION
The Azure CopyFiles@2 task does not preserve symlinks when copying files, it insteads resolves links to the original file and copies those over instead. In the case of the copyHIP pipeline, library files that are normally symlinked to each other become full, duplicate library files. CLR builds that were triggered by HIP builds will have these full files. Standalone CLR builds will have symlinks, since those don't call copyHIP.

For some reason, this is causing rocMLIR tests to fail to build when it pulls in a CLR build that was triggered by HIP. The tests do pass when pulling a standalone CLR build, which resulted in sporadic pipeline failures.

This PR changes copyHIP to use `cp -a` instead of CopyFiles@2, which does preserve symlinks. 

Also adds extra flags to the 'list files' step in deps-rocm to show more file info.

Passing rocMLIR run:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=28041&view=results