### PR TITLE
[External CI] clr/hip workaround

### DIFF
--- a/.azuredevops/components/HIP.yml
+++ b/.azuredevops/components/HIP.yml
@@ -35,6 +35,18 @@ parameters:
   type: object
   default:
     - llvm-project
+- name: repos
+  type: object
+  default:
+    - hip:
+      url: 'https://github.com/ROCm/HIP.git'
+      commit: 'efee830'
+    - clr:
+      url: 'https://github.com/ROCm/clr.git'
+      commit: '78f3cab'
+    - hipother:
+      url: 'https://github.com/ROCm/hipother.git'
+      commit: 'e0ff75f'
 
 # hip and clr are tightly-coupled
 # run this same template for both repos
@@ -72,18 +84,16 @@ jobs:
         aptPackages: ${{ parameters.aptPackages }}
         pipModules: ${{ parameters.pipModules }}
         packageManager: ${{ job.packageManager }}
-  # checkout triggering repo (either HIP or clr)
-    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
-      parameters:
-        checkoutRepo: ${{ parameters.checkoutRepo }}
-  # if this is triggered by HIP repo, matching repo is clr
-  # if this is triggered by clr repo, matching repo is HIP
-    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
-      parameters:
-        checkoutRepo: matching_repo
-    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
-      parameters:
-        checkoutRepo: hipother_repo
+    - ${{ each repoName in parameters.repos }}:
+      - task: Bash@3
+        displayName: 'Clone ${{ repoName }} @ ${{ parameters.repos[repoName].commit }}'
+        inputs:
+          targetType: inline
+          script: |
+            echo "Cloning ${{ parameters.repos[repoName].url }}..."
+            git clone ${{ parameters.repos[repoName].url }} ${{ repoName }}
+            cd ${{ repoName }}
+            git checkout ${{ parameters.repos[repoName].commit }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
       parameters:
         checkoutRef: ${{ parameters.checkoutRef }}
@@ -140,18 +150,16 @@ jobs:
         pipModules: ${{ parameters.pipModules }}
         packageManager: ${{ job.packageManager }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
-  # checkout triggering repo (either HIP or clr)
-    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
-      parameters:
-        checkoutRepo: ${{ parameters.checkoutRepo }}
-  # if this is triggered by HIP repo, matching repo is clr
-  # if this is triggered by clr repo, matching repo is HIP
-    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
-      parameters:
-        checkoutRepo: matching_repo
-    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
-      parameters:
-        checkoutRepo: hipother_repo
+    - ${{ each repoName in parameters.repos }}:
+      - task: Bash@3
+        displayName: 'Clone ${{ repoName }} @ ${{ parameters.repos[repoName].commit }}'
+        inputs:
+          targetType: inline
+          script: |
+            echo "Cloning ${{ parameters.repos[repoName].url }}..."
+            git clone ${{ parameters.repos[repoName].url }} ${{ repoName }}
+            cd ${{ repoName }}
+            git checkout ${{ parameters.repos[repoName].commit }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
       parameters:
         checkoutRef: ${{ parameters.checkoutRef }}

--- a/.azuredevops/components/HIP.yml
+++ b/.azuredevops/components/HIP.yml
@@ -88,6 +88,7 @@ jobs:
         aptPackages: ${{ parameters.aptPackages }}
         pipModules: ${{ parameters.pipModules }}
         packageManager: ${{ job.packageManager }}
+    - checkout: none
     - ${{ each repo in parameters.repos.cloneRepos }}:
       - task: Bash@3
         displayName: 'Clone ${{ repo.name }} @ ${{ repo.commit }}'
@@ -154,6 +155,7 @@ jobs:
         pipModules: ${{ parameters.pipModules }}
         packageManager: ${{ job.packageManager }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+    - checkout: none
     - ${{ each repo in parameters.repos.cloneRepos }}:
       - task: Bash@3
         displayName: 'Clone ${{ repo.name }} @ ${{ repo.commit }}'

--- a/.azuredevops/components/HIP.yml
+++ b/.azuredevops/components/HIP.yml
@@ -38,15 +38,19 @@ parameters:
 - name: repos
   type: object
   default:
-    - hip:
-      url: 'https://github.com/ROCm/HIP.git'
-      commit: 'efee830'
-    - clr:
-      url: 'https://github.com/ROCm/clr.git'
-      commit: '78f3cab'
-    - hipother:
-      url: 'https://github.com/ROCm/hipother.git'
-      commit: 'e0ff75f'
+    cloneRepos:
+      - hip:
+        name: 'HIP'
+        url: 'https://github.com/ROCm/HIP.git'
+        commit: 'efee830'
+      - clr:
+        name: 'clr'
+        url: 'https://github.com/ROCm/clr.git'
+        commit: '78f3cab'
+      - hipother:
+        name: 'hipother'
+        url: 'https://github.com/ROCm/hipother.git'
+        commit: 'e0ff75f'
 
 # hip and clr are tightly-coupled
 # run this same template for both repos
@@ -84,16 +88,16 @@ jobs:
         aptPackages: ${{ parameters.aptPackages }}
         pipModules: ${{ parameters.pipModules }}
         packageManager: ${{ job.packageManager }}
-    - ${{ each repoName in parameters.repos }}:
+    - ${{ each repo in parameters.repos.cloneRepos }}:
       - task: Bash@3
-        displayName: 'Clone ${{ repoName }} @ ${{ parameters.repos[repoName].commit }}'
+        displayName: 'Clone ${{ repo.name }} @ ${{ repo.commit }}'
         inputs:
           targetType: inline
           script: |
-            echo "Cloning ${{ parameters.repos[repoName].url }}..."
-            git clone ${{ parameters.repos[repoName].url }} ${{ repoName }}
-            cd ${{ repoName }}
-            git checkout ${{ parameters.repos[repoName].commit }}
+            echo "Cloning ${{ repo.name }}..."
+            git clone ${{ repo.url }} ${{ repo.name }}
+            cd ${{ repo.name }}
+            git checkout ${{ repo.commit }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
       parameters:
         checkoutRef: ${{ parameters.checkoutRef }}
@@ -150,16 +154,16 @@ jobs:
         pipModules: ${{ parameters.pipModules }}
         packageManager: ${{ job.packageManager }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
-    - ${{ each repoName in parameters.repos }}:
+    - ${{ each repo in parameters.repos.cloneRepos }}:
       - task: Bash@3
-        displayName: 'Clone ${{ repoName }} @ ${{ parameters.repos[repoName].commit }}'
+        displayName: 'Clone ${{ repo.name }} @ ${{ repo.commit }}'
         inputs:
           targetType: inline
           script: |
-            echo "Cloning ${{ parameters.repos[repoName].url }}..."
-            git clone ${{ parameters.repos[repoName].url }} ${{ repoName }}
-            cd ${{ repoName }}
-            git checkout ${{ parameters.repos[repoName].commit }}
+            echo "Cloning ${{ repo.name }}..."
+            git clone ${{ repo.url }} ${{ repo.name }}
+            cd ${{ repo.name }}
+            git checkout ${{ repo.commit }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
       parameters:
         checkoutRef: ${{ parameters.checkoutRef }}


### PR DESCRIPTION
- Build specific commit hashes to enable more OS profiles to be built up
- Revert this pull request when clr/hip fixed.
- [Build Log](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=32044&view=results)