### PR TITLE
[Ex CI] update ROCm versioning

### DIFF
--- a/.azuredevops/variables-global.yml
+++ b/.azuredevops/variables-global.yml
@@ -32,13 +32,13 @@ variables:
 - name: GFX90A_TEST_POOL
   value: gfx90a_test_pool
 - name: LATEST_RELEASE_VERSION
-  value: 6.4.0
+  value: 6.4.2
 - name: REPO_RADEON_VERSION
-  value: 6.4
+  value: 6.4.2
 - name: NEXT_RELEASE_VERSION
-  value: 6.5.0
+  value: 7.0.0
 - name: LATEST_RELEASE_TAG
-  value: rocm-6.4.0
+  value: rocm-6.4.2
 - name: DOCKER_SKIP_GFX
   value: gfx90a
 - name: AMDMIGRAPHX_PIPELINE_ID


### PR DESCRIPTION
Update current version to 6.4.2, update next major version to 7.0.0

rocm-core uses `NEXT_RELEASE_VERSION` for creating the `rocm/.info/version` file, which rocprofiler-compute (and probably many other components) uses to determine the current ROCm version and to adjust its behaviour as needed. For rp-compute, this change is needed for roofline tests, since those are provided as straight-up binaries and have different bins for different ROCm versions.