### PR TITLE
Update release notes with RHEL 9.6

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -78,11 +78,9 @@ R9700](https://www.amd.com/en/products/graphics/workstations/radeon-ai-pro/ai-90
 [Radeon RX 9070 XT](https://www.amd.com/en/products/graphics/desktops/radeon/9000-series/amd-radeon-rx-9070xt.html),
 Radeon RX 9070 GRE, and
 [Radeon RX 9060 XT](https://www.amd.com/en/products/graphics/desktops/radeon/9000-series/amd-radeon-rx-9060xt.html) GPUs
-for compute workloads. Currently, these GPUs are only supported on Ubuntu 24.04.2, Ubuntu 22.04.5, RHEL 9.5, and RHEL 9.4.
+for compute workloads. These GPUs are supported on Ubuntu 24.04.2, Ubuntu 22.04.5, RHEL 9.6, RHEL 9.5, and RHEL 9.4.
 For details, see the full list of [Supported GPUs
 (Linux)](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html#supported-gpus).
-
-Operating system support remains unchanged in this release.
 
 See the [Compatibility
 matrix](../../docs/compatibility/compatibility-matrix.rst)


### PR DESCRIPTION
Add RHEL 9.6 to release notes.