### PR TITLE
Ex CI: disable mathlibs-trigger triggers, fix template path

### DIFF
--- a/.azuredevops/ci-builds/mathlibs-trigger.yml
+++ b/.azuredevops/ci-builds/mathlibs-trigger.yml
@@ -23,8 +23,11 @@ resources:
     name: ROCm/rocm-libraries
     ref: ${{ parameters.librariesRepoRef }}
 
+trigger: none
+pr: none
+
 jobs:
-  - template: /.azuredevops/nightly/mathlibs.yml@pipelines_repo
+  - template: /.azuredevops/ci-builds/mathlibs.yml@pipelines_repo
     parameters:
       checkoutRepo: libraries_repo
       buildDependsOn: false


### PR DESCRIPTION
Disables mathlibs-trigger auto triggers, correct the mathlibs template path to `ci-builds/`