### PR TITLE
Ex CI: enable rocPRIM sparse checkout

### DIFF
--- a/.azuredevops/components/rocPRIM.yml
+++ b/.azuredevops/components/rocPRIM.yml
@@ -5,6 +5,12 @@ parameters:
 - name: checkoutRef
   type: string
   default: ''
+- name: sparseCheckout
+  type: boolean
+  default: false
+- name: sparseCheckoutDir
+  type: string
+  default: ''
 # set to true if doing full build of ROCm stack
 # and dependencies are pulled from same pipeline
 - name: aggregatePipeline
@@ -66,6 +72,8 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
       parameters:
         checkoutRepo: ${{ parameters.checkoutRepo }}
+        sparseCheckout: ${{ parameters.sparseCheckout }}
+        sparseCheckoutDir: ${{ parameters.sparseCheckoutDir }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
       parameters:
         checkoutRef: ${{ parameters.checkoutRef }}

--- a/.azuredevops/templates/steps/checkout.yml
+++ b/.azuredevops/templates/steps/checkout.yml
@@ -21,6 +21,7 @@ steps:
     clean: true
     submodules: ${{ parameters.submoduleBehaviour }}
     retryCountOnTaskFailure: 3
+    fetchFilter: blob:none
     ${{ if eq(parameters.sparseCheckout, true) }}:
       sparseCheckoutDirectories: ${{ parameters.sparseCheckoutDir }}
       path: sparse


### PR DESCRIPTION
Enables sparse checkout options for the rocPRIM pipeline. Required for: https://github.com/ROCm/rocm-libraries/pull/44

Adds a `blob:none` filter option when fetching a repo, which can greatly reduce download times, especially for the monorepo.
For fetching rocm-libraries:
- Without the filter: 4m 25s
  - https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=30144&view=results
- With the filter: 3s
  - https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=30156&view=results

https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone
> `git clone --filter=blob:none <url>` creates a blobless clone. These clones download all reachable commits and trees while fetching blobs on-demand.