### PR TITLE
Ex CI: make miopen-get-ck-build only fetch from successful CK builds

### DIFF
--- a/.azuredevops/templates/steps/miopen-get-ck-build.yml
+++ b/.azuredevops/templates/steps/miopen-get-ck-build.yml
@@ -25,7 +25,7 @@ steps:
       echo "Fetching CK build ID for commit $CK_COMMIT"
       CK_CHECKS_URL="$GH_API/composable_kernel/commits/${CK_COMMIT}/check-runs"
       CK_BUILD_ID=$(curl -s $CK_CHECKS_URL | \
-        jq '.check_runs[] | select(.name == "composable_kernel" and .app.slug == "azure-pipelines") | .details_url' | \
+        jq '.check_runs[] | select(.name == "composable_kernel" and .app.slug == "azure-pipelines" and .conclusion == "success") | .details_url' | \
         tr -d '"' | grep -oP 'buildId=\K\d+')
 
       # If none found, use latest successful CK build instead


### PR DESCRIPTION
Previously, the get-ck script was not checking if the specific CK build was successful before downloading its artifacts. If a CK build existed for some commit but was not successful, the script would try to download from it anyways. This led to having no CK artifacts in the pipeline when building MIOpen.

This change makes the script fall back to the latest successful CK build if the specific CK build was not successful.

Sample run:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=31820&view=results