### PR TITLE
Ex CI: rocBLAS use cmake-latest

### DIFF
--- a/.azuredevops/components/rocBLAS.yml
+++ b/.azuredevops/components/rocBLAS.yml
@@ -96,6 +96,7 @@ jobs:
       parameters:
         aptPackages: ${{ parameters.aptPackages }}
         pipModules: ${{ parameters.pipModules }}
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-cmake-latest.yml
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
       parameters:


### PR DESCRIPTION
rocBLAS is recently failing to build following a Tensile commit bump in https://github.com/ROCm/rocBLAS/commit/319c45b525b40d9f548deab32cc794855224c42f. Upgrading the CMake version resolves this issue, though I'm not entirely sure why.

Sample build logs:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=31574&view=results