### PR TITLE
Ex CI: add rocm-cmake to hipBLASLt

### DIFF
--- a/.azuredevops/components/hipBLASLt.yml
+++ b/.azuredevops/components/hipBLASLt.yml
@@ -56,6 +56,7 @@ parameters:
     - hipBLAS-common
     - llvm-project
     - rocminfo
+    - rocm-cmake
     - rocm_smi_lib
     - rocprofiler-register
     - ROCR-Runtime


### PR DESCRIPTION
To fix build errors following https://github.com/ROCm/hipBLASLt/commit/ec77e485a0a6a4e3db72f4a73458dc54c9b8be7a

Sample run:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=31821&view=results