### PR TITLE
Ex CI: use clr amd-mainline temporarily

### DIFF
--- a/.azuredevops/templates/steps/dependencies-rocm.yml
+++ b/.azuredevops/templates/steps/dependencies-rocm.yml
@@ -66,7 +66,7 @@ parameters:
       hasGpuTarget: false
     clr:
       pipelineId: $(CLR_PIPELINE_ID)
-      stagingBranch: amd-staging
+      stagingBranch: amd-mainline
       mainlineBranch: amd-mainline
       hasGpuTarget: false
     composable_kernel:
@@ -81,7 +81,7 @@ parameters:
       hasGpuTarget: false
     HIP:
       pipelineId: $(HIP_PIPELINE_ID)
-      stagingBranch: amd-staging
+      stagingBranch: amd-mainline
       mainlineBranch: amd-mainline
       hasGpuTarget: false
     hip-tests:


### PR DESCRIPTION
Set the default CLR branch to download artifacts from to `amd-mainline` temporarily, as staging is currently unstable.