### PR TITLE
[Ex CI] fix printed artifact download links

### DIFF
--- a/.azuredevops/templates/steps/artifact-links.yml
+++ b/.azuredevops/templates/steps/artifact-links.yml
@@ -15,8 +15,8 @@ steps:
       URL_BEGIN="https://artprodcus3.artifacts.visualstudio.com/"
       URL_MIDDLE="/_apis/artifact/"
       URL_END="/content?format=file&subPath=%2F"
-      FORMATTED_JOB_NAME=$(echo "$(Agent.JobName)_$(System.JobAttempt)" | sed 's/ /./g; s/[-_]//g')
-      ARTIFACT_STRING="pipelineartifact://ROCm-CI/projectId/$(DOWNLOAD_PROJECT_ID)/buildId/$(Build.BuildId)/artifactName/${FORMATTED_JOB_NAME}"
+      JOB_NAME="$(Agent.JobName)_$(System.JobAttempt)"
+      ARTIFACT_STRING="pipelineartifact://ROCm-CI/projectId/$(DOWNLOAD_PROJECT_ID)/buildId/$(Build.BuildId)/artifactName/${JOB_NAME}"
       ENCODED_STRING=$(echo -n "${ARTIFACT_STRING}" | base64 -w 0)
       PADDING_COUNT=$(echo -n "${ENCODED_STRING}" | awk -F= '{print NF-1}')
       if [ "$PADDING_COUNT" -gt 0 ]; then

--- a/.azuredevops/templates/steps/artifact-links.yml
+++ b/.azuredevops/templates/steps/artifact-links.yml
@@ -15,7 +15,7 @@ steps:
       URL_BEGIN="https://artprodcus3.artifacts.visualstudio.com/"
       URL_MIDDLE="/_apis/artifact/"
       URL_END="/content?format=file&subPath=%2F"
-      FORMATTED_JOB_NAME=$(echo $(Agent.JobName) | sed 's/ /./g; s/[-_]//g')
+      FORMATTED_JOB_NAME=$(echo "$(Agent.JobName)_$(System.JobAttempt)" | sed 's/ /./g; s/[-_]//g')
       ARTIFACT_STRING="pipelineartifact://ROCm-CI/projectId/$(DOWNLOAD_PROJECT_ID)/buildId/$(Build.BuildId)/artifactName/${FORMATTED_JOB_NAME}"
       ENCODED_STRING=$(echo -n "${ARTIFACT_STRING}" | base64 -w 0)
       PADDING_COUNT=$(echo -n "${ENCODED_STRING}" | awk -F= '{print NF-1}')

--- a/.azuredevops/templates/steps/artifact-links.yml
+++ b/.azuredevops/templates/steps/artifact-links.yml
@@ -15,8 +15,8 @@ steps:
       URL_BEGIN="https://artprodcus3.artifacts.visualstudio.com/"
       URL_MIDDLE="/_apis/artifact/"
       URL_END="/content?format=file&subPath=%2F"
-      JOB_NAME="$(Agent.JobName)_$(System.JobAttempt)"
-      ARTIFACT_STRING="pipelineartifact://ROCm-CI/projectId/$(DOWNLOAD_PROJECT_ID)/buildId/$(Build.BuildId)/artifactName/${JOB_NAME}"
+      ARTIFACT_NAME="$(Agent.JobName)_$(System.JobAttempt)"
+      ARTIFACT_STRING="pipelineartifact://ROCm-CI/projectId/$(DOWNLOAD_PROJECT_ID)/buildId/$(Build.BuildId)/artifactName/${ARTIFACT_NAME}"
       ENCODED_STRING=$(echo -n "${ARTIFACT_STRING}" | base64 -w 0)
       PADDING_COUNT=$(echo -n "${ENCODED_STRING}" | awk -F= '{print NF-1}')
       if [ "$PADDING_COUNT" -gt 0 ]; then

--- a/.azuredevops/templates/steps/artifact-upload.yml
+++ b/.azuredevops/templates/steps/artifact-upload.yml
@@ -46,5 +46,5 @@ steps:
     displayName: '${{ parameters.artifactName }} Publish'
     retryCountOnTaskFailure: 3
     inputs:
-      artifactName: ${{ parameters.componentName }}_$(Build.BuildId)_$(Build.BuildNumber)_${{ parameters.os }}_${{ parameters.gpuTarget }}_${{ parameters.artifactName }}_$(System.JobAttempt)
+      artifactName: $(Agent.JobName)_$(System.JobAttempt)
       targetPath: '$(Build.ArtifactStagingDirectory)'

--- a/.azuredevops/templates/steps/manifest.yml
+++ b/.azuredevops/templates/steps/manifest.yml
@@ -23,7 +23,7 @@ steps:
   inputs:
     targetType: inline
     script: |
-      ${{ iif(or(eq(job.os, 'ubuntu2204'), eq(job.os, 'ubuntu2404')), 'sudo apt-get install -y jq', '') }}
+      ${{ iif(or(eq(parameters.os, 'ubuntu2204'), eq(parameters.os, 'ubuntu2404')), 'sudo apt-get install -y jq', '') }}
 
       echo "##vso[task.setvariable variable=manifest_filename]manifest_${{ parameters.componentName }}_$(Build.BuildId)_$(Build.BuildNumber)_${{ parameters.os }}_${{ parameters.gpuTarget }}_${{ parameters.artifactName }}"
 

--- a/.azuredevops/templates/steps/manifest.yml
+++ b/.azuredevops/templates/steps/manifest.yml
@@ -30,6 +30,7 @@ steps:
       cat <<EOF > resources.repositories
       $(RESOURCES_REPOSITORIES)
       EOF
+      echo "Value of resources.repositories:"
       cat resources.repositories
 
       IS_TAG_BUILD=$(jq 'has("release_repo")' resources.repositories)
@@ -111,7 +112,14 @@ steps:
         ')
       dependencies_rows=$(echo $dependencies_rows)
       echo "##vso[task.setvariable variable=dependencies_rows;]$dependencies_rows"
-
+- task: Bash@3
+  displayName: Print manifest.json
+  condition: always()
+  continueOnError: true
+  inputs:
+    targetType: inline
+    script: |
+      manifest_json=$(Build.ArtifactStagingDirectory)/manifest_${{ parameters.componentName }}_$(Build.BuildId)_$(Build.BuildNumber)_${{ parameters.os }}_${{ parameters.gpuTarget }}_${{ parameters.artifactName }}.json
       cat $manifest_json
 - task: Bash@3
   displayName: Create manifest.html
@@ -123,7 +131,7 @@ steps:
       manifest_html=$(Build.ArtifactStagingDirectory)/manifest_${{ parameters.componentName }}_$(Build.BuildId)_$(Build.BuildNumber)_${{ parameters.os }}_${{ parameters.gpuTarget }}_${{ parameters.artifactName }}.html
       cat <<EOF > $manifest_html
       <html>
-      <h1>Manifest</h1>
+      <h1>$manifest_html</h1>
       <h2>Current</h2>
       <table border="1">
       <tr>

--- a/.azuredevops/templates/steps/manifest.yml
+++ b/.azuredevops/templates/steps/manifest.yml
@@ -23,7 +23,7 @@ steps:
   inputs:
     targetType: inline
     script: |
-      ${{ iif((eq(job.os, 'ubuntu2204'), eq(job.os, 'ubuntu2404')), 'sudo apt-get install -y jq', '') }}
+      ${{ iif(or(eq(job.os, 'ubuntu2204'), eq(job.os, 'ubuntu2404')), 'sudo apt-get install -y jq', '') }}
 
       echo "##vso[task.setvariable variable=manifest_filename]manifest_${{ parameters.componentName }}_$(Build.BuildId)_$(Build.BuildNumber)_${{ parameters.os }}_${{ parameters.gpuTarget }}_${{ parameters.artifactName }}"
 

--- a/.azuredevops/templates/steps/manifest.yml
+++ b/.azuredevops/templates/steps/manifest.yml
@@ -25,8 +25,6 @@ steps:
     script: |
       ${{ iif(or(eq(parameters.os, 'ubuntu2204'), eq(parameters.os, 'ubuntu2404')), 'sudo apt-get install -y jq', '') }}
 
-      echo "##vso[task.setvariable variable=manifest_filename]manifest_${{ parameters.componentName }}_$(Build.BuildId)_$(Build.BuildNumber)_${{ parameters.os }}_${{ parameters.gpuTarget }}_${{ parameters.artifactName }}"
-
       # RESOURCES_REPOSITORIES is a runtime variable (not an env var!) that contains quotations and newlines
       # So we need to save it to a file to properly preserve its formatting and contents
       cat <<EOF > resources.repositories
@@ -69,8 +67,6 @@ steps:
         )
       ' resources.repositories)
 
-      manifest_json=$(Build.ArtifactStagingDirectory)/$(manifest_filename).json
-
       dependencies=()
       for manifest_file in $(Pipeline.Workspace)/d/**/manifest_*.json; do
         echo "Processing $manifest_file"
@@ -80,6 +76,10 @@ steps:
         done <<< "$file"
       done
       dependencies_json=$(printf '%s\n' "${dependencies[@]}" | jq -s '.')
+
+      manifest_filename="manifest_${{ parameters.componentName }}_$(Build.BuildId)_$(Build.BuildNumber)_${{ parameters.os }}_${{ parameters.gpuTarget }}_${{ parameters.artifactName }}"
+      echo "##vso[task.setvariable variable=manifest_filename]$manifest_filename"
+      manifest_json=$(Build.ArtifactStagingDirectory)/$manifest_filename.json
 
       jq -n \
         --argjson current "$current" \
@@ -121,8 +121,7 @@ steps:
   inputs:
     targetType: inline
     script: |
-      manifest_json=$(Build.ArtifactStagingDirectory)/manifest_filename.json
-      cat $manifest_json
+      cat $(Build.ArtifactStagingDirectory)/$(manifest_filename).json
 - task: Bash@3
   displayName: Create manifest.html
   condition: always()

--- a/.azuredevops/templates/steps/manifest.yml
+++ b/.azuredevops/templates/steps/manifest.yml
@@ -23,7 +23,9 @@ steps:
   inputs:
     targetType: inline
     script: |
-      sudo apt-get install -y jq
+      ${{ iif((eq(job.os, 'ubuntu2204'), eq(job.os, 'ubuntu2404')), 'sudo apt-get install -y jq', '') }}
+
+      echo "##vso[task.setvariable variable=manifest_filename]manifest_${{ parameters.componentName }}_$(Build.BuildId)_$(Build.BuildNumber)_${{ parameters.os }}_${{ parameters.gpuTarget }}_${{ parameters.artifactName }}"
 
       # RESOURCES_REPOSITORIES is a runtime variable (not an env var!) that contains quotations and newlines
       # So we need to save it to a file to properly preserve its formatting and contents
@@ -67,7 +69,7 @@ steps:
         )
       ' resources.repositories)
 
-      manifest_json=$(Build.ArtifactStagingDirectory)/manifest_${{ parameters.componentName }}_$(Build.BuildId)_$(Build.BuildNumber)_${{ parameters.os }}_${{ parameters.gpuTarget }}_${{ parameters.artifactName }}.json
+      manifest_json=$(Build.ArtifactStagingDirectory)/$(manifest_filename).json
 
       dependencies=()
       for manifest_file in $(Pipeline.Workspace)/d/**/manifest_*.json; do
@@ -119,7 +121,7 @@ steps:
   inputs:
     targetType: inline
     script: |
-      manifest_json=$(Build.ArtifactStagingDirectory)/manifest_${{ parameters.componentName }}_$(Build.BuildId)_$(Build.BuildNumber)_${{ parameters.os }}_${{ parameters.gpuTarget }}_${{ parameters.artifactName }}.json
+      manifest_json=$(Build.ArtifactStagingDirectory)/manifest_filename.json
       cat $manifest_json
 - task: Bash@3
   displayName: Create manifest.html
@@ -128,10 +130,10 @@ steps:
   inputs:
     targetType: inline
     script: |
-      manifest_html=$(Build.ArtifactStagingDirectory)/manifest_${{ parameters.componentName }}_$(Build.BuildId)_$(Build.BuildNumber)_${{ parameters.os }}_${{ parameters.gpuTarget }}_${{ parameters.artifactName }}.html
+      manifest_html="$(Build.ArtifactStagingDirectory)/$(manifest_filename).html"
       cat <<EOF > $manifest_html
       <html>
-      <h1>$manifest_html</h1>
+      <h1>$(manifest_filename)</h1>
       <h2>Current</h2>
       <table border="1">
       <tr>
@@ -171,7 +173,7 @@ steps:
   continueOnError: true
   inputs:
     tabName: Manifest
-    reportDir: $(Build.ArtifactStagingDirectory)/manifest_${{ parameters.componentName }}_$(Build.BuildId)_$(Build.BuildNumber)_${{ parameters.os }}_${{ parameters.gpuTarget }}_${{ parameters.artifactName }}.html
+    reportDir: $(Build.ArtifactStagingDirectory)/$(manifest_filename).html
 - task: Bash@3
   displayName: Save manifest artifact file name
   condition: always()
@@ -180,5 +182,5 @@ steps:
     workingDirectory: $(Pipeline.Workspace)
     targetType: inline
     script: |
-      echo "manifest_${{ parameters.componentName }}_$(Build.BuildId)_$(Build.BuildNumber)_${{ parameters.os }}_${{ parameters.gpuTarget }}_${{ parameters.artifactName }}.html" >> pipelineArtifacts.txt
-      echo "manifest_${{ parameters.componentName }}_$(Build.BuildId)_$(Build.BuildNumber)_${{ parameters.os }}_${{ parameters.gpuTarget }}_${{ parameters.artifactName }}.json" >> pipelineArtifacts.txt
+      echo "$(manifest_filename).html" >> pipelineArtifacts.txt
+      echo "$(manifest_filename).json" >> pipelineArtifacts.txt


### PR DESCRIPTION
- Fixed printed artifact links which were broken following https://github.com/ROCm/ROCm/pull/4959

Reverted the more-verbose artifact names in that PR, since it'd require a lot more params in `artifact-links.yml` for little benefit. Artifact names now solely depend on Azure-defined system-wide variables (indicated by the `$(Var.SomeName)` syntax), which do not require adding parameters into every single template (ie. `ARTIFACT_NAME="$(Agent.JobName)_$(System.JobAttempt)"`). This will still allow rerun build jobs to work properly.

- Separated manifest JSON creation/printing into different steps to help with visibility
- Saved the manifest filename into an exported `manifest_filename` var to avoid repeating the really long filename creation line

Sample run:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=37006&view=results