### PR TITLE
Ex CI: disable rocm-examples rocfft_callback test

### DIFF
--- a/.azuredevops/components/rocm-examples.yml
+++ b/.azuredevops/components/rocm-examples.yml
@@ -183,6 +183,7 @@ jobs:
       parameters:
         componentName: rocm-examples
         testDir: $(Build.SourcesDirectory)/build
+        testParameters: '--output-on-failure --force-new-ctest-process --output-junit test_output.xml --exclude-regex "rocfft_callback"'
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/docker-container.yml
       parameters:
         aptPackages: ${{ parameters.aptPackages }}


### PR DESCRIPTION
Disables the sole consistently failing `rocfft_callback` test in rocm-examples, to make test runs meaningful again.

The failure arises only when compiling with no optimizations (-O0) and does not fail at -O1 and -O3. This issue is being tracked internally.

Sample run:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=29064&view=results