### PR TITLE
[Ex CI] rocAL: switch to medium pool

### DIFF
--- a/.azuredevops/components/rocAL.yml
+++ b/.azuredevops/components/rocAL.yml
@@ -86,8 +86,7 @@ jobs:
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
-    pool:
-      vmImage: ${{ variables.BASE_BUILD_POOL }}
+    pool:  ${{ variables.MEDIUM_BUILD_POOL }}
     workspace:
       clean: all
     steps:


### PR DESCRIPTION
To resolve out-of-storage errors when building rocAL.

Sample run:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=36393&view=results