### PR TITLE
Ex CI: add sparse option to checkout template

### DIFF
--- a/.azuredevops/templates/steps/build-cmake.yml
+++ b/.azuredevops/templates/steps/build-cmake.yml
@@ -10,10 +10,10 @@ parameters:
   default: ''
 - name: cmakeBuildDir
   type: string
-  default: 'build'
+  default: $(Pipeline.Workspace)/s/build
 - name: cmakeSourceDir
   type: string
-  default: '..'
+  default: $(Pipeline.Workspace)/s
 - name: customBuildTarget
   type: string
   default: ''
@@ -46,7 +46,7 @@ steps:
     ${{ if eq(parameters.customInstallPath, true) }}:
       cmakeArgs: -DCMAKE_INSTALL_PREFIX=${{ parameters.installDir }} ${{ parameters.extraBuildFlags }} ${{ parameters.cmakeSourceDir }}
     ${{ else }}:
-      cmakeArgs: ${{ parameters.extraBuildFlags }} ..
+      cmakeArgs: ${{ parameters.extraBuildFlags }} ${{ parameters.cmakeSourceDir }}
 - ${{ if parameters.printDiskSpace }}:
   - script: df -h
     displayName: Disk space before build

--- a/.azuredevops/templates/steps/build-cmake.yml
+++ b/.azuredevops/templates/steps/build-cmake.yml
@@ -10,10 +10,10 @@ parameters:
   default: ''
 - name: cmakeBuildDir
   type: string
-  default: $(Pipeline.Workspace)/s/build
+  default: $(Agent.BuildDirectory)/s/build
 - name: cmakeSourceDir
   type: string
-  default: $(Pipeline.Workspace)/s
+  default: $(Agent.BuildDirectory)/s
 - name: customBuildTarget
   type: string
   default: ''

--- a/.azuredevops/templates/steps/checkout.yml
+++ b/.azuredevops/templates/steps/checkout.yml
@@ -29,4 +29,4 @@ steps:
       displayName: Symlink sparse checkout
       inputs:
         targetType: inline
-        script: ln -s $(Pipeline.Workspace)/sparse/${{ parameters.sparseCheckoutDir }} $(Pipeline.Workspace)/s
+        script: ln -s $(Agent.BuildDirectory)/sparse/${{ parameters.sparseCheckoutDir }} $(Agent.BuildDirectory)/s

--- a/.azuredevops/templates/steps/checkout.yml
+++ b/.azuredevops/templates/steps/checkout.yml
@@ -4,6 +4,12 @@ parameters:
 - name: checkoutRepo
   type: string
   default: 'self'
+- name: sparseCheckout
+  type: boolean
+  default: false
+- name: sparseCheckoutDir
+  type: string
+  default: ''
 # submodule download behaviour
 # change to 'recursive' for repos with submodules
 - name: submoduleBehaviour
@@ -15,3 +21,12 @@ steps:
     clean: true
     submodules: ${{ parameters.submoduleBehaviour }}
     retryCountOnTaskFailure: 3
+    ${{ if eq(parameters.sparseCheckout, true) }}:
+      sparseCheckoutDirectories: ${{ parameters.sparseCheckoutDir }}
+      path: sparse
+  - ${{ if eq(parameters.sparseCheckout, true) }}:
+    - task: Bash@3
+      displayName: Symlink sparse checkout
+      inputs:
+        targetType: inline
+        script: ln -s $(Pipeline.Workspace)/sparse/${{ parameters.sparseCheckoutDir }} $(Pipeline.Workspace)/s


### PR DESCRIPTION
Adds the ability to set a single sparse checkout directory in `checkout.yml`, which will be cloned into `$(Agent.BuildDirectory)/sparse/{some_dir}` and then symlinked to `$(Agent.BuildDirectory)/s`.

Hardcodes `build-cmake.yml`'s build paths to `$(Agent.BuildDirectory)/s`, since its working directory can change depending on where a repo is checked out.
See `Build.SourcesDirectory` in https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables-devops-services

Sample rocBLAS w/ sparse (pulls from test repo):
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=28559&view=results
rocBLAS w/o sparse (pulls from ROCm/rocBLAS):
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=28571&view=results