### PR TITLE
[Ex CI] migrate roc/hipRAND pipelines, change migrated mathlibs's default branch to rocm-rel-7.0

### DIFF
--- a/.azuredevops/templates/steps/dependencies-rocm.yml
+++ b/.azuredevops/templates/steps/dependencies-rocm.yml
@@ -109,7 +109,7 @@ parameters:
       hasGpuTarget: false
     hipCUB:
       pipelineId: $(HIPCUB_PIPELINE_ID)
-      stagingBranch: develop
+      stagingBranch: release-staging/rocm-rel-7.0
       mainlineBranch: develop
       hasGpuTarget: true
     hipFFT:
@@ -129,7 +129,7 @@ parameters:
       hasGpuTarget: false
     hipRAND:
       pipelineId: $(HIPRAND_PIPELINE_ID)
-      stagingBranch: develop
+      stagingBranch: release-staging/rocm-rel-7.0
       mainlineBranch: develop
       hasGpuTarget: true
     hipSOLVER:
@@ -264,7 +264,7 @@ parameters:
       hasGpuTarget: false
     rocPRIM:
       pipelineId: $(ROCPRIM_PIPELINE_ID)
-      stagingBranch: develop
+      stagingBranch: release-staging/rocm-rel-7.0
       mainlineBranch: develop
       hasGpuTarget: true
     rocprofiler:
@@ -304,7 +304,7 @@ parameters:
       hasGpuTarget: false
     rocRAND:
       pipelineId: $(ROCRAND_PIPELINE_ID)
-      stagingBranch: develop
+      stagingBranch: release-staging/rocm-rel-7.0
       mainlineBranch: develop
       hasGpuTarget: true
     rocr_debug_agent:
@@ -329,7 +329,7 @@ parameters:
       hasGpuTarget: false
     rocThrust:
       pipelineId: $(ROCTHRUST_PIPELINE_ID)
-      stagingBranch: develop
+      stagingBranch: release-staging/rocm-rel-7.0
       mainlineBranch: develop
       hasGpuTarget: true
     roctracer:

--- a/.azuredevops/templates/steps/dependencies-rocm.yml
+++ b/.azuredevops/templates/steps/dependencies-rocm.yml
@@ -130,7 +130,7 @@ parameters:
     hipRAND:
       pipelineId: $(HIPRAND_PIPELINE_ID)
       stagingBranch: develop
-      mainlineBranch: mainline
+      mainlineBranch: develop
       hasGpuTarget: true
     hipSOLVER:
       pipelineId: $(HIPSOLVER_PIPELINE_ID)
@@ -305,7 +305,7 @@ parameters:
     rocRAND:
       pipelineId: $(ROCRAND_PIPELINE_ID)
       stagingBranch: develop
-      mainlineBranch: mainline
+      mainlineBranch: develop
       hasGpuTarget: true
     rocr_debug_agent:
       pipelineId: $(ROCR_DEBUG_AGENT_PIPELINE_ID)

--- a/.azuredevops/variables-global.yml
+++ b/.azuredevops/variables-global.yml
@@ -80,7 +80,7 @@ variables:
 - name: HIPIFY_PIPELINE_ID
   value: 92
 - name: HIPRAND_PIPELINE_ID
-  value: 90
+  value: 275
 - name: HIPSOLVER_PIPELINE_ID
   value: 84
 - name: HIPSPARSE_PIPELINE_ID
@@ -150,7 +150,7 @@ variables:
 - name: ROCR_RUNTIME_PIPELINE_ID
   value: 10
 - name: ROCRAND_PIPELINE_ID
-  value: 95
+  value: 274
 - name: ROCSOLVER_PIPELINE_ID
   value: 81
 - name: ROCSPARSE_PIPELINE_ID


### PR DESCRIPTION
Changes the pipeline to pull artifacts from for roc/hipRAND to their monorepo pipelines.

For the mathlibs that are currently completely migrated over (PRIMs and RANDs), they are developing on their own branch: `release-staging/rocm-rel-7.0`. This means that changes related to HIP 7.0 are on that branch and not on `develop`.

To get these fixes into downstream component builds, change the staging branch for these components to that rel-7.0 branch, since its their staging branch in practice anyways.