### PR TITLE
[Ex CI] fix hardcoded gfx in MIOpen CK script

### DIFF
--- a/.azuredevops/templates/steps/miopen-get-ck-build.yml
+++ b/.azuredevops/templates/steps/miopen-get-ck-build.yml
@@ -40,7 +40,7 @@ steps:
 
       AZURE_URL="$AZ_API/build/builds/$CK_BUILD_ID/artifacts?api-version=7.1"
       ARTIFACT_URL=$(curl -s $AZURE_URL | \
-        jq --arg os "ubuntu2204" --arg gfx "gfx942" '
+        jq --arg os "ubuntu2204" --arg gfx "${{ parameters.gpuTarget }}" '
           .value
           | map(select(.name | test($os) and test($gfx)))
           | max_by(.name | capture("drop_(?<dropNumber>\\d+)").dropNumber | tonumber)
@@ -56,7 +56,7 @@ steps:
         echo "Found latest CK build ID: $CK_BUILD_ID"
         AZURE_URL="$AZ_API/build/builds/$CK_BUILD_ID/artifacts?api-version=7.1"
         ARTIFACT_URL=$(curl -s $AZURE_URL | \
-          jq --arg os "ubuntu2204" --arg gfx "gfx942" '
+          jq --arg os "ubuntu2204" --arg gfx "${{ parameters.gpuTarget }}" '
             .value
             | map(select(.name | test($os) and test($gfx)))
             | max_by(.name | capture("drop_(?<dropNumber>\\d+)").dropNumber | tonumber)


### PR DESCRIPTION
Leftover hardcode value in the MIOpen CK fetch script from https://github.com/ROCm/ROCm/pull/4979

Sample logs:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=36649&view=logs&j=4ccf6814-32e2-5a45-fd08-84e9ca6c68aa&t=05487e32-0074-57d1-c37c-488dc0e472ca&l=17