### PR TITLE
[Ex CI] move from almalinux pool to manylinux containers

### DIFF
--- a/.azuredevops/components/HIP.yml
+++ b/.azuredevops/components/HIP.yml
@@ -183,7 +183,6 @@ jobs:
         cmakeBuildDir: '$(Build.SourcesDirectory)/clr/build'
         cmakeSourceDir: '$(Build.SourcesDirectory)/clr'
         os: ${{ job.os }}
-        useAmdclang: false
         extraBuildFlags: >-
           -DHIP_COMMON_DIR=$(Build.SourcesDirectory)/HIP
           -DHIP_PLATFORM=nvidia

--- a/.azuredevops/components/HIP.yml
+++ b/.azuredevops/components/HIP.yml
@@ -69,8 +69,7 @@ jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
   - job: hip_clr_combined_amd_${{ job.os }}
     pool:
-      ${{ if or(eq(job.os, 'ubuntu2204'), eq(job.os, 'almalinux8')) }}:
-        vmImage: 'ubuntu-22.04'
+      vmImage: 'ubuntu-22.04'
     ${{ if eq(job.os, 'almalinux8') }}:
       container:
         image: rocmexternalcicd.azurecr.io/manylinux228:latest
@@ -139,8 +138,7 @@ jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
   - job: hip_clr_combined_nvidia_${{ job.os }}
     pool:
-      ${{ if or(eq(job.os, 'ubuntu2204'), eq(job.os, 'almalinux8')) }}:
-        vmImage: 'ubuntu-22.04'
+      vmImage: 'ubuntu-22.04'
     ${{ if eq(job.os, 'almalinux8') }}:
       container:
         image: rocmexternalcicd.azurecr.io/manylinux228:latest

--- a/.azuredevops/components/HIP.yml
+++ b/.azuredevops/components/HIP.yml
@@ -69,10 +69,12 @@ jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
   - job: hip_clr_combined_amd_${{ job.os }}
     pool:
-      ${{ if eq(job.os, 'ubuntu2204') }}:
+      ${{ if or(eq(job.os, 'ubuntu2204'), eq(job.os, 'almalinux8')) }}:
         vmImage: 'ubuntu-22.04'
-      ${{ if eq(job.os, 'almalinux8') }}:
-        name: 'rocm-ci_low_build_pool_alma8'
+    ${{ if eq(job.os, 'almalinux8') }}:
+      container:
+        image: rocmexternalcicd.azurecr.io/manylinux228:latest
+        endpoint: ContainerService3
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
@@ -108,6 +110,7 @@ jobs:
         cmakeBuildDir: '$(Build.SourcesDirectory)/clr/build'
         cmakeSourceDir: '$(Build.SourcesDirectory)/clr'
         os: ${{ job.os }}
+        useAmdclang: false
         extraBuildFlags: >-
           -DHIP_COMMON_DIR=$(Build.SourcesDirectory)/HIP
           -DHIP_PLATFORM=amd
@@ -136,10 +139,12 @@ jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
   - job: hip_clr_combined_nvidia_${{ job.os }}
     pool:
-      ${{ if eq(job.os, 'ubuntu2204') }}:
+      ${{ if or(eq(job.os, 'ubuntu2204'), eq(job.os, 'almalinux8')) }}:
         vmImage: 'ubuntu-22.04'
-      ${{ if eq(job.os, 'almalinux8') }}:
-        name: 'rocm-ci_low_build_pool_alma8'
+    ${{ if eq(job.os, 'almalinux8') }}:
+      container:
+        image: rocmexternalcicd.azurecr.io/manylinux228:latest
+        endpoint: ContainerService3
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
@@ -178,6 +183,7 @@ jobs:
         cmakeBuildDir: '$(Build.SourcesDirectory)/clr/build'
         cmakeSourceDir: '$(Build.SourcesDirectory)/clr'
         os: ${{ job.os }}
+        useAmdclang: false
         extraBuildFlags: >-
           -DHIP_COMMON_DIR=$(Build.SourcesDirectory)/HIP
           -DHIP_PLATFORM=nvidia

--- a/.azuredevops/components/HIP.yml
+++ b/.azuredevops/components/HIP.yml
@@ -183,6 +183,7 @@ jobs:
         cmakeBuildDir: '$(Build.SourcesDirectory)/clr/build'
         cmakeSourceDir: '$(Build.SourcesDirectory)/clr'
         os: ${{ job.os }}
+        useAmdclang: false
         extraBuildFlags: >-
           -DHIP_COMMON_DIR=$(Build.SourcesDirectory)/HIP
           -DHIP_PLATFORM=nvidia

--- a/.azuredevops/components/ROCR-Runtime.yml
+++ b/.azuredevops/components/ROCR-Runtime.yml
@@ -46,10 +46,12 @@ jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
   - job: ROCR_Runtime_build_${{ job.os }}
     pool:
-      ${{ if eq(job.os, 'ubuntu2204') }}:
+      ${{ if or(eq(job.os, 'ubuntu2204'), eq(job.os, 'almalinux8')) }}:
         vmImage: 'ubuntu-22.04'
-      ${{ if eq(job.os, 'almalinux8') }}:
-        name: 'rocm-ci_low_build_pool_alma8'
+    ${{ if eq(job.os, 'almalinux8') }}:
+      container:
+        image: rocmexternalcicd.azurecr.io/manylinux228:latest
+        endpoint: ContainerService3
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
@@ -73,6 +75,7 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
       parameters:
         os: ${{ job.os }}
+        useAmdclang: false
         extraBuildFlags: >-
           -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm
           -DBUILD_SHARED_LIBS=ON

--- a/.azuredevops/components/ROCR-Runtime.yml
+++ b/.azuredevops/components/ROCR-Runtime.yml
@@ -46,8 +46,7 @@ jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
   - job: ROCR_Runtime_build_${{ job.os }}
     pool:
-      ${{ if or(eq(job.os, 'ubuntu2204'), eq(job.os, 'almalinux8')) }}:
-        vmImage: 'ubuntu-22.04'
+      vmImage: 'ubuntu-22.04'
     ${{ if eq(job.os, 'almalinux8') }}:
       container:
         image: rocmexternalcicd.azurecr.io/manylinux228:latest

--- a/.azuredevops/components/ROCdbgapi.yml
+++ b/.azuredevops/components/ROCdbgapi.yml
@@ -34,10 +34,12 @@ jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
   - job: ROCdbgapi_build_${{ job.os }}
     pool:
-      ${{ if eq(job.os, 'ubuntu2204') }}:
+      ${{ if or(eq(job.os, 'ubuntu2204'), eq(job.os, 'almalinux8')) }}:
         vmImage: 'ubuntu-22.04'
-      ${{ if eq(job.os, 'almalinux8') }}:
-        name: 'rocm-ci_low_build_pool_alma8'
+    ${{ if eq(job.os, 'almalinux8') }}:
+      container:
+        image: rocmexternalcicd.azurecr.io/manylinux228:latest
+        endpoint: ContainerService3
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
@@ -61,6 +63,7 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
       parameters:
         os: ${{ job.os }}
+        useAmdclang: false
         extraBuildFlags: >-
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm

--- a/.azuredevops/components/ROCdbgapi.yml
+++ b/.azuredevops/components/ROCdbgapi.yml
@@ -34,8 +34,7 @@ jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
   - job: ROCdbgapi_build_${{ job.os }}
     pool:
-      ${{ if or(eq(job.os, 'ubuntu2204'), eq(job.os, 'almalinux8')) }}:
-        vmImage: 'ubuntu-22.04'
+      vmImage: 'ubuntu-22.04'
     ${{ if eq(job.os, 'almalinux8') }}:
       container:
         image: rocmexternalcicd.azurecr.io/manylinux228:latest

--- a/.azuredevops/components/amdsmi.yml
+++ b/.azuredevops/components/amdsmi.yml
@@ -33,12 +33,14 @@ jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
   - job: amdsmi_build_${{ job.os }}
     pool:
-      ${{ if eq(job.os, 'ubuntu2204') }}:
+      ${{ if or(eq(job.os, 'ubuntu2204'), eq(job.os, 'almalinux8')) }}:
         vmImage: 'ubuntu-22.04'
       ${{ if eq(job.os, 'ubuntu2404') }}:
         vmImage: 'ubuntu-24.04'
-      ${{ if eq(job.os, 'almalinux8') }}:
-        name: 'rocm-ci_low_build_pool_alma8'
+    ${{ if eq(job.os, 'almalinux8') }}:
+      container:
+        image: rocmexternalcicd.azurecr.io/manylinux228:latest
+        endpoint: ContainerService3
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml

--- a/.azuredevops/components/amdsmi.yml
+++ b/.azuredevops/components/amdsmi.yml
@@ -58,6 +58,7 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
       parameters:
         os: ${{ job.os }}
+        useAmdclang: false
         extraBuildFlags: >-
           -DBUILD_TESTS=ON
           -GNinja

--- a/.azuredevops/components/amdsmi.yml
+++ b/.azuredevops/components/amdsmi.yml
@@ -33,10 +33,10 @@ jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
   - job: amdsmi_build_${{ job.os }}
     pool:
-      ${{ if or(eq(job.os, 'ubuntu2204'), eq(job.os, 'almalinux8')) }}:
-        vmImage: 'ubuntu-22.04'
       ${{ if eq(job.os, 'ubuntu2404') }}:
         vmImage: 'ubuntu-24.04'
+      ${{ else }}:
+        vmImage: 'ubuntu-22.04'
     ${{ if eq(job.os, 'almalinux8') }}:
       container:
         image: rocmexternalcicd.azurecr.io/manylinux228:latest

--- a/.azuredevops/components/llvm-project.yml
+++ b/.azuredevops/components/llvm-project.yml
@@ -36,8 +36,7 @@ jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
   - job: llvm_project_${{ job.os }}
     pool:
-      ${{ if or(eq(job.os, 'ubuntu2204'), eq(job.os, 'almalinux8')) }}:
-        name: 'rocm-ci_ultra_build_pool'
+      name: 'rocm-ci_ultra_build_pool'
     ${{ if eq(job.os, 'almalinux8') }}:
       container:
         image: rocmexternalcicd.azurecr.io/manylinux228:latest

--- a/.azuredevops/components/llvm-project.yml
+++ b/.azuredevops/components/llvm-project.yml
@@ -36,10 +36,12 @@ jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
   - job: llvm_project_${{ job.os }}
     pool:
-      ${{ if eq(job.os, 'ubuntu2204') }}:
+      ${{ if or(eq(job.os, 'ubuntu2204'), eq(job.os, 'almalinux8')) }}:
         name: 'rocm-ci_ultra_build_pool'
-      ${{ if eq(job.os, 'almalinux8') }}:
-        name: 'rocm-ci_ultra_build_pool_alma8'
+    ${{ if eq(job.os, 'almalinux8') }}:
+      container:
+        image: rocmexternalcicd.azurecr.io/manylinux228:latest
+        endpoint: ContainerService3
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
@@ -69,6 +71,7 @@ jobs:
       parameters:
         componentName: rocm-llvm
         os: ${{ job.os }}
+        useAmdclang: false
         extraBuildFlags: >-
           -DCMAKE_PREFIX_PATH="$(Build.BinariesDirectory)/llvm;$(Build.BinariesDirectory)"
           -DCMAKE_BUILD_TYPE=Release
@@ -138,6 +141,7 @@ jobs:
       parameters:
         componentName: device-libs
         os: ${{ job.os }}
+        useAmdclang: false
         extraBuildFlags: >-
           -DCMAKE_PREFIX_PATH="$(Build.SourcesDirectory)/llvm/build"
           -DCMAKE_BUILD_TYPE=Release
@@ -147,6 +151,7 @@ jobs:
       parameters:
         componentName: comgr
         os: ${{ job.os }}
+        useAmdclang: false
         extraBuildFlags: >-
           -DCMAKE_PREFIX_PATH="$(Build.SourcesDirectory)/llvm/build;$(Build.SourcesDirectory)/amd/device-libs/build"
           -DCOMGR_DISABLE_SPIRV=1
@@ -164,6 +169,7 @@ jobs:
       parameters:
         componentName: hipcc
         os: ${{ job.os }}
+        useAmdclang: false
         extraBuildFlags: >-
           -DCMAKE_BUILD_TYPE=Release
           -DHIPCC_BACKWARD_COMPATIBILITY=OFF

--- a/.azuredevops/components/llvm-project.yml
+++ b/.azuredevops/components/llvm-project.yml
@@ -29,7 +29,7 @@ parameters:
   type: object
   default:
     buildJobs:
-      - { os: ubuntu2204, packageManager: apt }
+      # - { os: ubuntu2204, packageManager: apt }
       - { os: almalinux8, packageManager: dnf }
 
 jobs:

--- a/.azuredevops/components/llvm-project.yml
+++ b/.azuredevops/components/llvm-project.yml
@@ -29,7 +29,7 @@ parameters:
   type: object
   default:
     buildJobs:
-      # - { os: ubuntu2204, packageManager: apt }
+      - { os: ubuntu2204, packageManager: apt }
       - { os: almalinux8, packageManager: dnf }
 
 jobs:

--- a/.azuredevops/components/rocPRIM.yml
+++ b/.azuredevops/components/rocPRIM.yml
@@ -79,18 +79,18 @@ parameters:
       skipUnifiedBuild: 'false'
       buildDependsOn:
         gfx942:
-          - rocPRIM_build_ubuntu2204_gfx942
+          - rocPRIM_build_gfx942
         gfx90a:
-          - rocPRIM_build_ubuntu2204_gfx90a
+          - rocPRIM_build_gfx90a
     - hipCUB:
       name: hipCUB
       sparseCheckoutDir: projects/hipcub
       skipUnifiedBuild: 'false'
       buildDependsOn:
         gfx942:
-          - rocPRIM_build_ubuntu2204_gfx942
+          - rocPRIM_build_gfx942
         gfx90a:
-          - rocPRIM_build_ubuntu2204_gfx90a
+          - rocPRIM_build_gfx90a
     # rocSOLVER depends on both rocBLAS and rocPRIM
     # for a unified build, rocBLAS will be the one to call rocSOLVER
     - rocSOLVER:
@@ -99,9 +99,9 @@ parameters:
       skipUnifiedBuild: 'true'
       buildDependsOn:
         gfx942:
-          - rocPRIM_build_ubuntu2204_gfx942
+          - rocPRIM_build_gfx942
         gfx90a:
-          - rocPRIM_build_ubuntu2204_gfx90a
+          - rocPRIM_build_gfx90a
 
 jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:

--- a/.azuredevops/components/rocPRIM.yml
+++ b/.azuredevops/components/rocPRIM.yml
@@ -79,18 +79,18 @@ parameters:
       skipUnifiedBuild: 'false'
       buildDependsOn:
         gfx942:
-          - rocPRIM_build_gfx942
+          - rocPRIM_build_ubuntu2204_gfx942
         gfx90a:
-          - rocPRIM_build_gfx90a
+          - rocPRIM_build_ubuntu2204_gfx90a
     - hipCUB:
       name: hipCUB
       sparseCheckoutDir: projects/hipcub
       skipUnifiedBuild: 'false'
       buildDependsOn:
         gfx942:
-          - rocPRIM_build_gfx942
+          - rocPRIM_build_ubuntu2204_gfx942
         gfx90a:
-          - rocPRIM_build_gfx90a
+          - rocPRIM_build_ubuntu2204_gfx90a
     # rocSOLVER depends on both rocBLAS and rocPRIM
     # for a unified build, rocBLAS will be the one to call rocSOLVER
     - rocSOLVER:
@@ -99,9 +99,9 @@ parameters:
       skipUnifiedBuild: 'true'
       buildDependsOn:
         gfx942:
-          - rocPRIM_build_gfx942
+          - rocPRIM_build_ubuntu2204_gfx942
         gfx90a:
-          - rocPRIM_build_gfx90a
+          - rocPRIM_build_ubuntu2204_gfx90a
 
 jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:

--- a/.azuredevops/components/rocm-cmake.yml
+++ b/.azuredevops/components/rocm-cmake.yml
@@ -37,10 +37,10 @@ jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
   - job: rocm_cmake_${{ job.os }}
     pool:
-      ${{ if or(eq(job.os, 'ubuntu2204'), eq(job.os, 'almalinux8')) }}:
-        vmImage: 'ubuntu-22.04'
       ${{ if eq(job.os, 'ubuntu2404') }}:
         vmImage: 'ubuntu-24.04'
+      ${{ else }}:
+        vmImage: 'ubuntu-22.04'
     ${{ if eq(job.os, 'almalinux8') }}:
       container:
         image: rocmexternalcicd.azurecr.io/manylinux228:latest

--- a/.azuredevops/components/rocm-cmake.yml
+++ b/.azuredevops/components/rocm-cmake.yml
@@ -37,12 +37,14 @@ jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
   - job: rocm_cmake_${{ job.os }}
     pool:
-      ${{ if eq(job.os, 'ubuntu2204') }}:
+      ${{ if or(eq(job.os, 'ubuntu2204'), eq(job.os, 'almalinux8')) }}:
         vmImage: 'ubuntu-22.04'
       ${{ if eq(job.os, 'ubuntu2404') }}:
         vmImage: 'ubuntu-24.04'
-      ${{ if eq(job.os, 'almalinux8') }}:
-        name: 'rocm-ci_low_build_pool_alma8'
+    ${{ if eq(job.os, 'almalinux8') }}:
+      container:
+        image: rocmexternalcicd.azurecr.io/manylinux228:latest
+        endpoint: ContainerService3
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
@@ -66,6 +68,7 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
       parameters:
         os: ${{ job.os }}
+        useAmdclang: false
     - task: Bash@3
       displayName: CTest setup
       inputs:

--- a/.azuredevops/components/rocm-core.yml
+++ b/.azuredevops/components/rocm-core.yml
@@ -28,12 +28,14 @@ jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
   - job: rocm_core_${{ job.os }}
     pool:
-      ${{ if eq(job.os, 'ubuntu2204') }}:
+      ${{ if or(eq(job.os, 'ubuntu2204'), eq(job.os, 'almalinux8')) }}:
         vmImage: 'ubuntu-22.04'
       ${{ if eq(job.os, 'ubuntu2404') }}:
         vmImage: 'ubuntu-24.04'
-      ${{ if eq(job.os, 'almalinux8') }}:
-        name: 'rocm-ci_low_build_pool_alma8'
+    ${{ if eq(job.os, 'almalinux8') }}:
+      container:
+        image: rocmexternalcicd.azurecr.io/manylinux228:latest
+        endpoint: ContainerService3
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
@@ -51,6 +53,7 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
       parameters:
         os: ${{ job.os }}
+        useAmdclang: false
         extraBuildFlags: >-
           -DCMAKE_CURRENT_BINARY_DIR=$PWD
           -DCMAKE_CURRENT_SOURCE_DIR=$PWD/../

--- a/.azuredevops/components/rocm-core.yml
+++ b/.azuredevops/components/rocm-core.yml
@@ -28,10 +28,10 @@ jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
   - job: rocm_core_${{ job.os }}
     pool:
-      ${{ if or(eq(job.os, 'ubuntu2204'), eq(job.os, 'almalinux8')) }}:
-        vmImage: 'ubuntu-22.04'
       ${{ if eq(job.os, 'ubuntu2404') }}:
         vmImage: 'ubuntu-24.04'
+      ${{ else }}:
+        vmImage: 'ubuntu-22.04'
     ${{ if eq(job.os, 'almalinux8') }}:
       container:
         image: rocmexternalcicd.azurecr.io/manylinux228:latest

--- a/.azuredevops/components/rocm_smi_lib.yml
+++ b/.azuredevops/components/rocm_smi_lib.yml
@@ -33,10 +33,10 @@ jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
   - job: rocm_smi_lib_build_${{ job.os }}
     pool:
-      ${{ if or(eq(job.os, 'ubuntu2204'), eq(job.os, 'almalinux8')) }}:
-        vmImage: 'ubuntu-22.04'
       ${{ if eq(job.os, 'ubuntu2404') }}:
         vmImage: 'ubuntu-24.04'
+      ${{ else }}:
+        vmImage: 'ubuntu-22.04'
     ${{ if eq(job.os, 'almalinux8') }}:
       container:
         image: rocmexternalcicd.azurecr.io/manylinux228:latest

--- a/.azuredevops/components/rocm_smi_lib.yml
+++ b/.azuredevops/components/rocm_smi_lib.yml
@@ -33,12 +33,14 @@ jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
   - job: rocm_smi_lib_build_${{ job.os }}
     pool:
-      ${{ if eq(job.os, 'ubuntu2204') }}:
+      ${{ if or(eq(job.os, 'ubuntu2204'), eq(job.os, 'almalinux8')) }}:
         vmImage: 'ubuntu-22.04'
       ${{ if eq(job.os, 'ubuntu2404') }}:
         vmImage: 'ubuntu-24.04'
-      ${{ if eq(job.os, 'almalinux8') }}:
-        name: 'rocm-ci_low_build_pool_alma8'
+    ${{ if eq(job.os, 'almalinux8') }}:
+      container:
+        image: rocmexternalcicd.azurecr.io/manylinux228:latest
+        endpoint: ContainerService3
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
@@ -56,6 +58,7 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
       parameters:
         os: ${{ job.os }}
+        useAmdclang: false
         extraBuildFlags: >-
           -DBUILD_TESTS=ON
           -DROCM_DEP_ROCMCORE=ON

--- a/.azuredevops/components/rocminfo.yml
+++ b/.azuredevops/components/rocminfo.yml
@@ -42,10 +42,12 @@ jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
   - job: rocminfo_build_${{ job.os }}
     pool:
-      ${{ if eq(job.os, 'ubuntu2204') }}:
+      ${{ if or(eq(job.os, 'ubuntu2204'), eq(job.os, 'almalinux8')) }}:
         vmImage: 'ubuntu-22.04'
-      ${{ if eq(job.os, 'almalinux8') }}:
-        name: 'rocm-ci_low_build_pool_alma8'
+    ${{ if eq(job.os, 'almalinux8') }}:
+      container:
+        image: rocmexternalcicd.azurecr.io/manylinux228:latest
+        endpoint: ContainerService3
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
@@ -71,6 +73,7 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
       parameters:
         os: ${{ job.os }}
+        useAmdclang: false
         extraBuildFlags: >-
           -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm
           -DROCRTST_BLD_TYPE=release

--- a/.azuredevops/components/rocminfo.yml
+++ b/.azuredevops/components/rocminfo.yml
@@ -42,8 +42,7 @@ jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
   - job: rocminfo_build_${{ job.os }}
     pool:
-      ${{ if or(eq(job.os, 'ubuntu2204'), eq(job.os, 'almalinux8')) }}:
-        vmImage: 'ubuntu-22.04'
+      vmImage: 'ubuntu-22.04'
     ${{ if eq(job.os, 'almalinux8') }}:
       container:
         image: rocmexternalcicd.azurecr.io/manylinux228:latest

--- a/.azuredevops/components/rocprofiler-register.yml
+++ b/.azuredevops/components/rocprofiler-register.yml
@@ -28,10 +28,10 @@ jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
   - job: rocprofiler_register_${{ job.os }}
     pool:
-      ${{ if or(eq(job.os, 'ubuntu2204'), eq(job.os, 'almalinux8')) }}:
-        vmImage: 'ubuntu-22.04'
       ${{ if eq(job.os, 'ubuntu2404') }}:
         vmImage: 'ubuntu-24.04'
+      ${{ else }}:
+        vmImage: 'ubuntu-22.04'
     ${{ if eq(job.os, 'almalinux8') }}:
       container:
         image: rocmexternalcicd.azurecr.io/manylinux228:latest

--- a/.azuredevops/components/rocprofiler-register.yml
+++ b/.azuredevops/components/rocprofiler-register.yml
@@ -28,12 +28,14 @@ jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
   - job: rocprofiler_register_${{ job.os }}
     pool:
-      ${{ if eq(job.os, 'ubuntu2204') }}:
+      ${{ if or(eq(job.os, 'ubuntu2204'), eq(job.os, 'almalinux8')) }}:
         vmImage: 'ubuntu-22.04'
       ${{ if eq(job.os, 'ubuntu2404') }}:
         vmImage: 'ubuntu-24.04'
-      ${{ if eq(job.os, 'almalinux8') }}:
-        name: 'rocm-ci_low_build_pool_alma8'
+    ${{ if eq(job.os, 'almalinux8') }}:
+      container:
+        image: rocmexternalcicd.azurecr.io/manylinux228:latest
+        endpoint: ContainerService3
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
@@ -52,6 +54,7 @@ jobs:
       parameters:
         componentName: rocprofiler-register
         os: ${{ job.os }}
+        useAmdclang: false
         extraBuildFlags: >-
           -DCMAKE_PREFIX_PATH=$(Build.BinariesDirectory)
           -DROCPROFILER_REGISTER_BUILD_TESTS=ON

--- a/.azuredevops/components/roctracer.yml
+++ b/.azuredevops/components/roctracer.yml
@@ -61,8 +61,7 @@ jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
   - job: roctracer_build_${{ job.os }}_${{ job.target }}
     pool:
-      ${{ if or(eq(job.os, 'ubuntu2204'), eq(job.os, 'almalinux8')) }}:
-        vmImage: 'ubuntu-22.04'
+      vmImage: 'ubuntu-22.04'
     ${{ if eq(job.os, 'almalinux8') }}:
       container:
         image: rocmexternalcicd.azurecr.io/manylinux228:latest

--- a/.azuredevops/components/roctracer.yml
+++ b/.azuredevops/components/roctracer.yml
@@ -61,10 +61,12 @@ jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
   - job: roctracer_build_${{ job.os }}_${{ job.target }}
     pool:
-      ${{ if eq(job.os, 'ubuntu2204') }}:
+      ${{ if or(eq(job.os, 'ubuntu2204'), eq(job.os, 'almalinux8')) }}:
         vmImage: 'ubuntu-22.04'
-      ${{ if eq(job.os, 'almalinux8') }}:
-        name: 'rocm-ci_low_build_pool_alma8'
+    ${{ if eq(job.os, 'almalinux8') }}:
+      container:
+        image: rocmexternalcicd.azurecr.io/manylinux228:latest
+        endpoint: ContainerService3
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
@@ -94,13 +96,13 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
       parameters:
         os: ${{ job.os }}
+        useAmdclang: false
         extraBuildFlags: >-
           -DCMAKE_BUILD_TYPE=release
           -DROCM_PATH=$(Agent.BuildDirectory)/rocm
           -DCMAKE_MODULE_PATH=$(Agent.BuildDirectory)/rocm/lib/cmake/hip;$(Agent.BuildDirectory)/rocm/lib64/cmake/hip
-          -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm;
+          -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm
           -DGPU_TARGETS=${{ job.target }}
-          -DCMAKE_EXE_LINKER_FLAGS="-L$(Agent.BuildDirectory)/rocm/lib64 -L/opt/rh/gcc-toolset-14/root/usr/lib/gcc/x86_64-redhat-linux/14/"
           -DCMAKE_POSITION_INDEPENDENT_CODE=ON
           -GNinja
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml

--- a/.azuredevops/dependencies/gtest.yml
+++ b/.azuredevops/dependencies/gtest.yml
@@ -29,10 +29,12 @@ jobs:
     - group: common
     - template: /.azuredevops/variables-global.yml
     pool:
-      ${{ if eq(job.os, 'ubuntu2204') }}:
-        vmImage: ${{ variables.BASE_BUILD_POOL }}
-      ${{ if eq(job.os, 'almalinux8') }}:
-        name: rocm-ci_low_build_pool_alma8
+      ${{ if or(eq(job.os, 'ubuntu2204'), eq(job.os, 'almalinux8')) }}:
+        vmImage: 'ubuntu-22.04'
+    ${{ if eq(job.os, 'almalinux8') }}:
+      container:
+        image: rocmexternalcicd.azurecr.io/manylinux228:latest
+        endpoint: ContainerService3
     workspace:
       clean: all
     steps:
@@ -53,6 +55,7 @@ jobs:
         os: ${{ job.os }}
         cmakeBuildDir: $(Agent.BuildDirectory)/googletest/build
         cmakeSourceDir: $(Agent.BuildDirectory)/googletest
+        useAmdclang: false
         extraBuildFlags: >-
           -DGTEST_FORCE_SHARED_CRT=ON
           -DCMAKE_DEBUG_POSTFIX=d

--- a/.azuredevops/dependencies/gtest.yml
+++ b/.azuredevops/dependencies/gtest.yml
@@ -29,8 +29,7 @@ jobs:
     - group: common
     - template: /.azuredevops/variables-global.yml
     pool:
-      ${{ if or(eq(job.os, 'ubuntu2204'), eq(job.os, 'almalinux8')) }}:
-        vmImage: 'ubuntu-22.04'
+      vmImage: 'ubuntu-22.04'
     ${{ if eq(job.os, 'almalinux8') }}:
       container:
         image: rocmexternalcicd.azurecr.io/manylinux228:latest

--- a/.azuredevops/templates/steps/build-cmake.yml
+++ b/.azuredevops/templates/steps/build-cmake.yml
@@ -62,9 +62,6 @@ steps:
     workingDirectory: ${{ parameters.cmakeBuildDir }}
     cmakeArgs: >-
       ${{ iif(parameters.customInstallPath, join('', format('-DCMAKE_INSTALL_PREFIX={0}', parameters.installDir)), '') }}
-      # ${{ iif(eq(parameters.os, 'almalinux8'), '-DCMAKE_SHARED_LINKER_FLAGS="-L$(Agent.BuildDirectory)/rocm/lib64 -L/opt/rh/gcc-toolset-14/root/usr/lib/gcc/x86_64-redhat-linux/14/"', '') }}
-      # ${{ iif(eq(parameters.os, 'almalinux8'), '-DCMAKE_EXE_LINKER_FLAGS="-L$(Agent.BuildDirectory)/rocm/lib64 -L/opt/rh/gcc-toolset-14/root/usr/lib/gcc/x86_64-redhat-linux/14/"', '') }}
-      # -DCMAKE_CXX_FLAGS="${{ parameters.extraCxxFlags }} ${{ iif(eq(parameters.os, 'almalinux8'), '--gcc-toolchain=/opt/rh/gcc-toolset-14/root', '') }}"
       ${{ parameters.extraBuildFlags }}
       ${{ parameters.cmakeSourceDir }}
 - ${{ if parameters.printDiskSpace }}:

--- a/.azuredevops/templates/steps/build-cmake.yml
+++ b/.azuredevops/templates/steps/build-cmake.yml
@@ -50,21 +50,21 @@ steps:
 # call cmake from within that directory using $cmakeArgs as its parameters
 - task: CMake@1
   displayName: '${{parameters.componentName }} CMake Flags'
-  ${{ if eq(parameters.os, 'almalinux8')}}:
-    env:
-      PATH: "/opt/rh/gcc-toolset-14/root/usr/bin:$(PATH)"
-      MANPATH: "/opt/rh/gcc-toolset-14/root/usr/share/man:$(MANPATH)"
-      INFOPATH: "/opt/rh/gcc-toolset-14/root/usr/share/info:$(INFOPATH)"
-      PCP_DIR: "/opt/rh/gcc-toolset-14/root"
-      LD_LIBRARY_PATH: "/opt/rh/gcc-toolset-14/root/usr/lib64:/opt/rh/gcc-toolset-14/root/usr/lib:$(LD_LIBRARY_PATH)"
-      PKG_CONFIG_PATH: "/opt/rh/gcc-toolset-14/root/usr/lib64/pkgconfig:$(PKG_CONFIG_PATH)"
+  # ${{ if eq(parameters.os, 'almalinux8')}}:
+  #   env:
+  #     PATH: "/opt/rh/gcc-toolset-14/root/usr/bin:$(PATH)"
+  #     MANPATH: "/opt/rh/gcc-toolset-14/root/usr/share/man:$(MANPATH)"
+  #     INFOPATH: "/opt/rh/gcc-toolset-14/root/usr/share/info:$(INFOPATH)"
+  #     PCP_DIR: "/opt/rh/gcc-toolset-14/root"
+  #     LD_LIBRARY_PATH: "/opt/rh/gcc-toolset-14/root/usr/lib64:/opt/rh/gcc-toolset-14/root/usr/lib:$(LD_LIBRARY_PATH)"
+  #     PKG_CONFIG_PATH: "/opt/rh/gcc-toolset-14/root/usr/lib64/pkgconfig:$(PKG_CONFIG_PATH)"
   inputs:
     workingDirectory: ${{ parameters.cmakeBuildDir }}
     cmakeArgs: >-
       ${{ iif(parameters.customInstallPath, join('', format('-DCMAKE_INSTALL_PREFIX={0}', parameters.installDir)), '') }}
-      ${{ iif(eq(parameters.os, 'almalinux8'), '-DCMAKE_SHARED_LINKER_FLAGS="-L$(Agent.BuildDirectory)/rocm/lib64 -L/opt/rh/gcc-toolset-14/root/usr/lib/gcc/x86_64-redhat-linux/14/"', '') }}
-      ${{ iif(eq(parameters.os, 'almalinux8'), '-DCMAKE_EXE_LINKER_FLAGS="-L$(Agent.BuildDirectory)/rocm/lib64 -L/opt/rh/gcc-toolset-14/root/usr/lib/gcc/x86_64-redhat-linux/14/"', '') }}
-      -DCMAKE_CXX_FLAGS="${{ parameters.extraCxxFlags }} ${{ iif(eq(parameters.os, 'almalinux8'), '--gcc-toolchain=/opt/rh/gcc-toolset-14/root', '') }}"
+      # ${{ iif(eq(parameters.os, 'almalinux8'), '-DCMAKE_SHARED_LINKER_FLAGS="-L$(Agent.BuildDirectory)/rocm/lib64 -L/opt/rh/gcc-toolset-14/root/usr/lib/gcc/x86_64-redhat-linux/14/"', '') }}
+      # ${{ iif(eq(parameters.os, 'almalinux8'), '-DCMAKE_EXE_LINKER_FLAGS="-L$(Agent.BuildDirectory)/rocm/lib64 -L/opt/rh/gcc-toolset-14/root/usr/lib/gcc/x86_64-redhat-linux/14/"', '') }}
+      # -DCMAKE_CXX_FLAGS="${{ parameters.extraCxxFlags }} ${{ iif(eq(parameters.os, 'almalinux8'), '--gcc-toolchain=/opt/rh/gcc-toolset-14/root', '') }}"
       ${{ parameters.extraBuildFlags }}
       ${{ parameters.cmakeSourceDir }}
 - ${{ if parameters.printDiskSpace }}:

--- a/.azuredevops/templates/steps/build-cmake.yml
+++ b/.azuredevops/templates/steps/build-cmake.yml
@@ -41,6 +41,10 @@ parameters:
 - name: printDiskSpace
   type: boolean
   default: true
+# todo: make this control cxx and c compiler flags
+- name: useAmdclang
+  type: boolean
+  default: true
 
 # for cmake calls, set env variables for AlmaLinux 8
 # to simulate running source /opt/rh/gcc-toolset-14/enable for the session
@@ -50,18 +54,21 @@ steps:
 # call cmake from within that directory using $cmakeArgs as its parameters
 - task: CMake@1
   displayName: '${{parameters.componentName }} CMake Flags'
-  # ${{ if eq(parameters.os, 'almalinux8')}}:
-  #   env:
-  #     PATH: "/opt/rh/gcc-toolset-14/root/usr/bin:$(PATH)"
-  #     MANPATH: "/opt/rh/gcc-toolset-14/root/usr/share/man:$(MANPATH)"
-  #     INFOPATH: "/opt/rh/gcc-toolset-14/root/usr/share/info:$(INFOPATH)"
-  #     PCP_DIR: "/opt/rh/gcc-toolset-14/root"
-  #     LD_LIBRARY_PATH: "/opt/rh/gcc-toolset-14/root/usr/lib64:/opt/rh/gcc-toolset-14/root/usr/lib:$(LD_LIBRARY_PATH)"
-  #     PKG_CONFIG_PATH: "/opt/rh/gcc-toolset-14/root/usr/lib64/pkgconfig:$(PKG_CONFIG_PATH)"
+  ${{ if eq(parameters.os, 'almalinux8')}}:
+    env:
+      PATH: "/opt/rh/gcc-toolset-14/root/usr/bin:$(PATH)"
+      MANPATH: "/opt/rh/gcc-toolset-14/root/usr/share/man:$(MANPATH)"
+      INFOPATH: "/opt/rh/gcc-toolset-14/root/usr/share/info:$(INFOPATH)"
+      PCP_DIR: "/opt/rh/gcc-toolset-14/root"
+      LD_LIBRARY_PATH: "/opt/rh/gcc-toolset-14/root/usr/lib64:/opt/rh/gcc-toolset-14/root/usr/lib:$(LD_LIBRARY_PATH)"
+      PKG_CONFIG_PATH: "/opt/rh/gcc-toolset-14/root/usr/lib64/pkgconfig:$(PKG_CONFIG_PATH)"
   inputs:
     workingDirectory: ${{ parameters.cmakeBuildDir }}
     cmakeArgs: >-
       ${{ iif(parameters.customInstallPath, join('', format('-DCMAKE_INSTALL_PREFIX={0}', parameters.installDir)), '') }}
+      ${{ iif(eq(parameters.os, 'almalinux8'), '-DCMAKE_SHARED_LINKER_FLAGS="-L$(Agent.BuildDirectory)/rocm/lib64 -L/opt/rh/gcc-toolset-14/root/usr/lib/gcc/x86_64-redhat-linux/14/"', '') }}
+      ${{ iif(eq(parameters.os, 'almalinux8'), '-DCMAKE_EXE_LINKER_FLAGS="-L$(Agent.BuildDirectory)/rocm/lib64 -L/opt/rh/gcc-toolset-14/root/usr/lib/gcc/x86_64-redhat-linux/14/"', '') }}
+      -DCMAKE_CXX_FLAGS="${{ parameters.extraCxxFlags }} ${{ iif(and(eq(parameters.os, 'almalinux8'), parameters.useAmdclang), '--gcc-toolchain=/opt/rh/gcc-toolset-14/root', '') }}"
       ${{ parameters.extraBuildFlags }}
       ${{ parameters.cmakeSourceDir }}
 - ${{ if parameters.printDiskSpace }}:

--- a/.azuredevops/templates/steps/dependencies-dnf.yml
+++ b/.azuredevops/templates/steps/dependencies-dnf.yml
@@ -123,7 +123,7 @@ steps:
     targetType: inline
     script: |
       sudo dnf -y module disable python36
-      sudo rm /usr/local/bin/python3.12
+      sudo rm /usr/local/bin/python3.14 /usr/local/bin/python3.12
       sudo alternatives --set python /usr/bin/python3.11
       sudo alternatives --set python3 /usr/bin/python3.11
       python3 --version

--- a/.azuredevops/templates/steps/dependencies-dnf.yml
+++ b/.azuredevops/templates/steps/dependencies-dnf.yml
@@ -123,7 +123,7 @@ steps:
     targetType: inline
     script: |
       sudo dnf -y module disable python36
-      sudo rm /usr/local/bin/python3.14 /usr/local/bin/python3.13 /usr/local/bin/python3.12
+      sudo rm -f /usr/local/bin/python3.14 /usr/local/bin/python3.13 /usr/local/bin/python3.12
       sudo alternatives --set python /usr/bin/python3.11
       sudo alternatives --set python3 /usr/bin/python3.11
       python3 --version

--- a/.azuredevops/templates/steps/dependencies-dnf.yml
+++ b/.azuredevops/templates/steps/dependencies-dnf.yml
@@ -15,6 +15,7 @@ parameters:
     - gcc-toolset-14-libatomic-devel
     - git
     - jq
+    - numactl
     - python3.11
     - python3.11-pip
     - vim-common
@@ -121,7 +122,7 @@ steps:
   inputs:
     targetType: inline
     script: |
-      sudo dnf -y module disable python36 python314
+      sudo dnf -y module disable python36 python314 python312
       sudo alternatives --set python /usr/bin/python3.11
       sudo alternatives --set python3 /usr/bin/python3.11
       python3 --version

--- a/.azuredevops/templates/steps/dependencies-dnf.yml
+++ b/.azuredevops/templates/steps/dependencies-dnf.yml
@@ -123,7 +123,7 @@ steps:
     targetType: inline
     script: |
       sudo dnf -y module disable python36
-      sudo rm /usr/local/bin/python3.14 /usr/local/bin/python3.12
+      sudo rm /usr/local/bin/python3.14 /usr/local/bin/python3.13 /usr/local/bin/python3.12
       sudo alternatives --set python /usr/bin/python3.11
       sudo alternatives --set python3 /usr/bin/python3.11
       python3 --version

--- a/.azuredevops/templates/steps/dependencies-dnf.yml
+++ b/.azuredevops/templates/steps/dependencies-dnf.yml
@@ -122,7 +122,8 @@ steps:
   inputs:
     targetType: inline
     script: |
-      sudo dnf -y module disable python36 python314 python312
+      sudo dnf -y module disable python36
+      sudo rm /usr/local/bin/python3.12
       sudo alternatives --set python /usr/bin/python3.11
       sudo alternatives --set python3 /usr/bin/python3.11
       python3 --version

--- a/.azuredevops/templates/steps/dependencies-dnf.yml
+++ b/.azuredevops/templates/steps/dependencies-dnf.yml
@@ -121,7 +121,7 @@ steps:
   inputs:
     targetType: inline
     script: |
-      sudo dnf -y module disable python36
+      sudo dnf -y module disable python36 python314
       sudo alternatives --set python /usr/bin/python3.11
       sudo alternatives --set python3 /usr/bin/python3.11
       python3 --version

--- a/.azuredevops/templates/steps/dependencies-dnf.yml
+++ b/.azuredevops/templates/steps/dependencies-dnf.yml
@@ -123,7 +123,7 @@ steps:
     targetType: inline
     script: |
       sudo dnf -y module disable python36
-      sudo rm -f /usr/local/bin/python3.14 /usr/local/bin/python3.13 /usr/local/bin/python3.12
+      sudo rm -f /usr/local/bin/python3.12 /usr/local/bin/python3.13 /usr/local/bin/python3.14
       sudo alternatives --set python /usr/bin/python3.11
       sudo alternatives --set python3 /usr/bin/python3.11
       python3 --version


### PR DESCRIPTION
- Replaces the almalinux pools with manylinux containers running on the standard ub22 pools for previously enabled components
- Adds a `useAmdclang` param to build-cmake to avoid passing build flags that don't exist in gcc/g++
- Adds `numactl` as base dnf package
  - Installed by default on ub22, needed for rocminfo
- Removes python 3.12, 3.13, 3.14 binaries from /usr/local/bin
  - We want to use only 3.11

[HIP](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=33214&view=results)
[ROCR-Runtime](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=33202&view=results)
[ROCdbgapi](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=33182&view=results)
[amdsmi](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=33163&view=results)
[llvm-project](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=33201&view=results)
[rocm-cmake](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=33172&view=results)
[rocm-core](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=33173&view=results)
[rocmsmi](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=33177&view=results)
[rocminfo](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=33190&view=results)
[rocprofiler-register](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=33187&view=results)
[roctracer](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=33200&view=results)