### PR TITLE
[Ex CI] add multi-OS support to copyHIP

### DIFF
--- a/.azuredevops/components/HIP.yml
+++ b/.azuredevops/components/HIP.yml
@@ -51,7 +51,7 @@ parameters:
 # HIP with AMD backend
 jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
-  - job: hip_clr_combined_amd_${{ job.os }}
+  - job: hip_clr_combined_${{ job.os }}_amd
     pool:
       vmImage: 'ubuntu-22.04'
     ${{ if eq(job.os, 'almalinux8') }}:
@@ -121,7 +121,7 @@ jobs:
 
 # HIP with Nvidia backend
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
-  - job: hip_clr_combined_nvidia_${{ job.os }}
+  - job: hip_clr_combined_${{ job.os }}_nvidia
     pool:
       vmImage: 'ubuntu-22.04'
     ${{ if eq(job.os, 'almalinux8') }}:

--- a/.azuredevops/components/copyHIP.yml
+++ b/.azuredevops/components/copyHIP.yml
@@ -32,11 +32,13 @@ jobs:
   # checkout nothing, just copy artifacts from triggering HIP job
   # and then publish for this clr job or for this hipother job to maintain latest
     - checkout: none
-    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-download.yml
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/local-artifact-download.yml
       parameters:
-        componentName: HIP
-        pipelineId: $(HIP_PIPELINE_ID)
-        fileFilter: ${{ job.os }}*${{ job.backend }}
+        buildType: specific
+        buildId: 35129
+        preTargetFilter: HIP
+        os: ${{ job.os }}
+        postTargetFilter: ${{ job.backend }}
     - task: Bash@3
       displayName: Copy HIP artifacts
       inputs:

--- a/.azuredevops/components/copyHIP.yml
+++ b/.azuredevops/components/copyHIP.yml
@@ -1,11 +1,4 @@
 parameters:
-- name: checkoutRepo
-  type: string
-  default: 'self'
-- name: checkoutRef
-  type: string
-  default: ''
-
 - name: jobMatrix
   type: object
   default:

--- a/.azuredevops/components/copyHIP.yml
+++ b/.azuredevops/components/copyHIP.yml
@@ -10,8 +10,10 @@ parameters:
   type: object
   default:
     buildJobs:
-      - { os: ubuntu2204 }
-      - { os: almalinux8 }
+      - { os: ubuntu2204, backend: amd }
+      - { os: almalinux8, backend: amd }
+      - { os: ubuntu2204, backend: nvidia }
+      - { os: almalinux8, backend: nvidia }
 
 # hip and clr are tightly-coupled
 # run this same template for both repos
@@ -34,7 +36,7 @@ jobs:
       parameters:
         componentName: HIP
         pipelineId: $(HIP_PIPELINE_ID)
-        fileFilter: ${{ job.os }}
+        fileFilter: ${{ job.os }}*${{ job.backend }}
     - task: Bash@3
       displayName: Copy HIP artifacts
       inputs:

--- a/.azuredevops/components/copyHIP.yml
+++ b/.azuredevops/components/copyHIP.yml
@@ -25,13 +25,11 @@ jobs:
   # checkout nothing, just copy artifacts from triggering HIP job
   # and then publish for this clr job or for this hipother job to maintain latest
     - checkout: none
-    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/local-artifact-download.yml
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-download.yml
       parameters:
-        buildType: specific
-        buildId: 35129
-        preTargetFilter: HIP
-        os: ${{ job.os }}
-        postTargetFilter: ${{ job.backend }}
+        componentName: HIP
+        pipelineId: $(HIP_PIPELINE_ID)
+        fileFilter: ${{ job.os }}*${{ job.backend }}
     - task: Bash@3
       displayName: Copy HIP artifacts
       inputs:

--- a/.azuredevops/components/copyHIP.yml
+++ b/.azuredevops/components/copyHIP.yml
@@ -2,7 +2,7 @@ parameters:
 - name: jobMatrix
   type: object
   default:
-    buildJobs:
+    copyJobs:
       - { os: ubuntu2204, backend: amd }
       - { os: almalinux8, backend: amd }
       - { os: ubuntu2204, backend: nvidia }
@@ -12,8 +12,8 @@ parameters:
 # run this same template for both repos
 # any changes for clr should just trigger HIP pipeline
 jobs:
-- ${{ each job in parameters.jobMatrix.buildJobs }}:
-  - job: hip_clr_combined_${{ job.os }}
+- ${{ each job in parameters.jobMatrix.copyJobs }}:
+  - job: hip_clr_combined_${{ job.os }}_${{ job.backend }}
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml

--- a/.azuredevops/components/copyHIP.yml
+++ b/.azuredevops/components/copyHIP.yml
@@ -6,31 +6,42 @@ parameters:
   type: string
   default: ''
 
+- name: jobMatrix
+  type: object
+  default:
+    buildJobs:
+      - { os: ubuntu2204 }
+      - { os: almalinux8 }
+
 # hip and clr are tightly-coupled
 # run this same template for both repos
 # any changes for clr should just trigger HIP pipeline
 jobs:
-- job: hip_clr_combined
-  variables:
-  - group: common
-  - template: /.azuredevops/variables-global.yml
-  pool:
-    vmImage: ${{ variables.BASE_BUILD_POOL }}
-  workspace:
-    clean: all
-  steps:
-# checkout nothing, just copy artifacts from triggering HIP job
-# and then publish for this clr job or for this hipother job to maintain latest
-  - checkout: none
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-download.yml
-    parameters:
-      componentName: HIP
-      pipelineId: $(HIP_PIPELINE_ID)
-  - task: Bash@3
-    displayName: Copy HIP artifacts
-    inputs:
-      targetType: inline
-      script: cp -a $(Agent.BuildDirectory)/rocm/* $(Build.BinariesDirectory)/
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
-  - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml
+- ${{ each job in parameters.jobMatrix.buildJobs }}:
+  - job: hip_clr_combined_${{ job.os }}
+    variables:
+    - group: common
+    - template: /.azuredevops/variables-global.yml
+    pool:
+      vmImage: ${{ variables.BASE_BUILD_POOL }}
+    workspace:
+      clean: all
+    steps:
+  # checkout nothing, just copy artifacts from triggering HIP job
+  # and then publish for this clr job or for this hipother job to maintain latest
+    - checkout: none
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-download.yml
+      parameters:
+        componentName: HIP
+        pipelineId: $(HIP_PIPELINE_ID)
+        fileFilter: ${{ job.os }}
+    - task: Bash@3
+      displayName: Copy HIP artifacts
+      inputs:
+        targetType: inline
+        script: cp -a $(Agent.BuildDirectory)/rocm/* $(Build.BinariesDirectory)/
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
+      parameters:
+        os: ${{ job.os }}
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml

--- a/.azuredevops/tag-builds/clr.yml
+++ b/.azuredevops/tag-builds/clr.yml
@@ -50,9 +50,6 @@ pr: none
 jobs:
   - ${{ if eq(variables['Build.Reason'], 'ResourceTrigger') }}:
     - template: ${{ variables.CI_COMPONENT_PATH }}/copyHIP.yml@pipelines_repo
-      parameters:
-        checkoutRepo: release_repo
-        checkoutRef: ${{ parameters.checkoutRef }}
   - ${{ if ne(variables['Build.Reason'], 'ResourceTrigger') }}:
     - template: ${{ variables.CI_COMPONENT_PATH }}/HIP.yml@pipelines_repo
       parameters:

--- a/.azuredevops/tag-builds/clr.yml
+++ b/.azuredevops/tag-builds/clr.yml
@@ -28,12 +28,33 @@ resources:
     endpoint: ROCm
     name: ROCm/hipother
     ref: ${{ parameters.checkoutRef }}
+  pipelines:
+  - pipeline: hip_pipeline
+    source: \experimental\HIP
+    trigger:
+      branches:
+        include:
+        - amd-staging
+        - amd-mainline
+  - pipeline: hipother_pipeline
+    source: \experimental\hipother
+    trigger:
+      branches:
+        include:
+        - amd-staging
+        - amd-mainline
 
 trigger: none
 pr: none
 
 jobs:
-  - template: ${{ variables.CI_COMPONENT_PATH }}/HIP.yml
-    parameters:
-      checkoutRepo: release_repo
-      checkoutRef: ${{ parameters.checkoutRef }}
+  - ${{ if eq(variables['Build.Reason'], 'ResourceTrigger') }}:
+    - template: ${{ variables.CI_COMPONENT_PATH }}/copyHIP.yml@pipelines_repo
+      parameters:
+        checkoutRepo: release_repo
+        checkoutRef: ${{ parameters.checkoutRef }}
+  - ${{ if ne(variables['Build.Reason'], 'ResourceTrigger') }}:
+    - template: ${{ variables.CI_COMPONENT_PATH }}/HIP.yml@pipelines_repo
+      parameters:
+        checkoutRepo: release_repo
+        checkoutRef: ${{ parameters.checkoutRef }}


### PR DESCRIPTION
- Adds multi-OS support to copyHIP, also multi-backend support which was not originally implemented
  - Achieves this by setting `fileFilter` when calling artifact-download
- Swapped HIP's job name ordering from backend-OS to OS-backend, to align with build artifact naming.
- Removed unused `checkoutRepo/Ref` parameters from copyHIP
- Added a pipeline trigger from experimental HIP to CLR pipelines, should help make future copyHIP development a bit easier
  - Can't really test this unless it's merged to develop, so whether it works is to be seen

Sample HIP artifacts:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=35129&view=artifacts&pathAsName=false&type=publishedArtifacts

Sample copyHIP artifacts, pulling from the above run:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=35133&view=artifacts&pathAsName=false&type=publishedArtifacts