### PR TITLE
Ex CI: manifest changes to support monorepo & mathlibs builds

### DIFF
--- a/.azuredevops/components/hipBLAS-common.yml
+++ b/.azuredevops/components/hipBLAS-common.yml
@@ -95,6 +95,7 @@ jobs:
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
     parameters:
       componentName: ${{ parameters.componentName }}
+      sparseCheckoutDir: ${{ parameters.sparseCheckoutDir }}
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
     parameters:
       componentName: ${{ parameters.componentName }}

--- a/.azuredevops/components/hipBLASLt.yml
+++ b/.azuredevops/components/hipBLASLt.yml
@@ -196,6 +196,7 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
       parameters:
         componentName: ${{ parameters.componentName }}
+        sparseCheckoutDir: ${{ parameters.sparseCheckoutDir }}
         gpuTarget: ${{ job.target }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
       parameters:

--- a/.azuredevops/components/hipCUB.yml
+++ b/.azuredevops/components/hipCUB.yml
@@ -43,7 +43,7 @@ parameters:
     - clr
     - llvm-project
     - rocminfo
-    # - rocPRIM
+    - rocPRIM
     - ROCR-Runtime
 - name: rocmTestDependencies
   type: object
@@ -89,11 +89,6 @@ jobs:
       parameters:
         checkoutRepo: ${{ parameters.checkoutRepo }}
         sparseCheckoutDir: ${{ parameters.sparseCheckoutDir }}
-    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/local-artifact-download.yml
-      parameters:
-        gpuTarget: ${{ job.target }}
-        buildType: specific
-        buildId: 32325
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
       parameters:
         checkoutRef: ${{ parameters.checkoutRef }}
@@ -114,6 +109,7 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
       parameters:
         componentName: ${{ parameters.componentName }}
+        sparseCheckoutDir: ${{ parameters.sparseCheckoutDir }}
         gpuTarget: ${{ job.target }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
       parameters:

--- a/.azuredevops/components/hipCUB.yml
+++ b/.azuredevops/components/hipCUB.yml
@@ -91,7 +91,6 @@ jobs:
         sparseCheckoutDir: ${{ parameters.sparseCheckoutDir }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/local-artifact-download.yml
       parameters:
-        preTargetFilter: ${{ parameters.componentName }}
         gpuTarget: ${{ job.target }}
         buildType: specific
         buildId: 32325

--- a/.azuredevops/components/hipCUB.yml
+++ b/.azuredevops/components/hipCUB.yml
@@ -43,7 +43,7 @@ parameters:
     - clr
     - llvm-project
     - rocminfo
-    - rocPRIM
+    # - rocPRIM
     - ROCR-Runtime
 - name: rocmTestDependencies
   type: object
@@ -89,6 +89,12 @@ jobs:
       parameters:
         checkoutRepo: ${{ parameters.checkoutRepo }}
         sparseCheckoutDir: ${{ parameters.sparseCheckoutDir }}
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/local-artifact-download.yml
+      parameters:
+        preTargetFilter: ${{ parameters.componentName }}
+        gpuTarget: ${{ job.target }}
+        buildType: specific
+        buildId: 32325
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
       parameters:
         checkoutRef: ${{ parameters.checkoutRef }}

--- a/.azuredevops/components/hipRAND.yml
+++ b/.azuredevops/components/hipRAND.yml
@@ -114,6 +114,7 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
       parameters:
         componentName: ${{ parameters.componentName }}
+        sparseCheckoutDir: ${{ parameters.sparseCheckoutDir }}
         gpuTarget: ${{ job.target }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
       parameters:

--- a/.azuredevops/components/rocBLAS.yml
+++ b/.azuredevops/components/rocBLAS.yml
@@ -177,6 +177,7 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
       parameters:
         componentName: ${{ parameters.componentName }}
+        sparseCheckoutDir: ${{ parameters.sparseCheckoutDir }}
         gpuTarget: ${{ job.target }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
       parameters:

--- a/.azuredevops/components/rocPRIM.yml
+++ b/.azuredevops/components/rocPRIM.yml
@@ -140,6 +140,7 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
       parameters:
         componentName: ${{ parameters.componentName }}
+        sparseCheckoutDir: ${{ parameters.sparseCheckoutDir }}
         gpuTarget: ${{ job.target }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
       parameters:

--- a/.azuredevops/components/rocRAND.yml
+++ b/.azuredevops/components/rocRAND.yml
@@ -123,6 +123,7 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
       parameters:
         componentName: ${{ parameters.componentName }}
+        sparseCheckoutDir: ${{ parameters.sparseCheckoutDir }}
         gpuTarget: ${{ job.target }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
       parameters:

--- a/.azuredevops/components/rocSOLVER.yml
+++ b/.azuredevops/components/rocSOLVER.yml
@@ -143,6 +143,7 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
       parameters:
         componentName: ${{ parameters.componentName }}
+        sparseCheckoutDir: ${{ parameters.sparseCheckoutDir }}
         gpuTarget: ${{ job.target }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
       parameters:

--- a/.azuredevops/components/rocThrust.yml
+++ b/.azuredevops/components/rocThrust.yml
@@ -111,6 +111,7 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
       parameters:
         componentName: ${{ parameters.componentName }}
+        sparseCheckoutDir: ${{ parameters.sparseCheckoutDir }}
         gpuTarget: ${{ job.target }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
       parameters:

--- a/.azuredevops/templates/steps/manifest.yml
+++ b/.azuredevops/templates/steps/manifest.yml
@@ -34,8 +34,9 @@ steps:
 
       IS_TAG_BUILD=$(jq 'has("release_repo")' resources.repositories)
       IS_AOMP_BUILD=$(jq 'has("aomp_repo")' resources.repositories)
+      IS_MATHLIBS_BUILD=$(jq 'has("libraries_repo")' resources.repositories)
 
-      if [ "$IS_TAG_BUILD" = "true" ] || [ "$IS_AOMP_BUILD" = "true" ]; then
+      if [ "$IS_TAG_BUILD" = "true" ] || [ "$IS_AOMP_BUILD" = "true" ] || [ "$IS_MATHLIBS_BUILD" = "true" ]; then
         exclude_keys=("pipelines_repo" "self") # Triggered by a file under ROCm/ROCm
       else
         exclude_keys=("pipelines_repo") # Triggered by a file under a component repo

--- a/.azuredevops/templates/steps/manifest.yml
+++ b/.azuredevops/templates/steps/manifest.yml
@@ -2,6 +2,9 @@ parameters:
 - name: componentName
   type: string
   default: $(Build.DefinitionName)
+- name: sparseCheckoutDir
+  type: string
+  default: ''
 - name: gpuTarget
   type: string
   default: ''
@@ -51,6 +54,7 @@ steps:
               buildId: "$(Build.BuildId)",
               repoId: $entry.value.id,
               repoName: $entry.value.name,
+              repoSparse: "${{ parameters.sparseCheckoutDir }}",
               repoRef: $entry.value.ref,
               repoUrl: $entry.value.url,
               repoVersion: $entry.value.version
@@ -87,6 +91,7 @@ steps:
           "<tr><td>" + .buildNumber + "</td>" +
           "<td><a href=\"https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=" + .buildId + "\">" + .buildId + "</a></td>" +
           "<td><a href=\"" + .repoUrl + "\">" + .repoName + "</a></td>" +
+          "<td><a href=\"" + .repoUrl + "/tree/" + .repoRef + "/" + .repoSparse + "\">" + .repoSparse + "</a></td>" +
           "<td><a href=\"" + .repoUrl + "/tree/" + .repoRef + "\">" + .repoRef + "</a></td>" +
           "<td><a href=\"" + .repoUrl + "/commit/" + .repoVersion + "\">" + .repoVersion + "</a></td></tr>"
         ')
@@ -99,6 +104,7 @@ steps:
           "<tr><td>" + .buildNumber + "</td>" +
           "<td><a href=\"https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=" + .buildId + "\">" + .buildId + "</a></td>" +
           "<td><a href=\"" + .repoUrl + "\">" + .repoName + "</a></td>" +
+          "<td><a href=\"" + .repoUrl + "/tree/" + .repoRef + "/" + .repoSparse + "\">" + .repoSparse + "</a></td>" +
           "<td><a href=\"" + .repoUrl + "/tree/" + .repoRef + "\">" + .repoRef + "</a></td>" +
           "<td><a href=\"" + .repoUrl + "/commit/" + .repoVersion + "\">" + .repoVersion + "</a></td></tr>"
         ')
@@ -123,6 +129,7 @@ steps:
         <th>Build Number</th>
         <th>Build ID</th>
         <th>Repo Name</th>
+        <th>Repo Sparse</th>
         <th>Repo Ref</th>
         <th>Repo Version</th>
       </tr>
@@ -134,6 +141,7 @@ steps:
         <th>Build Number</th>
         <th>Build ID</th>
         <th>Repo Name</th>
+        <th>Repo Sparse</th>
         <th>Repo Ref</th>
         <th>Repo Version</th>
       </tr>


### PR DESCRIPTION
Adds a sparse checkout directory field in manifests to differentiate between monorepo builds that originate from the same repo. Also adds in some logic to check if the current run is part of a unified mathlibs build.

Sample:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=32352&view=awardedsolutions.azure-pipelines-html-report-awardedsolutions.build-html-report-tab
![image](https://github.com/user-attachments/assets/533e4a9d-fdba-4b85-a166-ad3a61472f79)
