### PR TITLE
[Ex CI] add more OSs to nightly build

### DIFF
--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -3,12 +3,21 @@ parameters:
 - name: jobList
   type: object
   default:
-    - gfx942-staging:
-      target: gfx942
-      source: staging
-    - gfx90a-staging:
-      target: gfx90a
-      source: staging
+    - { os: ubuntu2204, target: gfx942, source: staging }
+    - { os: ubuntu2204, target: gfx90a, source: staging }
+    - { os: ubuntu2204, target: gfx1201, source: staging }
+    - { os: ubuntu2204, target: gfx1100, source: staging }
+    - { os: ubuntu2204, target: gfx1030, source: staging }
+    - { os: ubuntu2404, target: gfx942, source: staging }
+    - { os: ubuntu2404, target: gfx90a, source: staging }
+    - { os: ubuntu2404, target: gfx1201, source: staging }
+    - { os: ubuntu2404, target: gfx1100, source: staging }
+    - { os: ubuntu2404, target: gfx1030, source: staging }
+    - { os: almalinux8, target: gfx942, source: staging }
+    - { os: almalinux8, target: gfx90a, source: staging }
+    - { os: almalinux8, target: gfx1201, source: staging }
+    - { os: almalinux8, target: gfx1100, source: staging }
+    - { os: almalinux8, target: gfx1030, source: staging }
 - name: rocmDependencies
   type: object
   default:
@@ -16,9 +25,9 @@ parameters:
     - amdsmi
     - aomp-extras
     - aomp
+    - clr
     - composable_kernel
     - half
-    - HIP
     - hip-tests
     - hipBLAS
     - hipBLAS-common
@@ -83,7 +92,7 @@ schedules:
 
 jobs:
 - ${{ each job in parameters.jobList }}:
-  - job: rocm_nightly_${{ job.target }}_${{ job.source }}
+  - job: rocm_nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
@@ -108,9 +117,9 @@ jobs:
       parameters:
         dependencySource: ${{ job.source }}
         dependencyList: ${{ parameters.rocmDependencies }}
+        os: ${{ job.os }}
         gpuTarget: ${{ job.target }}
         skipLibraryLinking: true
-        skipLlvmSymlink: true
     - script: df -h
       displayName: System disk space after ROCm
     - script: du -sh $(Agent.BuildDirectory)/rocm

--- a/.azuredevops/templates/steps/dependencies-rocm.yml
+++ b/.azuredevops/templates/steps/dependencies-rocm.yml
@@ -438,14 +438,14 @@ steps:
       targetType: inline
       script: |
         sudo mkdir -p $(Agent.BuildDirectory)/rocm/lib
-        sudo ln -s $(Agent.BuildDirectory)/rocm/llvm $(Agent.BuildDirectory)/rocm/lib/llvm
+        sudo ln -sr $(Agent.BuildDirectory)/rocm/llvm $(Agent.BuildDirectory)/rocm/lib/llvm
   - task: Bash@3
     displayName: Symlink executables from rocm/llvm/bin to rocm/bin
     inputs:
       targetType: inline
       script: |
         for file in amdclang amdclang++ amdclang-cl amdclang-cpp amdflang amdlld aompcc mygpu mycpu offload-arch; do
-          sudo ln -s $(Agent.BuildDirectory)/rocm/llvm/bin/$file $(Agent.BuildDirectory)/rocm/bin/$file
+          sudo ln -sr $(Agent.BuildDirectory)/rocm/llvm/bin/$file $(Agent.BuildDirectory)/rocm/bin/$file
         done
 # dlopen calls within a ctest or pytest sequence runs into issues when shared library symlink convention is not followed
 # the convention is as follows:


### PR DESCRIPTION
- Adds multi-OS and gfx support to the nightly tarball pipeline
- Changes the nightly run to pull clr instead of hip, to align with how all other pipelines pull clr/hip
- Enables llvm binary symlinks in the nightly run
  - Adds `-r` flag to the symlink creation to create relative links, allows binaries to work in unfamiliar environments
  - https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=34962&view=logs&j=f2fc284a-998a-50e0-02ab-5ff8754dbe1a&t=84d358d3-c6aa-5a68-daac-c8902bb3a2c3&l=131

Sample run:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=34962&view=results