### PR TITLE
update to HIP 6.4.1 Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,9 @@ See the full [AMD SMI changelog](https://github.com/ROCm/amdsmi/blob/release/roc
 #### Changed
 
 * HIP runtime uses device bitcode before SPIRV.
-* The implementation of preventing `hipLaunchKernel` latency degradation with number of idle streams is reverted or disabled by default.
+* The implementation of preventing `hipLaunchKernel` latency degradation with number of idle streams is reverted/disabled by default.
+* Stop using `__AMDGCN_WAVEFRONT_SIZE` and `warpSize` as compile-time constants. The `warpSize` variable is no longer `constexpr`, in order to match the CUDA specification.
+  See more details of the `warpSize` change within the [ROCm upcoming changes](#rocm-upcoming-changes).
 
 #### Optimized
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -462,6 +462,8 @@ See the full [AMD SMI changelog](https://github.com/ROCm/amdsmi/blob/release/roc
 
 * HIP runtime uses device bitcode before SPIRV.
 * The implementation of preventing `hipLaunchKernel` latency degradation with number of idle streams is reverted/disabled by default.
+* Stop using `__AMDGCN_WAVEFRONT_SIZE` and `warpSize` as compile-time constants. The `warpSize` variable is no longer `constexpr`, in order to match the CUDA specification.
+  See more details of the `warpSize` change within the [ROCm upcoming changes](#rocm-upcoming-changes).
 
 #### Optimized
 


### PR DESCRIPTION
Add note regarding the deprecation of warpSize constant

Update RELEASE.md and CHANGELOG.md