### PR TITLE
[Ex CI] rccl: use vendored gtest, use GPU_TARGETS flag

### DIFF
--- a/.azuredevops/components/rccl.yml
+++ b/.azuredevops/components/rccl.yml
@@ -15,7 +15,6 @@ parameters:
   default:
     - cmake
     - git
-    - googletest
     - libboost-program-options-dev
     - libdrm-dev
     - libfftw3-dev
@@ -90,6 +89,10 @@ jobs:
       parameters:
         checkoutRepo: ${{ parameters.checkoutRepo }}
         submoduleBehaviour: recursive
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-vendor.yml
+      parameters:
+        dependencyList:
+          - gtest
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
       parameters:
         checkoutRef: ${{ parameters.checkoutRef }}
@@ -101,12 +104,11 @@ jobs:
         extraBuildFlags: >-
           -DCMAKE_CXX_COMPILER=$(Agent.BuildDirectory)/rocm/bin/hipcc
           -DCMAKE_C_COMPILER=$(Agent.BuildDirectory)/rocm/bin/hipcc
-          -DHALF_INCLUDE_DIR=$(Agent.BuildDirectory)/rocm/include
           -DCMAKE_BUILD_TYPE=Release
           -DROCM_PATH=$(Agent.BuildDirectory)/rocm
           -DBUILD_TESTS=ON
           -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm;$(Agent.BuildDirectory)/rocm/share/rocm/cmake;$(Agent.BuildDirectory)/rocm/libexec/hipify
-          -DAMDGPU_TARGETS=${{ job.target }}
+          -DGPU_TARGETS=${{ job.target }}
           -GNinja
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
       parameters:


### PR DESCRIPTION
rccl no longer accepts `AMDGPU_TARGETS`, which was likely causing build issues as it was building for all its default archs while its dependencies were only built for one arch at a time. Switch to `GPU_TARGETS` to fix this. `HALF_INCLUDE_DIR` was also marked as being unused, so removed that as well.

Also switch to vendored gtest.

Sample run off of https://github.com/ROCm/rccl/pull/1744:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=34495&view=results