### PR TITLE
[Ex CI] add component name to artifact download filter

### DIFF
--- a/.azuredevops/templates/steps/artifact-download.yml
+++ b/.azuredevops/templates/steps/artifact-download.yml
@@ -22,19 +22,16 @@ steps:
 - task: DownloadPipelineArtifact@2
   displayName: Download ${{ parameters.componentName }}
   inputs:
+    itemPattern: '**/${{ parameters.componentName }}*${{ parameters.fileFilter }}*'
+    targetPath: '$(Pipeline.Workspace)/d'
+    allowPartiallySucceededBuilds: true
     ${{ if parameters.aggregatePipeline }}:
       buildType: 'current'
-      itemPattern: '**/${{ parameters.componentName }}*${{ parameters.fileFilter }}*'
-      allowPartiallySucceededBuilds: true
-      targetPath: '$(Pipeline.Workspace)/d'
     ${{ else }}:
       buildType: 'specific'
       project: ROCm-CI
       specificBuildWithTriggering: true
-      allowPartiallySucceededBuilds: true
       definition: ${{ parameters.pipelineId }}
-      itemPattern: '**/*${{ parameters.fileFilter }}*'
-      targetPath: '$(Pipeline.Workspace)/d'
       branchName: refs/heads/${{ parameters.branchName }}
       ${{ if eq(parameters.componentName, 'aomp') }}:
         buildVersionToDownload: latest # aomp trigger lives in ROCm/ROCm, so cannot use ROCm/aomp branch names

--- a/.azuredevops/templates/steps/artifact-download.yml
+++ b/.azuredevops/templates/steps/artifact-download.yml
@@ -22,7 +22,7 @@ steps:
 - task: DownloadPipelineArtifact@2
   displayName: Download ${{ parameters.componentName }}
   inputs:
-    itemPattern: '**/${{ parameters.componentName }}*${{ parameters.fileFilter }}*'
+    itemPattern: '**/*${{ parameters.componentName }}*${{ parameters.fileFilter }}*'
     targetPath: '$(Pipeline.Workspace)/d'
     allowPartiallySucceededBuilds: true
     ${{ if parameters.aggregatePipeline }}:


### PR DESCRIPTION
Adds `componentName` to artifact download filters for the `aggregatePipeline==false` case. Fixes a case for builds containing downstream jobs, which will upload artifacts for multiple components.

Moved parameters that were identical across the two cases outside of the if statements.

Sample hipRAND run, no longer downloads hipRAND artifacts from the rocRAND build it's pulling from:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=36248&view=logs&j=934d792e-1aad-56dd-d526-a919023137ca&t=3fe09b6f-96a8-5e46-f1bb-3409f156ec45&l=61