### PR TITLE
Ex CI: skip docker creation on gfx942

### DIFF
--- a/.azuredevops/templates/steps/docker-container.yml
+++ b/.azuredevops/templates/steps/docker-container.yml
@@ -106,6 +106,7 @@ parameters:
   type: object
   default:
     - gfx90a
+    - gfx942
 
 steps:
 # these steps should only be run if there was a failure or warning


### PR DESCRIPTION
Skip Docker creation for gfx942 until we get it working in the new Kubernetes setup.