### PR TITLE
Ex CI: add msgpack to rocm-examples

### DIFF
--- a/.azuredevops/components/rocm-examples.yml
+++ b/.azuredevops/components/rocm-examples.yml
@@ -15,6 +15,7 @@ parameters:
   default:
     - cmake
     - libglfw3-dev
+    - libmsgpack-dev
     - libtbb-dev
     - ninja-build
     - python3-pip


### PR DESCRIPTION
To fix runtime test failures.

Sample logs:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=33011&view=results

cc: @zichguan-amd 