### PR TITLE
Ex CI: pull rocPRIM builds from monorepo pipeline

### DIFF
--- a/.azuredevops/templates/steps/dependencies-rocm.yml
+++ b/.azuredevops/templates/steps/dependencies-rocm.yml
@@ -262,7 +262,7 @@ parameters:
     rocPRIM:
       pipelineId: $(ROCPRIM_PIPELINE_ID)
       stagingBranch: develop
-      mainlineBranch: mainline
+      mainlineBranch: develop
       hasGpuTarget: true
     rocprofiler:
       pipelineId: $(ROCPROFILER_PIPELINE_ID)

--- a/.azuredevops/variables-global.yml
+++ b/.azuredevops/variables-global.yml
@@ -258,7 +258,7 @@ variables:
 - name: ROCPRIM_GFX942_TEST_PIPELINE_ID
   value: 180
 - name: ROCPRIM_PIPELINE_ID
-  value: 82
+  value: 273
 - name: ROCPRIM_TAGGED_PIPELINE_ID
   value: 20
 - name: ROCPROFILER_GFX942_TEST_PIPELINE_ID


### PR DESCRIPTION
Changes pipelines to pull rocPRIM builds from the monorepo pipeline instead of the standalone pipeline. Also changes the mainline branch name since the monorepo has no mainline branch.

Sample rocThrust build:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=31343&view=results