### PR TITLE
[Ex CI] change ROCm version to 6.4.1

### DIFF
--- a/.azuredevops/variables-global.yml
+++ b/.azuredevops/variables-global.yml
@@ -32,13 +32,13 @@ variables:
 - name: GFX90A_TEST_POOL
   value: gfx90a_test_pool
 - name: LATEST_RELEASE_VERSION
-  value: 6.4.2
+  value: 6.4.1
 - name: REPO_RADEON_VERSION
-  value: 6.4.2
+  value: 6.4.1
 - name: NEXT_RELEASE_VERSION
   value: 7.0.0
 - name: LATEST_RELEASE_TAG
-  value: rocm-6.4.2
+  value: rocm-6.4.1
 - name: DOCKER_SKIP_GFX
   value: gfx90a
 - name: AMDMIGRAPHX_PIPELINE_ID


### PR DESCRIPTION
The current version is actually 6.4.1