### PR TITLE
[Ex CI] remove usage of ALLOWED_PARTIAL_SUCCEED_BUILDS library variable

### DIFF
--- a/.azuredevops/components/ROCR-Runtime.yml
+++ b/.azuredevops/components/ROCR-Runtime.yml
@@ -138,7 +138,6 @@ jobs:
         runRocminfo: false
     - task: Bash@3
       displayName: Build kfdtest
-      continueOnError: true
       inputs:
         targetType: 'inline'
         workingDirectory: $(Build.SourcesDirectory)/libhsakmt/tests/kfdtest
@@ -158,7 +157,6 @@ jobs:
         os: ${{ job.os }}
     - task: Bash@3
       displayName: Build rocrtst
-      continueOnError: true
       inputs:
         targetType: 'inline'
         workingDirectory: $(Build.SourcesDirectory)/rocrtst/suites/test_common

--- a/.azuredevops/components/amdsmi.yml
+++ b/.azuredevops/components/amdsmi.yml
@@ -104,7 +104,7 @@ jobs:
       parameters:
         componentName: amdsmi
         testDir: '$(Agent.BuildDirectory)'
-        testExecutable: './rocm/share/amd_smi/tests/amdsmitst'
+        testExecutable: 'sudo ./rocm/share/amd_smi/tests/amdsmitst'
         testParameters: '--gtest_output=xml:./test_output.xml --gtest_color=yes'
         os: ${{ job.os }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/docker-container.yml

--- a/.azuredevops/components/rocm_smi_lib.yml
+++ b/.azuredevops/components/rocm_smi_lib.yml
@@ -105,7 +105,7 @@ jobs:
       parameters:
         componentName: rocm_smi_lib
         testDir: '$(Agent.BuildDirectory)'
-        testExecutable: './rocm/share/rocm_smi/rsmitst_tests/rsmitst'
+        testExecutable: 'sudo ./rocm/share/rocm_smi/rsmitst_tests/rsmitst'
         testParameters: '--gtest_output=xml:./test_output.xml --gtest_color=yes'
         os: ${{ job.os }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/docker-container.yml

--- a/.azuredevops/templates/steps/artifact-download.yml
+++ b/.azuredevops/templates/steps/artifact-download.yml
@@ -19,36 +19,27 @@ parameters:
   default: false
 
 steps:
-- task: Bash@3
-  displayName: Set allowPartiallySucceededBuilds
-  inputs:
-    targetType: inline
-    script: |
-      if [[ ",$ALLOWED_PARTIAL_SUCCEED_BUILDS," == *",${{ parameters.componentName }},"* ]]; then
-        echo "##vso[task.setvariable variable=allowPartiallySucceededBuilds;]true"
-      else
-        echo "##vso[task.setvariable variable=allowPartiallySucceededBuilds;]false"
-      fi
 - task: DownloadPipelineArtifact@2
   displayName: Download ${{ parameters.componentName }}
   inputs:
-    ${{ if eq(parameters.aggregatePipeline, false) }}:
-      buildType: 'specific'
-      project: ROCm-CI
-      definition: ${{ parameters.pipelineId }}
-      specificBuildWithTriggering: true
-      itemPattern: '**/*${{ parameters.fileFilter }}*'
-      # aomp is a special case, since the trigger file is under ROCm/ROCm instead of the component repo
-      ${{ if notIn(parameters.componentName, 'aomp') }}:
-        buildVersionToDownload: latestFromBranch # default is 'latest'
-      branchName: refs/heads/${{ parameters.branchName }}
-      allowPartiallySucceededBuilds: $(allowPartiallySucceededBuilds)
-      targetPath: '$(Pipeline.Workspace)/d'
-    ${{ else }}:
+    ${{ if parameters.aggregatePipeline }}:
       buildType: 'current'
       itemPattern: '**/${{ parameters.componentName }}*${{ parameters.fileFilter }}*'
-      allowPartiallySucceededBuilds: $(allowPartiallySucceededBuilds)
+      allowPartiallySucceededBuilds: true
       targetPath: '$(Pipeline.Workspace)/d'
+    ${{ else }}:
+      buildType: 'specific'
+      project: ROCm-CI
+      specificBuildWithTriggering: true
+      allowPartiallySucceededBuilds: true
+      definition: ${{ parameters.pipelineId }}
+      itemPattern: '**/*${{ parameters.fileFilter }}*'
+      targetPath: '$(Pipeline.Workspace)/d'
+      branchName: refs/heads/${{ parameters.branchName }}
+      ${{ if eq(parameters.componentName, 'aomp') }}:
+        buildVersionToDownload: latest # aomp trigger lives in ROCm/ROCm, so cannot use ROCm/aomp branch names
+      ${{ else }}:
+        buildVersionToDownload: latestFromBranch
 - task: ExtractFiles@1
   displayName: Extract ${{ parameters.componentName }}
   inputs:

--- a/.azuredevops/templates/steps/test.yml
+++ b/.azuredevops/templates/steps/test.yml
@@ -1,19 +1,19 @@
 parameters:
-- name: os
-  type: string
-  default: 'ubuntu2204'
 - name: componentName
   type: string
   default: ''
+- name: os
+  type: string
+  default: ubuntu2204
 - name: testDir
   type: string
-  default: 'build'
+  default: build
 - name: testExecutable
   type: string
-  default: 'ctest'
+  default: ctest
 - name: testParameters
   type: string
-  default: '--output-on-failure --force-new-ctest-process --output-junit test_output.xml'
+  default: --output-on-failure --force-new-ctest-process --output-junit test_output.xml
 - name: extraTestParameters
   type: string
   default: ''
@@ -22,7 +22,7 @@ parameters:
   default: test_output.xml
 - name: testOutputFormat
   type: string
-  default: 'JUnit'
+  default: JUnit
   values:
     - JUnit
     - NUnit
@@ -32,31 +32,28 @@ parameters:
 - name: testPublishResults
   type: boolean
   default: true
-- name: allowPartiallySucceededBuilds
+- name: allowComponentTestFailure
   type: object
   default:
     - amdsmi
-    - aomp
     - HIPIFY
-    - MIVisionX
     - rocm_smi_lib
-    - rocprofiler-sdk
     - roctracer
+    # the following do not use this template but allow test failures, included for completeness
+    - aomp
+    - ROCgdb
 
 steps:
 # run test, continue on failure to publish results
 # and to publish build artifacts
 - task: Bash@3
   displayName: '${{ parameters.componentName }} Test'
-  continueOnError: ${{ containsValue(parameters.allowPartiallySucceededBuilds, parameters.componentName) }}
+  continueOnError: ${{ containsValue(parameters.allowComponentTestFailure, parameters.componentName) }}
   inputs:
     targetType: inline
-    ${{ if ne(parameters.os, 'almalinux8') }}:
-      script: ${{ parameters.testExecutable }} ${{ parameters.testParameters }} ${{ parameters.extraTestParameters }}
-    ${{ else }}:
-      script: |
-        source /opt/rh/gcc-toolset-14/enable
-        ${{ parameters.testExecutable }} ${{ parameters.testParameters }} ${{ parameters.extraTestParameters }}
+    script: |
+      ${{ iif(eq(parameters.os, 'almalinux8'), 'source /opt/rh/gcc-toolset-14/enable', '') }}
+      ${{ parameters.testExecutable }} ${{ parameters.testParameters }} ${{ parameters.extraTestParameters }}
     workingDirectory: ${{ parameters.testDir }}
 - ${{ if parameters.testPublishResults }}:
   - task: PublishTestResults@2


### PR DESCRIPTION
- Removes usage of the `ALLOWED_PARTIAL_SUCCEED_BUILDS` global library variable
- Runs amdsmi/rocmsmi tests with sudo
- Removes `continueOnError: true` from ROCR-Runtime test build steps
- Removes MIVisionX and rocprofiler-sdk from list of allowed test failures
  - Addresses first part of https://github.com/ROCm/ROCm/issues/4900

`ALLOWED_PARTIAL_SUCCEED_BUILDS` was used to check whether to allow downloading partially successful builds for a component. However, build steps can only be marked as partially successful if we allow it to be, such as through the `allowComponentTestFailure` list in `test.yml` or in MIOpen's CK fetch script.

Since we need to explicitly allow individual build steps to be partially successful, there's no need to repeat ourselves by then adding component names into a global variable.

The resulting behaviour of this PR is that artifacts from partially successful builds will always be considered for download, whereas previously the global variable would be consulted first.

AMDMIGraphX, pulls partially successful MIOpen build:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=34810&view=results

amdsmi:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=34811&view=results

rocm_smi_lib:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=34812&view=results

ROCR-Runtime:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=34813&view=results