### PR TITLE
[Ex CI] hipBLASLt: build some archs on medium pool

### DIFF
--- a/.azuredevops/components/hipBLASLt.yml
+++ b/.azuredevops/components/hipBLASLt.yml
@@ -77,16 +77,16 @@ parameters:
   type: object
   default:
     buildJobs:
-      - { os: ubuntu2204, packageManager: apt, target: gfx942 }
-      - { os: ubuntu2204, packageManager: apt, target: gfx90a }
-      - { os: ubuntu2204, packageManager: apt, target: gfx1201 }
-      - { os: ubuntu2204, packageManager: apt, target: gfx1100 }
-      - { os: ubuntu2204, packageManager: apt, target: gfx1030 }
-      - { os: almalinux8, packageManager: dnf, target: gfx942 }
-      - { os: almalinux8, packageManager: dnf, target: gfx90a }
-      - { os: almalinux8, packageManager: dnf, target: gfx1201 }
-      - { os: almalinux8, packageManager: dnf, target: gfx1100 }
-      - { os: almalinux8, packageManager: dnf, target: gfx1030 }
+      - { pool: rocm-ci_ultra_build_pool, os: ubuntu2204, packageManager: apt, target: gfx942 }
+      - { pool: rocm-ci_medium_build_pool, os: ubuntu2204, packageManager: apt, target: gfx90a }
+      - { pool: rocm-ci_medium_build_pool, os: ubuntu2204, packageManager: apt, target: gfx1201 }
+      - { pool: rocm-ci_medium_build_pool, os: ubuntu2204, packageManager: apt, target: gfx1100 }
+      - { pool: rocm-ci_medium_build_pool, os: ubuntu2204, packageManager: apt, target: gfx1030 }
+      - { pool: rocm-ci_ultra_build_pool, os: almalinux8, packageManager: dnf, target: gfx942 }
+      - { pool: rocm-ci_medium_build_pool, os: almalinux8, packageManager: dnf, target: gfx90a }
+      - { pool: rocm-ci_medium_build_pool, os: almalinux8, packageManager: dnf, target: gfx1201 }
+      - { pool: rocm-ci_medium_build_pool, os: almalinux8, packageManager: dnf, target: gfx1100 }
+      - { pool: rocm-ci_medium_build_pool, os: almalinux8, packageManager: dnf, target: gfx1030 }
     testJobs:
       - { os: ubuntu2204, packageManager: apt, target: gfx942 }
       - { os: ubuntu2204, packageManager: apt, target: gfx90a }
@@ -121,7 +121,7 @@ jobs:
       value: $(Agent.BuildDirectory)/rocm
     - name: DAY_STRING
       value: $[format('{0:ddMMyyyy}', pipeline.startTime)]
-    pool: ${{ variables.ULTRA_BUILD_POOL }}
+    pool: ${{ job.pool }}
     ${{ if eq(job.os, 'almalinux8') }}:
       container:
         image: rocmexternalcicd.azurecr.io/manylinux228:latest

--- a/.azuredevops/components/hipBLASLt.yml
+++ b/.azuredevops/components/hipBLASLt.yml
@@ -77,12 +77,12 @@ parameters:
   type: object
   default:
     buildJobs:
-      # - { pool: rocm-ci_ultra_build_pool, os: ubuntu2204, packageManager: apt, target: gfx942 }
+      - { pool: rocm-ci_ultra_build_pool, os: ubuntu2204, packageManager: apt, target: gfx942 }
       - { pool: rocm-ci_medium_build_pool, os: ubuntu2204, packageManager: apt, target: gfx90a }
       - { pool: rocm-ci_medium_build_pool, os: ubuntu2204, packageManager: apt, target: gfx1201 }
       - { pool: rocm-ci_medium_build_pool, os: ubuntu2204, packageManager: apt, target: gfx1100 }
       - { pool: rocm-ci_medium_build_pool, os: ubuntu2204, packageManager: apt, target: gfx1030 }
-      # - { pool: rocm-ci_ultra_build_pool, os: almalinux8, packageManager: dnf, target: gfx942 }
+      - { pool: rocm-ci_ultra_build_pool, os: almalinux8, packageManager: dnf, target: gfx942 }
       - { pool: rocm-ci_medium_build_pool, os: almalinux8, packageManager: dnf, target: gfx90a }
       - { pool: rocm-ci_medium_build_pool, os: almalinux8, packageManager: dnf, target: gfx1201 }
       - { pool: rocm-ci_medium_build_pool, os: almalinux8, packageManager: dnf, target: gfx1100 }
@@ -225,61 +225,61 @@ jobs:
           extraCopyDirectories:
             - deps
 
-# - ${{ if eq(parameters.unifiedBuild, False) }}:
-#   - ${{ each job in parameters.jobMatrix.testJobs }}:
-#     - job: ${{ parameters.componentName }}_test_${{ job.os }}_${{ job.target }}
-#       timeoutInMinutes: 300
-#       dependsOn: ${{ parameters.componentName }}_build_${{ job.os }}_${{ job.target }}
-#       condition:
-#         and(succeeded(),
-#           eq(variables['ENABLE_${{ upper(job.target) }}_TESTS'], 'true'),
-#           not(containsValue(split(variables['DISABLED_${{ upper(job.target) }}_TESTS'], ','), '${{ parameters.componentName }}')),
-#           eq(${{ parameters.aggregatePipeline }}, False)
-#         )
-#       variables:
-#       - group: common
-#       - template: /.azuredevops/variables-global.yml
-#       - name: ROCM_PATH
-#         value: $(Agent.BuildDirectory)/rocm
-#       pool: ${{ job.target }}_test_pool
-#       workspace:
-#         clean: all
-#       steps:
-#       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
-#         parameters:
-#           aptPackages: ${{ parameters.aptPackages }}
-#           pipModules: ${{ parameters.pipModules }}
-#       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
-#       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/local-artifact-download.yml
-#         parameters:
-#           preTargetFilter: ${{ parameters.componentName }}
-#           os: ${{ job.os }}
-#           gpuTarget: ${{ job.target }}
-#       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-aqlprofile.yml
-#         parameters:
-#           os: ${{ job.os }}
-#       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
-#         parameters:
-#           checkoutRef: ${{ parameters.checkoutRef }}
-#           dependencyList: ${{ parameters.rocmTestDependencies }}
-#           os: ${{ job.os }}
-#           gpuTarget: ${{ job.target }}
-#           ${{ if parameters.triggerDownstreamJobs }}:
-#             downstreamAggregateNames: ${{ parameters.downstreamAggregateNames }}
-#       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/gpu-diagnostics.yml
-#       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
-#         parameters:
-#           componentName: ${{ parameters.componentName }}
-#           os: ${{ job.os }}
-#           testDir: '$(Agent.BuildDirectory)/rocm/bin'
-#           testExecutable: './hipblaslt-test'
-#           testParameters: '--gtest_output=xml:./test_output.xml --gtest_color=yes --gtest_filter=*pre_checkin*'
-#       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/docker-container.yml
-#         parameters:
-#           aptPackages: ${{ parameters.aptPackages }}
-#           pipModules: ${{ parameters.pipModules }}
-#           environment: test
-#           gpuTarget: ${{ job.target }}
+- ${{ if eq(parameters.unifiedBuild, False) }}:
+  - ${{ each job in parameters.jobMatrix.testJobs }}:
+    - job: ${{ parameters.componentName }}_test_${{ job.os }}_${{ job.target }}
+      timeoutInMinutes: 300
+      dependsOn: ${{ parameters.componentName }}_build_${{ job.os }}_${{ job.target }}
+      condition:
+        and(succeeded(),
+          eq(variables['ENABLE_${{ upper(job.target) }}_TESTS'], 'true'),
+          not(containsValue(split(variables['DISABLED_${{ upper(job.target) }}_TESTS'], ','), '${{ parameters.componentName }}')),
+          eq(${{ parameters.aggregatePipeline }}, False)
+        )
+      variables:
+      - group: common
+      - template: /.azuredevops/variables-global.yml
+      - name: ROCM_PATH
+        value: $(Agent.BuildDirectory)/rocm
+      pool: ${{ job.target }}_test_pool
+      workspace:
+        clean: all
+      steps:
+      - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
+        parameters:
+          aptPackages: ${{ parameters.aptPackages }}
+          pipModules: ${{ parameters.pipModules }}
+      - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+      - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/local-artifact-download.yml
+        parameters:
+          preTargetFilter: ${{ parameters.componentName }}
+          os: ${{ job.os }}
+          gpuTarget: ${{ job.target }}
+      - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-aqlprofile.yml
+        parameters:
+          os: ${{ job.os }}
+      - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
+        parameters:
+          checkoutRef: ${{ parameters.checkoutRef }}
+          dependencyList: ${{ parameters.rocmTestDependencies }}
+          os: ${{ job.os }}
+          gpuTarget: ${{ job.target }}
+          ${{ if parameters.triggerDownstreamJobs }}:
+            downstreamAggregateNames: ${{ parameters.downstreamAggregateNames }}
+      - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/gpu-diagnostics.yml
+      - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
+        parameters:
+          componentName: ${{ parameters.componentName }}
+          os: ${{ job.os }}
+          testDir: '$(Agent.BuildDirectory)/rocm/bin'
+          testExecutable: './hipblaslt-test'
+          testParameters: '--gtest_output=xml:./test_output.xml --gtest_color=yes --gtest_filter=*pre_checkin*'
+      - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/docker-container.yml
+        parameters:
+          aptPackages: ${{ parameters.aptPackages }}
+          pipModules: ${{ parameters.pipModules }}
+          environment: test
+          gpuTarget: ${{ job.target }}
 
 # - ${{ if parameters.triggerDownstreamJobs }}:
 #   - ${{ each component in parameters.downstreamComponentMatrix }}:

--- a/.azuredevops/components/hipBLASLt.yml
+++ b/.azuredevops/components/hipBLASLt.yml
@@ -77,12 +77,12 @@ parameters:
   type: object
   default:
     buildJobs:
-      - { pool: rocm-ci_ultra_build_pool, os: ubuntu2204, packageManager: apt, target: gfx942 }
+      # - { pool: rocm-ci_ultra_build_pool, os: ubuntu2204, packageManager: apt, target: gfx942 }
       - { pool: rocm-ci_medium_build_pool, os: ubuntu2204, packageManager: apt, target: gfx90a }
       - { pool: rocm-ci_medium_build_pool, os: ubuntu2204, packageManager: apt, target: gfx1201 }
       - { pool: rocm-ci_medium_build_pool, os: ubuntu2204, packageManager: apt, target: gfx1100 }
       - { pool: rocm-ci_medium_build_pool, os: ubuntu2204, packageManager: apt, target: gfx1030 }
-      - { pool: rocm-ci_ultra_build_pool, os: almalinux8, packageManager: dnf, target: gfx942 }
+      # - { pool: rocm-ci_ultra_build_pool, os: almalinux8, packageManager: dnf, target: gfx942 }
       - { pool: rocm-ci_medium_build_pool, os: almalinux8, packageManager: dnf, target: gfx90a }
       - { pool: rocm-ci_medium_build_pool, os: almalinux8, packageManager: dnf, target: gfx1201 }
       - { pool: rocm-ci_medium_build_pool, os: almalinux8, packageManager: dnf, target: gfx1100 }
@@ -225,61 +225,61 @@ jobs:
           extraCopyDirectories:
             - deps
 
-- ${{ if eq(parameters.unifiedBuild, False) }}:
-  - ${{ each job in parameters.jobMatrix.testJobs }}:
-    - job: ${{ parameters.componentName }}_test_${{ job.os }}_${{ job.target }}
-      timeoutInMinutes: 300
-      dependsOn: ${{ parameters.componentName }}_build_${{ job.os }}_${{ job.target }}
-      condition:
-        and(succeeded(),
-          eq(variables['ENABLE_${{ upper(job.target) }}_TESTS'], 'true'),
-          not(containsValue(split(variables['DISABLED_${{ upper(job.target) }}_TESTS'], ','), '${{ parameters.componentName }}')),
-          eq(${{ parameters.aggregatePipeline }}, False)
-        )
-      variables:
-      - group: common
-      - template: /.azuredevops/variables-global.yml
-      - name: ROCM_PATH
-        value: $(Agent.BuildDirectory)/rocm
-      pool: ${{ job.target }}_test_pool
-      workspace:
-        clean: all
-      steps:
-      - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
-        parameters:
-          aptPackages: ${{ parameters.aptPackages }}
-          pipModules: ${{ parameters.pipModules }}
-      - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
-      - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/local-artifact-download.yml
-        parameters:
-          preTargetFilter: ${{ parameters.componentName }}
-          os: ${{ job.os }}
-          gpuTarget: ${{ job.target }}
-      - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-aqlprofile.yml
-        parameters:
-          os: ${{ job.os }}
-      - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
-        parameters:
-          checkoutRef: ${{ parameters.checkoutRef }}
-          dependencyList: ${{ parameters.rocmTestDependencies }}
-          os: ${{ job.os }}
-          gpuTarget: ${{ job.target }}
-          ${{ if parameters.triggerDownstreamJobs }}:
-            downstreamAggregateNames: ${{ parameters.downstreamAggregateNames }}
-      - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/gpu-diagnostics.yml
-      - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
-        parameters:
-          componentName: ${{ parameters.componentName }}
-          os: ${{ job.os }}
-          testDir: '$(Agent.BuildDirectory)/rocm/bin'
-          testExecutable: './hipblaslt-test'
-          testParameters: '--gtest_output=xml:./test_output.xml --gtest_color=yes --gtest_filter=*pre_checkin*'
-      - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/docker-container.yml
-        parameters:
-          aptPackages: ${{ parameters.aptPackages }}
-          pipModules: ${{ parameters.pipModules }}
-          environment: test
-          gpuTarget: ${{ job.target }}
+# - ${{ if eq(parameters.unifiedBuild, False) }}:
+#   - ${{ each job in parameters.jobMatrix.testJobs }}:
+#     - job: ${{ parameters.componentName }}_test_${{ job.os }}_${{ job.target }}
+#       timeoutInMinutes: 300
+#       dependsOn: ${{ parameters.componentName }}_build_${{ job.os }}_${{ job.target }}
+#       condition:
+#         and(succeeded(),
+#           eq(variables['ENABLE_${{ upper(job.target) }}_TESTS'], 'true'),
+#           not(containsValue(split(variables['DISABLED_${{ upper(job.target) }}_TESTS'], ','), '${{ parameters.componentName }}')),
+#           eq(${{ parameters.aggregatePipeline }}, False)
+#         )
+#       variables:
+#       - group: common
+#       - template: /.azuredevops/variables-global.yml
+#       - name: ROCM_PATH
+#         value: $(Agent.BuildDirectory)/rocm
+#       pool: ${{ job.target }}_test_pool
+#       workspace:
+#         clean: all
+#       steps:
+#       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
+#         parameters:
+#           aptPackages: ${{ parameters.aptPackages }}
+#           pipModules: ${{ parameters.pipModules }}
+#       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+#       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/local-artifact-download.yml
+#         parameters:
+#           preTargetFilter: ${{ parameters.componentName }}
+#           os: ${{ job.os }}
+#           gpuTarget: ${{ job.target }}
+#       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-aqlprofile.yml
+#         parameters:
+#           os: ${{ job.os }}
+#       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
+#         parameters:
+#           checkoutRef: ${{ parameters.checkoutRef }}
+#           dependencyList: ${{ parameters.rocmTestDependencies }}
+#           os: ${{ job.os }}
+#           gpuTarget: ${{ job.target }}
+#           ${{ if parameters.triggerDownstreamJobs }}:
+#             downstreamAggregateNames: ${{ parameters.downstreamAggregateNames }}
+#       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/gpu-diagnostics.yml
+#       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
+#         parameters:
+#           componentName: ${{ parameters.componentName }}
+#           os: ${{ job.os }}
+#           testDir: '$(Agent.BuildDirectory)/rocm/bin'
+#           testExecutable: './hipblaslt-test'
+#           testParameters: '--gtest_output=xml:./test_output.xml --gtest_color=yes --gtest_filter=*pre_checkin*'
+#       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/docker-container.yml
+#         parameters:
+#           aptPackages: ${{ parameters.aptPackages }}
+#           pipModules: ${{ parameters.pipModules }}
+#           environment: test
+#           gpuTarget: ${{ job.target }}
 
 # - ${{ if parameters.triggerDownstreamJobs }}:
 #   - ${{ each component in parameters.downstreamComponentMatrix }}:


### PR DESCRIPTION
For hipBLASLt, move everything except gfx942 onto the medium pool to save time and resources, as ultra pool is not currently equipped to handle its workload. For some reason they have the exact same build time as on the ultra pool, so no loss there.

Sample run:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=36597&view=results