### PR TITLE
[External CI] AlmaLinux 8 job for clr and rocminfo

### DIFF
--- a/.azuredevops/components/HIP.yml
+++ b/.azuredevops/components/HIP.yml
@@ -20,7 +20,7 @@ parameters:
     - ocl-icd-libopencl1
     - ocl-icd-opencl-dev
     - opencl-headers
-    - python3-pip
+    - zlib1g-dev
 - name: pipModules
   type: object
   default:
@@ -41,120 +41,147 @@ parameters:
 # any changes for clr should just trigger HIP pipeline
 # similarly for hipother repo, for Nvidia backend
 
+- name: jobMatrix
+  type: object
+  default:
+    buildJobs:
+      - ubuntu2204:
+        os: ubuntu2204
+        packageManager: apt
+      - almalinux8:
+        os: almalinux8
+        packageManager: dnf
+
 # HIP with AMD backend
 jobs:
-- job: hip_clr_combined_amd
-  variables:
-  - group: common
-  - template: /.azuredevops/variables-global.yml
-  pool:
-    vmImage: ${{ variables.BASE_BUILD_POOL }}
-  workspace:
-    clean: all
-  steps:
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
-    parameters:
-      aptPackages: ${{ parameters.aptPackages }}
-      pipModules: ${{ parameters.pipModules }}
-# checkout triggering repo (either HIP or clr)
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
-    parameters:
-      checkoutRepo: ${{ parameters.checkoutRepo }}
-# if this is triggered by HIP repo, matching repo is clr
-# if this is triggered by clr repo, matching repo is HIP
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
-    parameters:
-      checkoutRepo: matching_repo
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
-    parameters:
-      checkoutRepo: hipother_repo
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
-    parameters:
-      checkoutRef: ${{ parameters.checkoutRef }}
-      dependencyList: ${{ parameters.rocmDependenciesAMD }}
-      aggregatePipeline: ${{ parameters.aggregatePipeline }}
-# compile clr
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
-    parameters:
-      componentName: clr
-      cmakeBuildDir: '$(Build.SourcesDirectory)/clr/build'
-      cmakeSourceDir: '$(Build.SourcesDirectory)/clr'
-      extraBuildFlags: >-
-        -DHIP_COMMON_DIR=$(Build.SourcesDirectory)/HIP
-        -DHIP_PLATFORM=amd
-        -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm
-        -DROCM_PATH=$(Agent.BuildDirectory)/rocm
-        -DHIPCC_BIN_DIR=$(Agent.BuildDirectory)/rocm/bin
-        -DCLR_BUILD_HIP=ON
-        -DCLR_BUILD_OCL=ON
-        -GNinja
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
-    parameters:
-      artifactName: amd
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
-    parameters:
-      artifactName: amd
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml
-  # - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/docker-container.yml
-  #   parameters:
-  #     aptPackages: ${{ parameters.aptPackages }}
-  #     pipModules: ${{ parameters.pipModules }}
-  #     environment: amd
+- ${{ each job in parameters.jobMatrix.buildJobs }}:
+  - job: hip_clr_combined_amd_${{ job.os }}
+    pool:
+      ${{ if eq(job.os, 'ubuntu2204') }}:
+        vmImage: 'ubuntu-22.04'
+      ${{ if eq(job.os, 'almalinux8') }}:
+        name: 'rocm-ci_low_build_pool_alma8'
+    variables:
+    - group: common
+    - template: /.azuredevops/variables-global.yml
+    workspace:
+      clean: all
+    steps:
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
+      parameters:
+        aptPackages: ${{ parameters.aptPackages }}
+        pipModules: ${{ parameters.pipModules }}
+        packageManager: ${{ job.packageManager }}
+  # checkout triggering repo (either HIP or clr)
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+      parameters:
+        checkoutRepo: ${{ parameters.checkoutRepo }}
+  # if this is triggered by HIP repo, matching repo is clr
+  # if this is triggered by clr repo, matching repo is HIP
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+      parameters:
+        checkoutRepo: matching_repo
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+      parameters:
+        checkoutRepo: hipother_repo
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
+      parameters:
+        checkoutRef: ${{ parameters.checkoutRef }}
+        dependencyList: ${{ parameters.rocmDependenciesAMD }}
+        aggregatePipeline: ${{ parameters.aggregatePipeline }}
+        os: ${{ job.os }}
+  # compile clr
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+      parameters:
+        componentName: clr
+        cmakeBuildDir: '$(Build.SourcesDirectory)/clr/build'
+        cmakeSourceDir: '$(Build.SourcesDirectory)/clr'
+        extraBuildFlags: >-
+          -DHIP_COMMON_DIR=$(Build.SourcesDirectory)/HIP
+          -DHIP_PLATFORM=amd
+          -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm
+          -DROCM_PATH=$(Agent.BuildDirectory)/rocm
+          -DHIPCC_BIN_DIR=$(Agent.BuildDirectory)/rocm/bin
+          -DCLR_BUILD_HIP=ON
+          -DCLR_BUILD_OCL=ON
+          -GNinja
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
+      parameters:
+        artifactName: amd
+        os: ${{ job.os }}
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
+      parameters:
+        artifactName: amd
+        os: ${{ job.os }}
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml
+    # - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/docker-container.yml
+    #   parameters:
+    #     aptPackages: ${{ parameters.aptPackages }}
+    #     pipModules: ${{ parameters.pipModules }}
+    #     environment: amd
 
 # HIP with Nvidia backend
-- job: hip_clr_combined_nvidia
-  variables:
-  - group: common
-  - template: /.azuredevops/variables-global.yml
-  pool:
-    vmImage: ${{ variables.BASE_BUILD_POOL }}
-  workspace:
-    clean: all
-  steps:
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
-    parameters:
-      aptPackages: ${{ parameters.aptPackages }}
-      pipModules: ${{ parameters.pipModules }}
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
-# checkout triggering repo (either HIP or clr)
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
-    parameters:
-      checkoutRepo: ${{ parameters.checkoutRepo }}
-# if this is triggered by HIP repo, matching repo is clr
-# if this is triggered by clr repo, matching repo is HIP
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
-    parameters:
-      checkoutRepo: matching_repo
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
-    parameters:
-      checkoutRepo: hipother_repo
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
-    parameters:
-      checkoutRef: ${{ parameters.checkoutRef }}
-      dependencyList: ${{ parameters.rocmDependenciesNvidia }}
-      aggregatePipeline: ${{ parameters.aggregatePipeline }}
-  - script: 'ls -1R $(Agent.BuildDirectory)/rocm'
-    displayName: 'Artifact listing'
-# compile clr
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
-    parameters:
-      componentName: clr
-      cmakeBuildDir: '$(Build.SourcesDirectory)/clr/build'
-      cmakeSourceDir: '$(Build.SourcesDirectory)/clr'
-      extraBuildFlags: >-
-        -DHIP_COMMON_DIR=$(Build.SourcesDirectory)/HIP
-        -DHIP_PLATFORM=nvidia
-        -DHIPCC_BIN_DIR=$(Agent.BuildDirectory)/rocm/bin
-        -DCLR_BUILD_HIP=ON
-        -DCLR_BUILD_OCL=OFF
-        -DHIPNV_DIR=$(Build.SourcesDirectory)/hipother/hipnv
-        -GNinja
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
-    parameters:
-      artifactName: nvidia
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml
-  # - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/docker-container.yml
-  #   parameters:
-  #     aptPackages: ${{ parameters.aptPackages }}
-  #     pipModules: ${{ parameters.pipModules }}
-  #     environment: nvidia
+- ${{ each job in parameters.jobMatrix.buildJobs }}:
+  - job: hip_clr_combined_nvidia_${{ job.os }}
+    pool:
+      ${{ if eq(job.os, 'ubuntu2204') }}:
+        vmImage: 'ubuntu-22.04'
+      ${{ if eq(job.os, 'almalinux8') }}:
+        name: 'rocm-ci_low_build_pool_alma8'
+    variables:
+    - group: common
+    - template: /.azuredevops/variables-global.yml
+    workspace:
+      clean: all
+    steps:
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
+      parameters:
+        aptPackages: ${{ parameters.aptPackages }}
+        pipModules: ${{ parameters.pipModules }}
+        packageManager: ${{ job.packageManager }}
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+  # checkout triggering repo (either HIP or clr)
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+      parameters:
+        checkoutRepo: ${{ parameters.checkoutRepo }}
+  # if this is triggered by HIP repo, matching repo is clr
+  # if this is triggered by clr repo, matching repo is HIP
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+      parameters:
+        checkoutRepo: matching_repo
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+      parameters:
+        checkoutRepo: hipother_repo
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
+      parameters:
+        checkoutRef: ${{ parameters.checkoutRef }}
+        dependencyList: ${{ parameters.rocmDependenciesNvidia }}
+        aggregatePipeline: ${{ parameters.aggregatePipeline }}
+        os: ${{ job.os }}
+        skipLlvmSymlink: true
+    - script: 'ls -1R $(Agent.BuildDirectory)/rocm'
+      displayName: 'Artifact listing'
+  # compile clr
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+      parameters:
+        componentName: clr
+        cmakeBuildDir: '$(Build.SourcesDirectory)/clr/build'
+        cmakeSourceDir: '$(Build.SourcesDirectory)/clr'
+        extraBuildFlags: >-
+          -DHIP_COMMON_DIR=$(Build.SourcesDirectory)/HIP
+          -DHIP_PLATFORM=nvidia
+          -DHIPCC_BIN_DIR=$(Agent.BuildDirectory)/rocm/bin
+          -DCLR_BUILD_HIP=ON
+          -DCLR_BUILD_OCL=OFF
+          -DHIPNV_DIR=$(Build.SourcesDirectory)/hipother/hipnv
+          -GNinja
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
+      parameters:
+        artifactName: nvidia
+        os: ${{ job.os }}
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml
+    # - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/docker-container.yml
+    #   parameters:
+    #     aptPackages: ${{ parameters.aptPackages }}
+    #     pipModules: ${{ parameters.pipModules }}
+    #     environment: nvidia

--- a/.azuredevops/components/rocminfo.yml
+++ b/.azuredevops/components/rocminfo.yml
@@ -17,7 +17,6 @@ parameters:
     - libdrm-amdgpu-dev
     - libdrm-dev
     - ninja-build
-    - python3-pip
 - name: rocmDependencies
   type: object
   default:
@@ -32,49 +31,70 @@ parameters:
 - name: jobMatrix
   type: object
   default:
+    buildJobs:
+      - ubuntu2204:
+        os: ubuntu2204
+        packageManager: apt
+      - almalinux8:
+        os: almalinux8
+        packageManager: dnf
     testJobs:
-      - gfx942:
+      - ubuntu2204_gfx942:
+        os: ubuntu2204
+        packageManager: apt
         target: gfx942
-      - gfx90a:
+      - ubuntu2204_gfx90a:
+        os: ubuntu2204
+        packageManager: apt
         target: gfx90a
 
 jobs:
-- job: rocminfo
-  variables:
-  - group: common
-  - template: /.azuredevops/variables-global.yml
-  pool:
-    vmImage: ${{ variables.BASE_BUILD_POOL }}
-  workspace:
-    clean: all
-  steps:
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
-    parameters:
-      aptPackages: ${{ parameters.aptPackages }}
-      registerROCmPackages: true
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
-    parameters:
-      checkoutRepo: ${{ parameters.checkoutRepo }}
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
-    parameters:
-      checkoutRef: ${{ parameters.checkoutRef }}
-      dependencyList: ${{ parameters.rocmDependencies }}
-      aggregatePipeline: ${{ parameters.aggregatePipeline }}
-      skipLlvmSymlink: true
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
-    parameters:
-      extraBuildFlags: >-
-        -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm
-        -DROCRTST_BLD_TYPE=release
-        -GNinja
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml
+- ${{ each job in parameters.jobMatrix.buildJobs }}:
+  - job: rocminfo_build_${{ job.os }}
+    pool:
+      ${{ if eq(job.os, 'ubuntu2204') }}:
+        vmImage: 'ubuntu-22.04'
+      ${{ if eq(job.os, 'almalinux8') }}:
+        name: 'rocm-ci_low_build_pool_alma8'
+    variables:
+    - group: common
+    - template: /.azuredevops/variables-global.yml
+    workspace:
+      clean: all
+    steps:
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
+      parameters:
+        aptPackages: ${{ parameters.aptPackages }}
+        packageManager: ${{ job.packageManager }}
+        registerROCmPackages: true
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
+      parameters:
+        checkoutRepo: ${{ parameters.checkoutRepo }}
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
+      parameters:
+        checkoutRef: ${{ parameters.checkoutRef }}
+        dependencyList: ${{ parameters.rocmDependencies }}
+        aggregatePipeline: ${{ parameters.aggregatePipeline }}
+        skipLlvmSymlink: true
+        os: ${{ job.os }}
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+      parameters:
+        extraBuildFlags: >-
+          -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm
+          -DROCRTST_BLD_TYPE=release
+          -GNinja
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
+      parameters:
+        os: ${{ job.os }}
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
+      parameters:
+        os: ${{ job.os }}
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml
 
 - ${{ each job in parameters.jobMatrix.testJobs }}:
   - job: rocminfo_test_${{ job.target }}
-    dependsOn: rocminfo
+    dependsOn: rocminfo_build_${{ job.os }}
     condition:
       and(succeeded(),
         eq(variables['ENABLE_${{ upper(job.target) }}_TESTS'], 'true'),
@@ -91,14 +111,18 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
       parameters:
         aptPackages: ${{ parameters.aptPackages }}
+        packageManager: ${{ job.packageManager }}
         registerROCmPackages: true
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/local-artifact-download.yml
+      parameters:
+        os: ${{ job.os }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
       parameters:
         checkoutRef: ${{ parameters.checkoutRef }}
         dependencyList: ${{ parameters.rocmTestDependencies }}
         gpuTarget: ${{ job.target }}
+        os: ${{ job.os }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/gpu-diagnostics.yml
       parameters:
         runRocminfo: false

--- a/.azuredevops/templates/steps/dependencies-dnf.yml
+++ b/.azuredevops/templates/steps/dependencies-dnf.yml
@@ -13,9 +13,14 @@ parameters:
     # note: doxygen-doc is not available in dnf
     # note: g++ is installed by default with gcc-toolset-14
     libdrm-dev: libdrm-devel
+    libdrm-amdgpu-dev: libdrm-amdgpu-devel
     libelf-dev: elfutils-libelf-devel
     libnuma-dev: numactl-devel
+    mesa-common-dev: mesa-libGL-devel
     # note: llvm needs ninja-build version newer than what dnf provides
+    ocl-icd-libopencl1: ocl-icd
+    ocl-icd-opencl-dev: ocl-icd-devel
+    opencl-headers: opencl-headers
     pkg-config: pkgconf-pkg-config
     # note: python3 is the default python in AlmaLinux 8
     # and python3-pip is already installed when updating to python 3.11
@@ -31,13 +36,13 @@ steps:
         sudo rpm --import https://repo.radeon.com/rocm/rocm.gpg.key
         echo '[amdgpu]' | sudo tee /etc/yum.repos.d/amdgpu.repo > /dev/null
         echo "name=amdgpu" | sudo tee --append /etc/yum.repos.d/amdgpu.repo
-        echo "baseurl=https://repo.radeon.com/amdgpu/$(REPO_RADEON_VERSION)/rhel/8.10/" | sudo tee --append /etc/yum.repos.d/amdgpu.repo
+        echo "baseurl=https://repo.radeon.com/amdgpu/$(REPO_RADEON_VERSION)/rhel/8.10/main/x86_64/" | sudo tee --append /etc/yum.repos.d/amdgpu.repo
         echo "enabled=1" | sudo tee --append /etc/yum.repos.d/amdgpu.repo
         echo "gpgcheck=1" | sudo tee --append /etc/yum.repos.d/amdgpu.repo
         echo "gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key" | sudo tee --append /etc/yum.repos.d/amdgpu.repo
         echo '[rocm]' | sudo tee /etc/yum.repos.d/rocm.repo > /dev/null
         echo "name=ROCm$(REPO_RADEON_VERSION)" | sudo tee --append /etc/yum.repos.d/rocm.repo
-        echo "baseurl=https://repo.radeon.com/rocm/yum/$(REPO_RADEON_VERSION)/" | sudo tee --append /etc/yum.repos.d/rocm.repo
+        echo "baseurl=https://repo.radeon.com/rocm/rhel8/$(REPO_RADEON_VERSION)/main/" | sudo tee --append /etc/yum.repos.d/rocm.repo
         echo "enabled=1" | sudo tee --append /etc/yum.repos.d/rocm.repo
         echo "gpgcheck=1" | sudo tee --append /etc/yum.repos.d/rocm.repo
         echo "gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key" | sudo tee --append /etc/yum.repos.d/rocm.repo
@@ -49,7 +54,7 @@ steps:
     targetType: inline
     script: |
       sudo dnf config-manager --set-enabled powertools
-      sudo dnf -y install epel-release git jq vim-common
+      sudo dnf -y install epel-release git jq vim-common libstdc++-devel
 - task: Bash@3
   displayName: 'Install gcc-toolset-14'
   inputs:


### PR DESCRIPTION
- Added more dnf package mappings and a base-level dependency.
- Fix registering for ROCm packages with dnf.
- [rocminfo build log](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=32016&view=results)
- [clr/hip build log](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=32025&view=results)