### PR TITLE
Ex CI: use clr amd-staging builds again

### DIFF
--- a/.azuredevops/templates/steps/dependencies-rocm.yml
+++ b/.azuredevops/templates/steps/dependencies-rocm.yml
@@ -66,7 +66,7 @@ parameters:
       hasGpuTarget: false
     clr:
       pipelineId: $(CLR_PIPELINE_ID)
-      stagingBranch: amd-mainline
+      stagingBranch: amd-staging
       mainlineBranch: amd-mainline
       hasGpuTarget: false
     composable_kernel:
@@ -81,7 +81,7 @@ parameters:
       hasGpuTarget: false
     HIP:
       pipelineId: $(HIP_PIPELINE_ID)
-      stagingBranch: amd-mainline
+      stagingBranch: amd-staging
       mainlineBranch: amd-mainline
       hasGpuTarget: false
     hip-tests:


### PR DESCRIPTION
amd-mainline clr is not functional. Instead we will switch back to amd-staging, delete all "bad" clr builds, and disable new builds until everything is stable again.

Currently I believe the bad builds started somewhere around https://github.com/ROCm/clr/commit/3cd3b3ffc5eba1def2b7a2b39ea9785dbdeddba7