### PR TITLE
Ex CI: switch all prims to monorepo

### DIFF
--- a/.azuredevops/templates/steps/dependencies-rocm.yml
+++ b/.azuredevops/templates/steps/dependencies-rocm.yml
@@ -110,7 +110,7 @@ parameters:
     hipCUB:
       pipelineId: $(HIPCUB_PIPELINE_ID)
       stagingBranch: develop
-      mainlineBranch: mainline
+      mainlineBranch: develop
       hasGpuTarget: true
     hipFFT:
       pipelineId: $(HIPFFT_PIPELINE_ID)
@@ -330,7 +330,7 @@ parameters:
     rocThrust:
       pipelineId: $(ROCTHRUST_PIPELINE_ID)
       stagingBranch: develop
-      mainlineBranch: mainline
+      mainlineBranch: develop
       hasGpuTarget: true
     roctracer:
       pipelineId: $(ROCTRACER_PIPELINE_ID)

--- a/.azuredevops/variables-global.yml
+++ b/.azuredevops/variables-global.yml
@@ -108,7 +108,7 @@ variables:
 - name: HIPCUB_GFX942_TEST_PIPELINE_ID
   value: 186
 - name: HIPCUB_PIPELINE_ID
-  value: 97
+  value: 277
 - name: HIPCUB_TAGGED_PIPELINE_ID
   value: 46
 - name: HIPFFT_GFX942_TEST_PIPELINE_ID
@@ -320,7 +320,7 @@ variables:
 - name: ROCTHRUST_GFX942_TEST_PIPELINE_ID
   value: 194
 - name: ROCTHRUST_PIPELINE_ID
-  value: 94
+  value: 276
 - name: ROCTHRUST_TAGGED_PIPELINE_ID
   value: 26
 - name: ROCTRACER_GFX942_TEST_PIPELINE_ID


### PR DESCRIPTION
Switch rocThrust and hipCUB to their monorepo pipelines.