### PR TITLE
[Ex CI] fix hipRAND multi-OS tests, Tensile sparse dir

### DIFF
--- a/.azuredevops/components/Tensile.yml
+++ b/.azuredevops/components/Tensile.yml
@@ -106,19 +106,19 @@ jobs:
       inputs:
         targetType: inline
         script: python3 setup.py bdist_wheel
-        workingDirectory: $(Build.SourcesDirectory)
+        workingDirectory: $(Agent.BuildDirectory)/s
     - task: Bash@3
       displayName: Rename wheel file with job OS
       inputs:
         targetType: inline
-        workingDirectory: $(Build.SourcesDirectory)
+        workingDirectory: $(Agent.BuildDirectory)/s
         script: |
-          wheelFile=$(find "$(Build.SourcesDirectory)/dist" -type f -name "*.whl" | head -n 1)
+          wheelFile=$(find "$(Agent.BuildDirectory)/s/dist" -type f -name "*.whl" | head -n 1)
           newWheelFile="$(basename "$wheelFile" .whl)-${{ job.os }}.whl"
           mv "$wheelFile" "$(dirname "$wheelFile")/$newWheelFile"
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-prepare-package.yml
       parameters:
-        sourceDir: $(Build.SourcesDirectory)/dist
+        sourceDir: $(Agent.BuildDirectory)/s/dist
         contentsString: '*.whl'
         targetDir: $(Build.ArtifactStagingDirectory)
         clean: false
@@ -207,7 +207,7 @@ jobs:
       inputs:
         targetType: inline
         script: tox run -v -e ci -- -m pre_checkin
-        workingDirectory: $(Build.SourcesDirectory)
+        workingDirectory: $(Agent.BuildDirectory)/s
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/docker-container.yml
       parameters:
         aptPackages: ${{ parameters.aptPackages }}

--- a/.azuredevops/components/hipRAND.yml
+++ b/.azuredevops/components/hipRAND.yml
@@ -183,6 +183,7 @@ jobs:
       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/local-artifact-download.yml
         parameters:
           preTargetFilter: ${{ parameters.componentName }}
+          os: ${{ job.os }}
           gpuTarget: ${{ job.target }}
       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-aqlprofile.yml
       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml

--- a/.azuredevops/templates/steps/dependencies-rocm.yml
+++ b/.azuredevops/templates/steps/dependencies-rocm.yml
@@ -397,6 +397,7 @@ steps:
         ${{ if parameters.componentVarList[dependency].hasGpuTarget }}:
           gpuTarget: ${{ parameters.gpuTarget }}
         preTargetFilter: ${{ dependency }}
+        os: ${{ parameters.os }}
         buildType: current
   - ${{ else }}:
     - template: artifact-download.yml


### PR DESCRIPTION
Adds a missing job.os param to hipRAND test jobs.

Sample build:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=34294&view=results

Adds fixes for getting Tensile building from the monorepo.

Sample build:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=34300&view=results