### PR TITLE
[Ex CI] shard rocPRIM tests across 3 runners

### DIFF
--- a/.azuredevops/components/rocPRIM.yml
+++ b/.azuredevops/components/rocPRIM.yml
@@ -68,14 +68,18 @@ parameters:
       # - { os: almalinux8, packageManager: dnf, target: gfx1100 }
       - { os: almalinux8, packageManager: dnf, target: gfx1030 }
     testJobs:
-      - { os: ubuntu2204, packageManager: apt, target: gfx942, shard: 0, shardCount: 4 }
-      - { os: ubuntu2204, packageManager: apt, target: gfx942, shard: 1, shardCount: 4 }
-      - { os: ubuntu2204, packageManager: apt, target: gfx942, shard: 2, shardCount: 4 }
-      - { os: ubuntu2204, packageManager: apt, target: gfx942, shard: 3, shardCount: 4 }
-      - { os: ubuntu2204, packageManager: apt, target: gfx90a, shard: 0, shardCount: 4 }
-      - { os: ubuntu2204, packageManager: apt, target: gfx90a, shard: 1, shardCount: 4 }
-      - { os: ubuntu2204, packageManager: apt, target: gfx90a, shard: 2, shardCount: 4 }
-      - { os: ubuntu2204, packageManager: apt, target: gfx90a, shard: 3, shardCount: 4 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx942, shard: 1, shardCount: 6 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx942, shard: 2, shardCount: 6 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx942, shard: 3, shardCount: 6 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx942, shard: 4, shardCount: 6 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx942, shard: 5, shardCount: 6 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx942, shard: 6, shardCount: 6 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx90a, shard: 1, shardCount: 6 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx90a, shard: 2, shardCount: 6 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx90a, shard: 3, shardCount: 6 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx90a, shard: 4, shardCount: 6 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx90a, shard: 5, shardCount: 6 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx90a, shard: 6, shardCount: 6 }
 - name: downstreamComponentMatrix
   type: object
   default:

--- a/.azuredevops/components/rocPRIM.yml
+++ b/.azuredevops/components/rocPRIM.yml
@@ -68,8 +68,12 @@ parameters:
       # - { os: almalinux8, packageManager: dnf, target: gfx1100 }
       - { os: almalinux8, packageManager: dnf, target: gfx1030 }
     testJobs:
-      - { os: ubuntu2204, packageManager: apt, target: gfx942 }
-      - { os: ubuntu2204, packageManager: apt, target: gfx90a }
+      - { os: ubuntu2204, packageManager: apt, target: gfx942, shard: 0, shardCount: 3 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx942, shard: 1, shardCount: 3 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx942, shard: 2, shardCount: 3 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx90a, shard: 0, shardCount: 3 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx90a, shard: 1, shardCount: 3 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx90a, shard: 2, shardCount: 3 }
 - name: downstreamComponentMatrix
   type: object
   default:
@@ -172,7 +176,7 @@ jobs:
 
 - ${{ if eq(parameters.unifiedBuild, False) }}:
   - ${{ each job in parameters.jobMatrix.testJobs }}:
-    - job: ${{ parameters.componentName }}_test_${{ job.os }}_${{ job.target }}
+    - job: ${{ parameters.componentName }}_test_${{ job.os }}_${{ job.target }}_${{ job.shard }}
       dependsOn: ${{ parameters.componentName }}_build_${{ job.os }}_${{ job.target }}
       condition:
         and(succeeded(),
@@ -212,6 +216,7 @@ jobs:
         parameters:
           componentName: ${{ parameters.componentName }}
           testDir: '$(Agent.BuildDirectory)/rocm/bin/rocprim'
+          extraTestParameters: '-I ${{ job.shard }},,${{ job.shardCount }}'
           os: ${{ job.os }}
       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/docker-container.yml
         parameters:

--- a/.azuredevops/components/rocPRIM.yml
+++ b/.azuredevops/components/rocPRIM.yml
@@ -68,18 +68,12 @@ parameters:
       # - { os: almalinux8, packageManager: dnf, target: gfx1100 }
       - { os: almalinux8, packageManager: dnf, target: gfx1030 }
     testJobs:
-      - { os: ubuntu2204, packageManager: apt, target: gfx942, shard: 1, shardCount: 6 }
-      - { os: ubuntu2204, packageManager: apt, target: gfx942, shard: 2, shardCount: 6 }
-      - { os: ubuntu2204, packageManager: apt, target: gfx942, shard: 3, shardCount: 6 }
-      - { os: ubuntu2204, packageManager: apt, target: gfx942, shard: 4, shardCount: 6 }
-      - { os: ubuntu2204, packageManager: apt, target: gfx942, shard: 5, shardCount: 6 }
-      - { os: ubuntu2204, packageManager: apt, target: gfx942, shard: 6, shardCount: 6 }
-      - { os: ubuntu2204, packageManager: apt, target: gfx90a, shard: 1, shardCount: 6 }
-      - { os: ubuntu2204, packageManager: apt, target: gfx90a, shard: 2, shardCount: 6 }
-      - { os: ubuntu2204, packageManager: apt, target: gfx90a, shard: 3, shardCount: 6 }
-      - { os: ubuntu2204, packageManager: apt, target: gfx90a, shard: 4, shardCount: 6 }
-      - { os: ubuntu2204, packageManager: apt, target: gfx90a, shard: 5, shardCount: 6 }
-      - { os: ubuntu2204, packageManager: apt, target: gfx90a, shard: 6, shardCount: 6 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx942, shard: 1, shardCount: 3 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx942, shard: 2, shardCount: 3 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx942, shard: 3, shardCount: 3 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx90a, shard: 1, shardCount: 3 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx90a, shard: 2, shardCount: 3 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx90a, shard: 3, shardCount: 3 }
 - name: downstreamComponentMatrix
   type: object
   default:

--- a/.azuredevops/components/rocPRIM.yml
+++ b/.azuredevops/components/rocPRIM.yml
@@ -68,12 +68,14 @@ parameters:
       # - { os: almalinux8, packageManager: dnf, target: gfx1100 }
       - { os: almalinux8, packageManager: dnf, target: gfx1030 }
     testJobs:
-      - { os: ubuntu2204, packageManager: apt, target: gfx942, shard: 0, shardCount: 3 }
-      - { os: ubuntu2204, packageManager: apt, target: gfx942, shard: 1, shardCount: 3 }
-      - { os: ubuntu2204, packageManager: apt, target: gfx942, shard: 2, shardCount: 3 }
-      - { os: ubuntu2204, packageManager: apt, target: gfx90a, shard: 0, shardCount: 3 }
-      - { os: ubuntu2204, packageManager: apt, target: gfx90a, shard: 1, shardCount: 3 }
-      - { os: ubuntu2204, packageManager: apt, target: gfx90a, shard: 2, shardCount: 3 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx942, shard: 0, shardCount: 4 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx942, shard: 1, shardCount: 4 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx942, shard: 2, shardCount: 4 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx942, shard: 3, shardCount: 4 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx90a, shard: 0, shardCount: 4 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx90a, shard: 1, shardCount: 4 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx90a, shard: 2, shardCount: 4 }
+      - { os: ubuntu2204, packageManager: apt, target: gfx90a, shard: 3, shardCount: 4 }
 - name: downstreamComponentMatrix
   type: object
   default:

--- a/.azuredevops/templates/steps/test.yml
+++ b/.azuredevops/templates/steps/test.yml
@@ -14,6 +14,9 @@ parameters:
 - name: testParameters
   type: string
   default: '--output-on-failure --force-new-ctest-process --output-junit test_output.xml'
+- name: extraTestParameters
+  type: string
+  default: ''
 - name: testOutputFile
   type: string
   default: test_output.xml
@@ -49,11 +52,11 @@ steps:
   inputs:
     targetType: inline
     ${{ if ne(parameters.os, 'almalinux8') }}:
-      script: ${{ parameters.testExecutable }} ${{ parameters.testParameters }}
+      script: ${{ parameters.testExecutable }} ${{ parameters.testParameters }} ${{ parameters.extraTestParameters }}
     ${{ else }}:
       script: |
         source /opt/rh/gcc-toolset-14/enable
-        ${{ parameters.testExecutable }} ${{ parameters.testParameters }}
+        ${{ parameters.testExecutable }} ${{ parameters.testParameters }} ${{ parameters.extraTestParameters }}
     workingDirectory: ${{ parameters.testDir }}
 - ${{ if parameters.testPublishResults }}:
   - task: PublishTestResults@2


### PR DESCRIPTION
Adds CTest sharding for rocPRIM tests, to distribute them amongst multiple test runners and shorten test times. Currently set to 3 shards for both gfx942 and gfx90a.

Sample run:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=33266&view=results