### PR TITLE
Ex CI: remove SPARSEs as build dep for rocSOLVER

### DIFF
--- a/.azuredevops/components/rocSOLVER.yml
+++ b/.azuredevops/components/rocSOLVER.yml
@@ -26,14 +26,12 @@ parameters:
   type: object
   default:
     - clr
-    - hipSPARSE
     - llvm-project
     - rocBLAS
     - rocm-cmake
     - rocminfo
     - rocPRIM
     - ROCR-Runtime
-    - rocSPARSE
 - name: rocmTestDependencies
   type: object
   default:


### PR DESCRIPTION
Removes SPARSEs as build dependencies for rocSOLVER, to align with what's specified in TheRock.

Sample build log (tests are failing on develop as well):
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=31349&view=results