### PR TITLE
Ex CI: add roctracer to rocprof-sys dependencies

### DIFF
--- a/.azuredevops/components/rocprofiler-systems.yml
+++ b/.azuredevops/components/rocprofiler-systems.yml
@@ -67,6 +67,7 @@ parameters:
     - rocprofiler-register
     - rocprofiler-sdk
     - ROCR-Runtime
+    - roctracer
 
 - name: jobMatrix
   type: object


### PR DESCRIPTION
Add roctracer to rocprofiler-systems' dependencies to resolve a number of test failures.

Current gfx942 results:
`76% tests passed, 61 tests failed out of 255`
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=28276&view=logs&j=d8c72aa6-c5a3-593f-8d46-26eba74c2013&t=0bd9ffa9-0ef9-5489-204e-c50c0832796a&l=81658

gfx942 with roctracer:
`80% tests passed, 51 tests failed out of 255`
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=28284&view=logs&j=d8c72aa6-c5a3-593f-8d46-26eba74c2013&t=c9f63a05-6ecb-5ab5-b99d-4a1d66e1e34a&l=92133