### PR TITLE
[Ex CI] rocBLAS: increase test timeout to 2 hours

### DIFF
--- a/.azuredevops/components/rocBLAS.yml
+++ b/.azuredevops/components/rocBLAS.yml
@@ -202,6 +202,7 @@ jobs:
 - ${{ if eq(parameters.unifiedBuild, False) }}:
   - ${{ each job in parameters.jobMatrix.testJobs }}:
     - job: ${{ parameters.componentName }}_test_${{ job.os }}_${{ job.target }}
+      timeoutInMinutes: 120
       dependsOn: ${{ parameters.componentName }}_build_${{ job.os }}_${{ job.target }}
       condition:
         and(succeeded(),


### PR DESCRIPTION
Observed timeout in rocBLAS gfx942 tests: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=36771&view=results

Sample run:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=36919&view=results