### PR TITLE
[Ex CI] create Docker images for nightly builds

### DIFF
--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -211,7 +211,7 @@ jobs:
               RUN ARTIFACT_URL="https://dev.azure.com/ROCm-CI/ROCm-CI/_apis/build/builds/$(Build.BuildId)/artifacts?artifactName=nightly${{ job.os }}${{ job.target }}${{ job.source }}&api-version=7.1" \
                 && DOWNLOAD_URL=$(curl -s $ARTIFACT_URL | jq ".resource.downloadUrl" | tr -d '"') \
                 && wget -nv --retry-connrefused $DOWNLOAD_URL -O nightly.zip \
-                && unzip nightly.zip \
+                && UNZIP_DISABLE_ZIPBOMB_DETECTION=TRUE unzip nightly.zip \
                 && tar -xf nightly${{ job.os }}${{ job.target }}${{ job.source }}/rocm-nightly*${{ job.os }}*${{ job.target }}*.tar.gz -C rocm
 
               RUN echo /root/rocm/lib | tee /etc/ld.so.conf.d/rocm-ci.conf

--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -150,11 +150,9 @@ stages:
           script: echo "$(Build.DefinitionName)_$(Build.BuildNumber)_ubuntu2204_${{ job.target }}.tar.gz" >> pipelineArtifacts.txt
       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml
 
-  - stage: rocm_nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}_docker
-    dependsOn: rocm_nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}
-    condition: succeeded()
-    jobs:
     - job: rocm_nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}_docker
+      dependsOn: rocm_nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}
+      condition: succeeded()
       variables:
       - group: common
       - template: /.azuredevops/variables-global.yml

--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -174,11 +174,11 @@ stages:
               RUN apt install -y cmake curl git gcc g++ gpg lsb-release lsof ninja-build pkg-config python3 python3-pip wget zip libdrm-dev libelf-dev libgtest-dev libhsakmt-dev libhwloc-dev libnuma-dev libstdc++-12-dev libtbb-dev jq
               RUN apt clean all
               RUN mkdir rocm
-              RUN curl -s https://repo.radeon.com/rocm/apt/latest/pool/main/h/hsa-amd-aqlprofile/ | grep -oP "href=\"\K[^\"]*$(lsb_release -rs)[^\"]*\.deb" > packageName
-              RUN wget https://repo.radeon.com/rocm/apt/latest/pool/main/h/hsa-amd-aqlprofile/$(cat packageName)
-              RUN mkdir hsa-amd-aqlprofile
-              RUN dpkg-deb -R $(cat packageName) hsa-amd-aqlprofile
-              RUN cp -R hsa-amd-aqlprofile/opt/rocm-*/* rocm
+              RUN curl -s https://repo.radeon.com/rocm/apt/latest/pool/main/h/hsa-amd-aqlprofile/ | grep -oP "href=\"\K[^\"]*$(lsb_release -rs)[^\"]*\.deb" > packageName \
+                && wget https://repo.radeon.com/rocm/apt/latest/pool/main/h/hsa-amd-aqlprofile/$(cat packageName) \
+                && mkdir hsa-amd-aqlprofile \
+                && dpkg-deb -R $(cat packageName) hsa-amd-aqlprofile \
+                && cp -R hsa-amd-aqlprofile/opt/rocm-*/* rocm
               RUN ARTIFACT_URL="https://dev.azure.com/ROCm-CI/ROCm-CI/_apis/build/builds/$(Build.BuildId)/artifacts?artifactName=rocmnightly${{ job.os }}${{ job.target }}${{ job.source }}&api-version=7.1" \
                 && DOWNLOAD_URL=$(curl -s $ARTIFACT_URL | jq ".resource.downloadUrl" | tr -d '"') \
                 && wget $DOWNLOAD_URL -O nightly.zip

--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -90,112 +90,108 @@ schedules:
     - develop
   always: true
 
-stages:
 - ${{ each job in parameters.jobList }}:
-  - stage: nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}
-    dependsOn: []
-    jobs:
-    - job: nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}
-      variables:
-      - group: common
-      - template: /.azuredevops/variables-global.yml
-      pool: ${{ variables.MEDIUM_BUILD_POOL }}
-      workspace:
-        clean: all
-      steps:
-      - task: DeleteFiles@1
-        displayName: 'Cleanup checkout space'
-        inputs:
-          SourceFolder: '$(Agent.BuildDirectory)/s'
-          Contents: '**/*'
-      - task: DeleteFiles@1
-        displayName: 'Cleanup Staging Area'
-        inputs:
-          SourceFolder: '$(Build.ArtifactStagingDirectory)'
-          Contents: '/**/*'
-          RemoveDotFiles: true
-      - script: df -h
-        displayName: System disk space before ROCm
-      - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
-        parameters:
-          dependencySource: ${{ job.source }}
-          dependencyList: ${{ parameters.rocmDependencies }}
-          os: ${{ job.os }}
-          gpuTarget: ${{ job.target }}
-      - script: df -h
-        displayName: System disk space after ROCm
-      - script: du -sh $(Agent.BuildDirectory)/rocm
-        displayName: Uncompressed ROCm size
-      - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
-      - task: ArchiveFiles@2
-        displayName: Compress rocm-nightly
-        inputs:
-          rootFolderOrFile: $(Agent.BuildDirectory)/rocm
-          includeRootFolder: false
-          archiveType: tar
-          tarCompression: gz
-          archiveFile: $(Build.ArtifactStagingDirectory)/$(Build.DefinitionName)_$(Build.BuildNumber)_ubuntu2204_${{ job.target }}.tar.gz
-      - script: du -sh $(Build.ArtifactStagingDirectory)
-        displayName: Compressed ROCm size
-      - task: PublishPipelineArtifact@1
-        displayName: 'Publish ROCm Nightly Artifact'
-        retryCountOnTaskFailure: 3
-        inputs:
-          targetPath: '$(Build.ArtifactStagingDirectory)'
-      - task: Bash@3
-        displayName: Save pipeline artifact file name
-        inputs:
-          workingDirectory: $(Pipeline.Workspace)
-          targetType: inline
-          script: echo "$(Build.DefinitionName)_$(Build.BuildNumber)_ubuntu2204_${{ job.target }}.tar.gz" >> pipelineArtifacts.txt
-      - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml
+  - job: nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}
+    variables:
+    - group: common
+    - template: /.azuredevops/variables-global.yml
+    pool: ${{ variables.MEDIUM_BUILD_POOL }}
+    workspace:
+      clean: all
+    steps:
+    - task: DeleteFiles@1
+      displayName: 'Cleanup checkout space'
+      inputs:
+        SourceFolder: '$(Agent.BuildDirectory)/s'
+        Contents: '**/*'
+    - task: DeleteFiles@1
+      displayName: 'Cleanup Staging Area'
+      inputs:
+        SourceFolder: '$(Build.ArtifactStagingDirectory)'
+        Contents: '/**/*'
+        RemoveDotFiles: true
+    - script: df -h
+      displayName: System disk space before ROCm
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
+      parameters:
+        dependencySource: ${{ job.source }}
+        dependencyList: ${{ parameters.rocmDependencies }}
+        os: ${{ job.os }}
+        gpuTarget: ${{ job.target }}
+    - script: df -h
+      displayName: System disk space after ROCm
+    - script: du -sh $(Agent.BuildDirectory)/rocm
+      displayName: Uncompressed ROCm size
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
+    - task: ArchiveFiles@2
+      displayName: Compress rocm-nightly
+      inputs:
+        rootFolderOrFile: $(Agent.BuildDirectory)/rocm
+        includeRootFolder: false
+        archiveType: tar
+        tarCompression: gz
+        archiveFile: $(Build.ArtifactStagingDirectory)/$(Build.DefinitionName)_$(Build.BuildNumber)_ubuntu2204_${{ job.target }}.tar.gz
+    - script: du -sh $(Build.ArtifactStagingDirectory)
+      displayName: Compressed ROCm size
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish ROCm Nightly Artifact'
+      retryCountOnTaskFailure: 3
+      inputs:
+        targetPath: '$(Build.ArtifactStagingDirectory)'
+    - task: Bash@3
+      displayName: Save pipeline artifact file name
+      inputs:
+        workingDirectory: $(Pipeline.Workspace)
+        targetType: inline
+        script: echo "$(Build.DefinitionName)_$(Build.BuildNumber)_ubuntu2204_${{ job.target }}.tar.gz" >> pipelineArtifacts.txt
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml
 
-    - job: nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}_docker
-      dependsOn: nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}
-      condition: succeeded()
-      variables:
-      - group: common
-      - template: /.azuredevops/variables-global.yml
-      pool: ${{ variables.MEDIUM_BUILD_POOL }}
-      workspace:
-        clean: all
-      steps:
-      - task: Bash@3
-        displayName: Create Dockerfile
-        inputs:
-          workingDirectory: $(Agent.BuildDirectory)
-          targetType: inline
-          script: |
-            cat <<'EOF' > Dockerfile
-              FROM ubuntu:22.04
-              WORKDIR /root
-              RUN apt update
-              RUN apt upgrade -y
-              RUN apt install -y cmake curl git gcc g++ gpg lsb-release lsof ninja-build pkg-config python3 python3-pip wget zip libdrm-dev libelf-dev libgtest-dev libhsakmt-dev libhwloc-dev libnuma-dev libstdc++-12-dev libtbb-dev jq
-              RUN apt clean all
-              RUN mkdir rocm
-              RUN PACKAGE_NAME=$(curl -s https://repo.radeon.com/rocm/apt/latest/pool/main/h/hsa-amd-aqlprofile/ | grep -oP "href=\"\K[^\"]*$(lsb_release -rs)[^\"]*\.deb") \
-                && wget https://repo.radeon.com/rocm/apt/latest/pool/main/h/hsa-amd-aqlprofile/$PACKAGE_NAME \
-                && mkdir hsa-amd-aqlprofile \
-                && dpkg-deb -R $PACKAGE_NAME hsa-amd-aqlprofile \
-                && cp -R hsa-amd-aqlprofile/opt/rocm-*/* rocm
-              RUN ARTIFACT_URL="https://dev.azure.com/ROCm-CI/ROCm-CI/_apis/build/builds/$(Build.BuildId)/artifacts?artifactName=nightly${{ job.os }}${{ job.target }}${{ job.source }}&api-version=7.1" \
-                && DOWNLOAD_URL=$(curl -s $ARTIFACT_URL | jq ".resource.downloadUrl" | tr -d '"') \
-                && wget $DOWNLOAD_URL -O nightly.zip
-              RUN unzip nightly.zip
-              RUN tar -xf rocmnightly*/rocm-nightly_* -C rocm
-              RUN ln -s /root/rocm /opt/rocm
-              RUN ln -s /opt/rocm/llvm /opt/rocm/lib/llvm
-              RUN echo /opt/rocm/lib | tee /etc/ld.so.conf.d/rocm-ci.conf
-              RUN echo /opt/rocm/llvm/lib | tee -a /etc/ld.so.conf.d/rocm-ci.conf
-              RUN ldconfig
-              ENV PATH="$PATH:/opt/rocm/bin"
-              ENTRYPOINT ["/bin/bash"]
-            EOF
-      - task: Docker@2
-        displayName: Build and upload Docker image
-        inputs:
-          containerRegistry: ContainerService3
-          repository: 'nightly-${{ job.os }}-${{ job.target }}-${{ job.source }}'
-          Dockerfile: '$(Agent.BuildDirectory)/Dockerfile'
-          buildContext: '$(Agent.BuildDirectory)'
+  - job: nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}_docker
+    dependsOn: nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}
+    condition: succeeded()
+    variables:
+    - group: common
+    - template: /.azuredevops/variables-global.yml
+    pool: ${{ variables.MEDIUM_BUILD_POOL }}
+    workspace:
+      clean: all
+    steps:
+    - task: Bash@3
+      displayName: Create Dockerfile
+      inputs:
+        workingDirectory: $(Agent.BuildDirectory)
+        targetType: inline
+        script: |
+          cat <<'EOF' > Dockerfile
+            FROM ubuntu:22.04
+            WORKDIR /root
+            RUN apt update
+            RUN apt upgrade -y
+            RUN apt install -y cmake curl git gcc g++ gpg lsb-release lsof ninja-build pkg-config python3 python3-pip wget zip libdrm-dev libelf-dev libgtest-dev libhsakmt-dev libhwloc-dev libnuma-dev libstdc++-12-dev libtbb-dev jq
+            RUN apt clean all
+            RUN mkdir rocm
+            RUN PACKAGE_NAME=$(curl -s https://repo.radeon.com/rocm/apt/latest/pool/main/h/hsa-amd-aqlprofile/ | grep -oP "href=\"\K[^\"]*$(lsb_release -rs)[^\"]*\.deb") \
+              && wget https://repo.radeon.com/rocm/apt/latest/pool/main/h/hsa-amd-aqlprofile/$PACKAGE_NAME \
+              && mkdir hsa-amd-aqlprofile \
+              && dpkg-deb -R $PACKAGE_NAME hsa-amd-aqlprofile \
+              && cp -R hsa-amd-aqlprofile/opt/rocm-*/* rocm
+            RUN ARTIFACT_URL="https://dev.azure.com/ROCm-CI/ROCm-CI/_apis/build/builds/$(Build.BuildId)/artifacts?artifactName=nightly${{ job.os }}${{ job.target }}${{ job.source }}&api-version=7.1" \
+              && DOWNLOAD_URL=$(curl -s $ARTIFACT_URL | jq ".resource.downloadUrl" | tr -d '"') \
+              && wget $DOWNLOAD_URL -O nightly.zip
+            RUN unzip nightly.zip
+            RUN tar -xf rocmnightly*/rocm-nightly_* -C rocm
+            RUN ln -s /root/rocm /opt/rocm
+            RUN ln -s /opt/rocm/llvm /opt/rocm/lib/llvm
+            RUN echo /opt/rocm/lib | tee /etc/ld.so.conf.d/rocm-ci.conf
+            RUN echo /opt/rocm/llvm/lib | tee -a /etc/ld.so.conf.d/rocm-ci.conf
+            RUN ldconfig
+            ENV PATH="$PATH:/opt/rocm/bin"
+            ENTRYPOINT ["/bin/bash"]
+          EOF
+    - task: Docker@2
+      displayName: Build and upload Docker image
+      inputs:
+        containerRegistry: ContainerService3
+        repository: 'nightly-${{ job.os }}-${{ job.target }}-${{ job.source }}'
+        Dockerfile: '$(Agent.BuildDirectory)/Dockerfile'
+        buildContext: '$(Agent.BuildDirectory)'

--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -174,10 +174,10 @@ stages:
               RUN apt install -y cmake curl git gcc g++ gpg lsb-release lsof ninja-build pkg-config python3 python3-pip wget zip libdrm-dev libelf-dev libgtest-dev libhsakmt-dev libhwloc-dev libnuma-dev libstdc++-12-dev libtbb-dev jq
               RUN apt clean all
               RUN mkdir rocm
-              RUN curl -s https://repo.radeon.com/rocm/apt/latest/pool/main/h/hsa-amd-aqlprofile/ | grep -oP "href=\"\K[^\"]*$(lsb_release -rs)[^\"]*\.deb" > packageName \
-                && wget https://repo.radeon.com/rocm/apt/latest/pool/main/h/hsa-amd-aqlprofile/$(cat packageName) \
+              RUN PACKAGE_NAME=$(curl -s https://repo.radeon.com/rocm/apt/latest/pool/main/h/hsa-amd-aqlprofile/ | grep -oP "href=\"\K[^\"]*$(lsb_release -rs)[^\"]*\.deb") \
+                && wget https://repo.radeon.com/rocm/apt/latest/pool/main/h/hsa-amd-aqlprofile/$PACKAGE_NAME \
                 && mkdir hsa-amd-aqlprofile \
-                && dpkg-deb -R $(cat packageName) hsa-amd-aqlprofile \
+                && dpkg-deb -R $PACKAGE_NAME hsa-amd-aqlprofile \
                 && cp -R hsa-amd-aqlprofile/opt/rocm-*/* rocm
               RUN ARTIFACT_URL="https://dev.azure.com/ROCm-CI/ROCm-CI/_apis/build/builds/$(Build.BuildId)/artifacts?artifactName=rocmnightly${{ job.os }}${{ job.target }}${{ job.source }}&api-version=7.1" \
                 && DOWNLOAD_URL=$(curl -s $ARTIFACT_URL | jq ".resource.downloadUrl" | tr -d '"') \

--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -3,20 +3,20 @@ parameters:
 - name: jobList
   type: object
   default:
-    - { os: ubuntu2204, target: gfx942, source: staging }
-    - { os: ubuntu2204, target: gfx90a, source: staging }
-    - { os: ubuntu2204, target: gfx1201, source: staging }
-    - { os: ubuntu2204, target: gfx1100, source: staging }
+    # - { os: ubuntu2204, target: gfx942, source: staging }
+    # - { os: ubuntu2204, target: gfx90a, source: staging }
+    # - { os: ubuntu2204, target: gfx1201, source: staging }
+    # - { os: ubuntu2204, target: gfx1100, source: staging }
     - { os: ubuntu2204, target: gfx1030, source: staging }
-    - { os: ubuntu2404, target: gfx942, source: staging }
-    - { os: ubuntu2404, target: gfx90a, source: staging }
-    - { os: ubuntu2404, target: gfx1201, source: staging }
-    - { os: ubuntu2404, target: gfx1100, source: staging }
+    # - { os: ubuntu2404, target: gfx942, source: staging }
+    # - { os: ubuntu2404, target: gfx90a, source: staging }
+    # - { os: ubuntu2404, target: gfx1201, source: staging }
+    # - { os: ubuntu2404, target: gfx1100, source: staging }
     - { os: ubuntu2404, target: gfx1030, source: staging }
-    - { os: almalinux8, target: gfx942, source: staging }
-    - { os: almalinux8, target: gfx90a, source: staging }
-    - { os: almalinux8, target: gfx1201, source: staging }
-    - { os: almalinux8, target: gfx1100, source: staging }
+    # - { os: almalinux8, target: gfx942, source: staging }
+    # - { os: almalinux8, target: gfx90a, source: staging }
+    # - { os: almalinux8, target: gfx1201, source: staging }
+    # - { os: almalinux8, target: gfx1100, source: staging }
     - { os: almalinux8, target: gfx1030, source: staging }
 - name: rocmDependencies
   type: object
@@ -90,59 +90,115 @@ schedules:
     - develop
   always: true
 
-jobs:
+stages:
 - ${{ each job in parameters.jobList }}:
-  - job: rocm_nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}
-    variables:
-    - group: common
-    - template: /.azuredevops/variables-global.yml
-    pool: ${{ variables.MEDIUM_BUILD_POOL }}
-    workspace:
-      clean: all
-    steps:
-    - task: DeleteFiles@1
-      displayName: 'Cleanup checkout space'
-      inputs:
-        SourceFolder: '$(Agent.BuildDirectory)/s'
-        Contents: '**/*'
-    - task: DeleteFiles@1
-      displayName: 'Cleanup Staging Area'
-      inputs:
-        SourceFolder: '$(Build.ArtifactStagingDirectory)'
-        Contents: '/**/*'
-        RemoveDotFiles: true
-    - script: df -h
-      displayName: System disk space before ROCm
-    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
-      parameters:
-        dependencySource: ${{ job.source }}
-        dependencyList: ${{ parameters.rocmDependencies }}
-        os: ${{ job.os }}
-        gpuTarget: ${{ job.target }}
-    - script: df -h
-      displayName: System disk space after ROCm
-    - script: du -sh $(Agent.BuildDirectory)/rocm
-      displayName: Uncompressed ROCm size
-    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
-    - task: ArchiveFiles@2
-      displayName: Compress rocm-nightly
-      inputs:
-        rootFolderOrFile: $(Agent.BuildDirectory)/rocm
-        includeRootFolder: false
-        archiveType: tar
-        tarCompression: gz
-        archiveFile: $(Build.ArtifactStagingDirectory)/$(Build.DefinitionName)_$(Build.BuildNumber)_ubuntu2204_${{ job.target }}.tar.gz
-    - script: du -sh $(Build.ArtifactStagingDirectory)
-      displayName: Compressed ROCm size
-    - task: PublishPipelineArtifact@1
-      displayName: 'Publish ROCm Nightly Artifact'
-      retryCountOnTaskFailure: 3
-      inputs:
-        targetPath: '$(Build.ArtifactStagingDirectory)'
-    - task: Bash@3
-      displayName: Save pipeline artifact file name
-      inputs:
-        workingDirectory: $(Pipeline.Workspace)
-        targetType: inline
-        script: echo "$(Build.DefinitionName)_$(Build.BuildNumber)_ubuntu2204_${{ job.target }}.tar.gz" >> pipelineArtifacts.txt
-    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml
+  - stage: rocm_nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}
+    jobs:
+    - job: rocm_nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}
+      variables:
+      - group: common
+      - template: /.azuredevops/variables-global.yml
+      pool: ${{ variables.MEDIUM_BUILD_POOL }}
+      workspace:
+        clean: all
+      steps:
+      - task: DeleteFiles@1
+        displayName: 'Cleanup checkout space'
+        inputs:
+          SourceFolder: '$(Agent.BuildDirectory)/s'
+          Contents: '**/*'
+      - task: DeleteFiles@1
+        displayName: 'Cleanup Staging Area'
+        inputs:
+          SourceFolder: '$(Build.ArtifactStagingDirectory)'
+          Contents: '/**/*'
+          RemoveDotFiles: true
+      - script: df -h
+        displayName: System disk space before ROCm
+      - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
+        parameters:
+          dependencySource: ${{ job.source }}
+          dependencyList: ${{ parameters.rocmDependencies }}
+          os: ${{ job.os }}
+          gpuTarget: ${{ job.target }}
+      - script: df -h
+        displayName: System disk space after ROCm
+      - script: du -sh $(Agent.BuildDirectory)/rocm
+        displayName: Uncompressed ROCm size
+      - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
+      - task: ArchiveFiles@2
+        displayName: Compress rocm-nightly
+        inputs:
+          rootFolderOrFile: $(Agent.BuildDirectory)/rocm
+          includeRootFolder: false
+          archiveType: tar
+          tarCompression: gz
+          archiveFile: $(Build.ArtifactStagingDirectory)/$(Build.DefinitionName)_$(Build.BuildNumber)_ubuntu2204_${{ job.target }}.tar.gz
+      - script: du -sh $(Build.ArtifactStagingDirectory)
+        displayName: Compressed ROCm size
+      - task: PublishPipelineArtifact@1
+        displayName: 'Publish ROCm Nightly Artifact'
+        retryCountOnTaskFailure: 3
+        inputs:
+          targetPath: '$(Build.ArtifactStagingDirectory)'
+      - task: Bash@3
+        displayName: Save pipeline artifact file name
+        inputs:
+          workingDirectory: $(Pipeline.Workspace)
+          targetType: inline
+          script: echo "$(Build.DefinitionName)_$(Build.BuildNumber)_ubuntu2204_${{ job.target }}.tar.gz" >> pipelineArtifacts.txt
+      - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml
+
+  - stage: rocm_nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}_docker
+    dependsOn: rocm_nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}
+    condition: succeeded()
+    jobs:
+    - job: rocm_nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}_docker
+      variables:
+      - group: common
+      - template: /.azuredevops/variables-global.yml
+      pool: ${{ variables.MEDIUM_BUILD_POOL }}
+      workspace:
+        clean: all
+      steps:
+      - task: Bash@3
+        displayName: Create Dockerfile
+        inputs:
+          workingDirectory: $(Agent.BuildDirectory)
+          targetType: inline
+          script: |
+            cat <<EOF > Dockerfile
+              FROM ubuntu:22.04
+              WORKDIR /root
+              RUN apt update
+              RUN apt upgrade -y
+              RUN apt install -y cmake curl git gcc g++ gpg lsb-release lsof ninja-build pkg-config python3 python3-pip wget zip libdrm-dev libelf-dev libgtest-dev libhsakmt-dev libhwloc-dev libnuma-dev libstdc++-12-dev libtbb-dev jq
+              RUN apt clean all
+              RUN mkdir rocm
+              RUN curl -s https://repo.radeon.com/rocm/apt/latest/pool/main/h/hsa-amd-aqlprofile/ | grep -oP "href=\"\K[^\"]*$(lsb_release -rs)[^\"]*\.deb" > packageName
+              RUN wget https://repo.radeon.com/rocm/apt/latest/pool/main/h/hsa-amd-aqlprofile/$(cat packageName)
+              RUN mkdir hsa-amd-aqlprofile
+              RUN dpkg-deb -R $(cat packageName) hsa-amd-aqlprofile
+              RUN cp -R hsa-amd-aqlprofile/opt/rocm-*/* rocm
+              RUN NIGHTLY_URL="https://dev.azure.com/ROCm-CI/ROCm-CI/_apis/build/builds?definitions=206&statusFilter=completed&resultFilter=succeeded&\$top=1&api-version=7.1" \
+                && BUILD_ID=$(curl -s $NIGHTLY_URL | jq ".value[0].id") \
+                && ARTIFACT_URL="https://dev.azure.com/ROCm-CI/ROCm-CI/_apis/build/builds/$BUILD_ID/artifacts?artifactName=rocmnightlyubuntu2204gfx942staging&api-version=7.1" \
+                && DOWNLOAD_URL=$(curl -s $ARTIFACT_URL | jq ".resource.downloadUrl" | tr -d '"') \
+                && wget -nv $DOWNLOAD_URL -O nightly.zip
+              RUN unzip nightly.zip
+              RUN tar -xf rocmnightly*/rocm-nightly_* -C rocm
+              RUN ln -s /root/rocm /opt/rocm
+              RUN ln -s /opt/rocm/llvm /opt/rocm/lib/llvm
+              RUN echo /opt/rocm/lib | tee /etc/ld.so.conf.d/rocm-ci.conf
+              RUN echo /opt/rocm/llvm/lib | tee -a /etc/ld.so.conf.d/rocm-ci.conf
+              RUN ldconfig
+              ENV PATH="$PATH:/opt/rocm/bin"
+              ENTRYPOINT ["/bin/bash"]
+            EOF
+      - task: Docker@2
+        displayName: Build and upload Docker image
+        inputs:
+          containerRegistry: ContainerService3
+          repository: 'nightly-${{ job.os }}-${{ job.target }}-${{ job.source }}'
+          Dockerfile: '$(Agent.BuildDirectory)/Dockerfile'
+          buildContext: '$(Agent.BuildDirectory)'

--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -161,15 +161,15 @@ jobs:
             RUN apt clean all
             RUN mkdir rocm
             RUN PACKAGE_NAME=$(curl -s https://repo.radeon.com/rocm/apt/latest/pool/main/h/hsa-amd-aqlprofile/ | grep -oP "href=\"\K[^\"]*$(lsb_release -rs)[^\"]*\.deb") \
-              && wget https://repo.radeon.com/rocm/apt/latest/pool/main/h/hsa-amd-aqlprofile/$PACKAGE_NAME \
+              && wget -nv --retry-connrefused https://repo.radeon.com/rocm/apt/latest/pool/main/h/hsa-amd-aqlprofile/$PACKAGE_NAME \
               && mkdir hsa-amd-aqlprofile \
               && dpkg-deb -R $PACKAGE_NAME hsa-amd-aqlprofile \
               && cp -R hsa-amd-aqlprofile/opt/rocm-*/* rocm
             RUN ARTIFACT_URL="https://dev.azure.com/ROCm-CI/ROCm-CI/_apis/build/builds/$(Build.BuildId)/artifacts?artifactName=nightly${{ job.os }}${{ job.target }}${{ job.source }}&api-version=7.1" \
               && DOWNLOAD_URL=$(curl -s $ARTIFACT_URL | jq ".resource.downloadUrl" | tr -d '"') \
-              && wget -nv $DOWNLOAD_URL -O nightly.zip
-            RUN unzip nightly.zip
-            RUN tar -xf nightly${{ job.os }}${{ job.target }}${{ job.source }}/rocm-nightly*${{ job.os }}*${{ job.target }}*.tar.gz -C rocm
+              && wget -nv --retry-connrefused $DOWNLOAD_URL -O nightly.zip
+              && unzip nightly.zip
+              && tar -xf nightly${{ job.os }}${{ job.target }}${{ job.source }}/rocm-nightly*${{ job.os }}*${{ job.target }}*.tar.gz -C rocm
             RUN ln -s /root/rocm /opt/rocm
             RUN ln -s /opt/rocm/llvm /opt/rocm/lib/llvm
             RUN echo /opt/rocm/lib | tee /etc/ld.so.conf.d/rocm-ci.conf

--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -166,7 +166,7 @@ stages:
           workingDirectory: $(Agent.BuildDirectory)
           targetType: inline
           script: |
-            cat <<EOF > Dockerfile
+            cat <<'EOF' > Dockerfile
               FROM ubuntu:22.04
               WORKDIR /root
               RUN apt update

--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -146,17 +146,6 @@ jobs:
         targetType: inline
         script: echo "$(Build.DefinitionName)_$(Build.BuildNumber)_ubuntu2204_${{ job.target }}.tar.gz" >> pipelineArtifacts.txt
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml
-
-  - job: nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}_docker
-    dependsOn: nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}
-    condition: succeeded()
-    variables:
-    - group: common
-    - template: /.azuredevops/variables-global.yml
-    pool: ${{ variables.MEDIUM_BUILD_POOL }}
-    workspace:
-      clean: all
-    steps:
     - task: Bash@3
       displayName: Create Dockerfile
       inputs:
@@ -178,9 +167,9 @@ jobs:
               && cp -R hsa-amd-aqlprofile/opt/rocm-*/* rocm
             RUN ARTIFACT_URL="https://dev.azure.com/ROCm-CI/ROCm-CI/_apis/build/builds/$(Build.BuildId)/artifacts?artifactName=nightly${{ job.os }}${{ job.target }}${{ job.source }}&api-version=7.1" \
               && DOWNLOAD_URL=$(curl -s $ARTIFACT_URL | jq ".resource.downloadUrl" | tr -d '"') \
-              && wget $DOWNLOAD_URL -O nightly.zip
+              && wget -nv $DOWNLOAD_URL -O nightly.zip
             RUN unzip nightly.zip
-            RUN tar -xf rocmnightly*/rocm-nightly_* -C rocm
+            RUN tar -xf nightly${{ job.os }}${{ job.target }}${{ job.source }}/rocm-nightly*${{ job.os }}*${{ job.target }}*.tar.gz -C rocm
             RUN ln -s /root/rocm /opt/rocm
             RUN ln -s /opt/rocm/llvm /opt/rocm/lib/llvm
             RUN echo /opt/rocm/lib | tee /etc/ld.so.conf.d/rocm-ci.conf

--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -170,12 +170,10 @@ jobs:
               && wget -nv --retry-connrefused $DOWNLOAD_URL -O nightly.zip \
               && unzip nightly.zip \
               && tar -xf nightly${{ job.os }}${{ job.target }}${{ job.source }}/rocm-nightly*${{ job.os }}*${{ job.target }}*.tar.gz -C rocm
-            RUN ln -s /root/rocm /opt/rocm
-            RUN ln -s /opt/rocm/llvm /opt/rocm/lib/llvm
-            RUN echo /opt/rocm/lib | tee /etc/ld.so.conf.d/rocm-ci.conf
-            RUN echo /opt/rocm/llvm/lib | tee -a /etc/ld.so.conf.d/rocm-ci.conf
-            RUN ldconfig
-            ENV PATH="$PATH:/opt/rocm/bin"
+            RUN echo /root/rocm/lib | tee /etc/ld.so.conf.d/rocm-ci.conf
+            RUN echo /root/rocm/llvm/lib | tee -a /etc/ld.so.conf.d/rocm-ci.conf
+            RUN ldconfig -v
+            ENV PATH="$PATH:/root/rocm/bin"
             ENTRYPOINT ["/bin/bash"]
           EOF
     - task: Docker@2

--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -92,10 +92,10 @@ schedules:
 
 stages:
 - ${{ each job in parameters.jobList }}:
-  - stage: rocm_nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}
+  - stage: nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}
     dependsOn: []
     jobs:
-    - job: rocm_nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}
+    - job: nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}
       variables:
       - group: common
       - template: /.azuredevops/variables-global.yml
@@ -150,8 +150,8 @@ stages:
           script: echo "$(Build.DefinitionName)_$(Build.BuildNumber)_ubuntu2204_${{ job.target }}.tar.gz" >> pipelineArtifacts.txt
       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml
 
-    - job: rocm_nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}_docker
-      dependsOn: rocm_nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}
+    - job: nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}_docker
+      dependsOn: nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}
       condition: succeeded()
       variables:
       - group: common

--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -167,8 +167,8 @@ jobs:
               && cp -R hsa-amd-aqlprofile/opt/rocm-*/* rocm
             RUN ARTIFACT_URL="https://dev.azure.com/ROCm-CI/ROCm-CI/_apis/build/builds/$(Build.BuildId)/artifacts?artifactName=nightly${{ job.os }}${{ job.target }}${{ job.source }}&api-version=7.1" \
               && DOWNLOAD_URL=$(curl -s $ARTIFACT_URL | jq ".resource.downloadUrl" | tr -d '"') \
-              && wget -nv --retry-connrefused $DOWNLOAD_URL -O nightly.zip
-              && unzip nightly.zip
+              && wget -nv --retry-connrefused $DOWNLOAD_URL -O nightly.zip \
+              && unzip nightly.zip \
               && tar -xf nightly${{ job.os }}${{ job.target }}${{ job.source }}/rocm-nightly*${{ job.os }}*${{ job.target }}*.tar.gz -C rocm
             RUN ln -s /root/rocm /opt/rocm
             RUN ln -s /opt/rocm/llvm /opt/rocm/lib/llvm

--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -179,7 +179,7 @@ stages:
                 && mkdir hsa-amd-aqlprofile \
                 && dpkg-deb -R $PACKAGE_NAME hsa-amd-aqlprofile \
                 && cp -R hsa-amd-aqlprofile/opt/rocm-*/* rocm
-              RUN ARTIFACT_URL="https://dev.azure.com/ROCm-CI/ROCm-CI/_apis/build/builds/$(Build.BuildId)/artifacts?artifactName=rocmnightly${{ job.os }}${{ job.target }}${{ job.source }}&api-version=7.1" \
+              RUN ARTIFACT_URL="https://dev.azure.com/ROCm-CI/ROCm-CI/_apis/build/builds/$(Build.BuildId)/artifacts?artifactName=nightly${{ job.os }}${{ job.target }}${{ job.source }}&api-version=7.1" \
                 && DOWNLOAD_URL=$(curl -s $ARTIFACT_URL | jq ".resource.downloadUrl" | tr -d '"') \
                 && wget $DOWNLOAD_URL -O nightly.zip
               RUN unzip nightly.zip

--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -185,3 +185,8 @@ jobs:
         repository: 'nightly-${{ job.os }}-${{ job.target }}-${{ job.source }}'
         Dockerfile: '$(Agent.BuildDirectory)/Dockerfile'
         buildContext: '$(Agent.BuildDirectory)'
+    - task: Bash@3
+      displayName: '!! Docker Run Command !!'
+      inputs:
+        targetType: inline
+        script: echo "docker run -it --network=host --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined rocmexternalcicd.azurecr.io/nightly-${{ job.os }}-${{ job.target }}-${{ job.source }}:$(Build.BuildId)" | tr '[:upper:]' '[:lower:]'

--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -180,11 +180,9 @@ stages:
               RUN mkdir hsa-amd-aqlprofile
               RUN dpkg-deb -R $(cat packageName) hsa-amd-aqlprofile
               RUN cp -R hsa-amd-aqlprofile/opt/rocm-*/* rocm
-              RUN NIGHTLY_URL="https://dev.azure.com/ROCm-CI/ROCm-CI/_apis/build/builds?definitions=206&statusFilter=completed&resultFilter=succeeded&\$top=1&api-version=7.1" \
-                && BUILD_ID=$(curl -s $NIGHTLY_URL | jq ".value[0].id") \
-                && ARTIFACT_URL="https://dev.azure.com/ROCm-CI/ROCm-CI/_apis/build/builds/$BUILD_ID/artifacts?artifactName=rocmnightlyubuntu2204gfx942staging&api-version=7.1" \
+              RUN ARTIFACT_URL="https://dev.azure.com/ROCm-CI/ROCm-CI/_apis/build/builds/$(Build.BuildId)/artifacts?artifactName=rocmnightly${{ job.os }}${{ job.target }}${{ job.source }}&api-version=7.1" \
                 && DOWNLOAD_URL=$(curl -s $ARTIFACT_URL | jq ".resource.downloadUrl" | tr -d '"') \
-                && wget -nv $DOWNLOAD_URL -O nightly.zip
+                && wget $DOWNLOAD_URL -O nightly.zip
               RUN unzip nightly.zip
               RUN tar -xf rocmnightly*/rocm-nightly_* -C rocm
               RUN ln -s /root/rocm /opt/rocm

--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -3,20 +3,20 @@ parameters:
 - name: jobList
   type: object
   default:
-    # - { os: ubuntu2204, target: gfx942, source: staging }
-    # - { os: ubuntu2204, target: gfx90a, source: staging }
-    # - { os: ubuntu2204, target: gfx1201, source: staging }
-    # - { os: ubuntu2204, target: gfx1100, source: staging }
+    - { os: ubuntu2204, target: gfx942, source: staging }
+    - { os: ubuntu2204, target: gfx90a, source: staging }
+    - { os: ubuntu2204, target: gfx1201, source: staging }
+    - { os: ubuntu2204, target: gfx1100, source: staging }
     - { os: ubuntu2204, target: gfx1030, source: staging }
-    # - { os: ubuntu2404, target: gfx942, source: staging }
-    # - { os: ubuntu2404, target: gfx90a, source: staging }
-    # - { os: ubuntu2404, target: gfx1201, source: staging }
-    # - { os: ubuntu2404, target: gfx1100, source: staging }
+    - { os: ubuntu2404, target: gfx942, source: staging }
+    - { os: ubuntu2404, target: gfx90a, source: staging }
+    - { os: ubuntu2404, target: gfx1201, source: staging }
+    - { os: ubuntu2404, target: gfx1100, source: staging }
     - { os: ubuntu2404, target: gfx1030, source: staging }
-    # - { os: almalinux8, target: gfx942, source: staging }
-    # - { os: almalinux8, target: gfx90a, source: staging }
-    # - { os: almalinux8, target: gfx1201, source: staging }
-    # - { os: almalinux8, target: gfx1100, source: staging }
+    - { os: almalinux8, target: gfx942, source: staging }
+    - { os: almalinux8, target: gfx90a, source: staging }
+    - { os: almalinux8, target: gfx1201, source: staging }
+    - { os: almalinux8, target: gfx1100, source: staging }
     - { os: almalinux8, target: gfx1030, source: staging }
 - name: rocmDependencies
   type: object

--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -3,21 +3,21 @@ parameters:
 - name: jobList
   type: object
   default:
-    - { os: ubuntu2204, target: gfx942, source: staging }
-    - { os: ubuntu2204, target: gfx90a, source: staging }
-    - { os: ubuntu2204, target: gfx1201, source: staging }
-    - { os: ubuntu2204, target: gfx1100, source: staging }
-    - { os: ubuntu2204, target: gfx1030, source: staging }
-    - { os: ubuntu2404, target: gfx942, source: staging }
-    - { os: ubuntu2404, target: gfx90a, source: staging }
-    - { os: ubuntu2404, target: gfx1201, source: staging }
-    - { os: ubuntu2404, target: gfx1100, source: staging }
-    - { os: ubuntu2404, target: gfx1030, source: staging }
-    - { os: almalinux8, target: gfx942, source: staging }
-    - { os: almalinux8, target: gfx90a, source: staging }
-    - { os: almalinux8, target: gfx1201, source: staging }
-    - { os: almalinux8, target: gfx1100, source: staging }
-    - { os: almalinux8, target: gfx1030, source: staging }
+    - { os: ubuntu2204, packageManager: apt, target: gfx942, source: staging }
+    - { os: ubuntu2204, packageManager: apt, target: gfx90a, source: staging }
+    - { os: ubuntu2204, packageManager: apt, target: gfx1201, source: staging }
+    - { os: ubuntu2204, packageManager: apt, target: gfx1100, source: staging }
+    - { os: ubuntu2204, packageManager: apt, target: gfx1030, source: staging }
+    - { os: ubuntu2404, packageManager: apt, target: gfx942, source: staging }
+    - { os: ubuntu2404, packageManager: apt, target: gfx90a, source: staging }
+    - { os: ubuntu2404, packageManager: apt, target: gfx1201, source: staging }
+    - { os: ubuntu2404, packageManager: apt, target: gfx1100, source: staging }
+    - { os: ubuntu2404, packageManager: apt, target: gfx1030, source: staging }
+    - { os: almalinux8, packageManager: dnf, target: gfx942, source: staging }
+    - { os: almalinux8, packageManager: dnf, target: gfx90a, source: staging }
+    - { os: almalinux8, packageManager: dnf, target: gfx1201, source: staging }
+    - { os: almalinux8, packageManager: dnf, target: gfx1100, source: staging }
+    - { os: almalinux8, packageManager: dnf, target: gfx1030, source: staging }
 - name: rocmDependencies
   type: object
   default:
@@ -146,36 +146,80 @@ jobs:
         targetType: inline
         script: echo "$(Build.DefinitionName)_$(Build.BuildNumber)_ubuntu2204_${{ job.target }}.tar.gz" >> pipelineArtifacts.txt
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml
-    - task: Bash@3
-      displayName: Create Dockerfile
-      inputs:
-        workingDirectory: $(Agent.BuildDirectory)
-        targetType: inline
-        script: |
-          cat <<'EOF' > Dockerfile
-            FROM ubuntu:22.04
-            WORKDIR /root
-            RUN apt update
-            RUN apt upgrade -y
-            RUN apt install -y cmake curl git gcc g++ gpg lsb-release lsof ninja-build pkg-config python3 python3-pip wget zip libdrm-dev libelf-dev libgtest-dev libhsakmt-dev libhwloc-dev libnuma-dev libstdc++-12-dev libtbb-dev jq
-            RUN apt clean all
-            RUN mkdir rocm
-            RUN PACKAGE_NAME=$(curl -s https://repo.radeon.com/rocm/apt/latest/pool/main/h/hsa-amd-aqlprofile/ | grep -oP "href=\"\K[^\"]*$(lsb_release -rs)[^\"]*\.deb") \
-              && wget -nv --retry-connrefused https://repo.radeon.com/rocm/apt/latest/pool/main/h/hsa-amd-aqlprofile/$PACKAGE_NAME \
-              && mkdir hsa-amd-aqlprofile \
-              && dpkg-deb -R $PACKAGE_NAME hsa-amd-aqlprofile \
-              && cp -R hsa-amd-aqlprofile/opt/rocm-*/* rocm
-            RUN ARTIFACT_URL="https://dev.azure.com/ROCm-CI/ROCm-CI/_apis/build/builds/$(Build.BuildId)/artifacts?artifactName=nightly${{ job.os }}${{ job.target }}${{ job.source }}&api-version=7.1" \
-              && DOWNLOAD_URL=$(curl -s $ARTIFACT_URL | jq ".resource.downloadUrl" | tr -d '"') \
-              && wget -nv --retry-connrefused $DOWNLOAD_URL -O nightly.zip \
-              && unzip nightly.zip \
-              && tar -xf nightly${{ job.os }}${{ job.target }}${{ job.source }}/rocm-nightly*${{ job.os }}*${{ job.target }}*.tar.gz -C rocm
-            RUN echo /root/rocm/lib | tee /etc/ld.so.conf.d/rocm-ci.conf
-            RUN echo /root/rocm/llvm/lib | tee -a /etc/ld.so.conf.d/rocm-ci.conf
-            RUN ldconfig -v
-            ENV PATH="$PATH:/root/rocm/bin"
-            ENTRYPOINT ["/bin/bash"]
-          EOF
+    - ${{ if eq(job.packageManager, 'apt') }}:
+      - task: Bash@3
+        displayName: Create Dockerfile
+        inputs:
+          workingDirectory: $(Agent.BuildDirectory)
+          targetType: inline
+          script: |
+            cat <<'EOF' > Dockerfile
+              ${{ iif(eq(job.os, 'ubuntu2204'), 'FROM ubuntu:22.04', '') }}
+              ${{ iif(eq(job.os, 'ubuntu2404'), 'FROM ubuntu:24.04', '') }}
+
+              WORKDIR /root
+              RUN mkdir rocm
+
+              RUN apt update \
+                && apt upgrade -y \
+                && apt install -y cmake curl git gcc g++ gpg lsb-release lsof ninja-build pkg-config python3 python3-pip wget zip libdrm-dev libelf-dev libgtest-dev libhsakmt-dev libhwloc-dev libnuma-dev libstdc++-12-dev libtbb-dev jq \
+                && apt clean all
+
+              RUN PACKAGE_NAME=$(curl -s https://repo.radeon.com/rocm/apt/latest/pool/main/h/hsa-amd-aqlprofile/ | grep -oP "href=\"\K[^\"]*$(lsb_release -rs)[^\"]*\.deb") \
+                && wget -nv --retry-connrefused https://repo.radeon.com/rocm/apt/latest/pool/main/h/hsa-amd-aqlprofile/$PACKAGE_NAME \
+                && mkdir hsa-amd-aqlprofile \
+                && dpkg-deb -R $PACKAGE_NAME hsa-amd-aqlprofile \
+                && cp -R hsa-amd-aqlprofile/opt/rocm-*/* rocm
+
+              RUN ARTIFACT_URL="https://dev.azure.com/ROCm-CI/ROCm-CI/_apis/build/builds/$(Build.BuildId)/artifacts?artifactName=nightly${{ job.os }}${{ job.target }}${{ job.source }}&api-version=7.1" \
+                && DOWNLOAD_URL=$(curl -s $ARTIFACT_URL | jq ".resource.downloadUrl" | tr -d '"') \
+                && wget -nv --retry-connrefused $DOWNLOAD_URL -O nightly.zip \
+                && unzip nightly.zip \
+                && tar -xf nightly${{ job.os }}${{ job.target }}${{ job.source }}/rocm-nightly*${{ job.os }}*${{ job.target }}*.tar.gz -C rocm
+
+              RUN echo /root/rocm/lib | tee /etc/ld.so.conf.d/rocm-ci.conf
+              RUN echo /root/rocm/llvm/lib | tee -a /etc/ld.so.conf.d/rocm-ci.conf
+              RUN ldconfig -v
+              ENV PATH="$PATH:/root/rocm/bin"
+              ENTRYPOINT ["/bin/bash"]
+            EOF
+            cat Dockerfile
+    - ${{ elseif eq(job.packageManager, 'dnf') }}:
+      - task: Bash@3
+        displayName: Create Dockerfile
+        inputs:
+          workingDirectory: $(Agent.BuildDirectory)
+          targetType: inline
+          script: |
+            cat <<'EOF' > Dockerfile
+              ${{ iif(eq(job.os, 'almalinux8'), 'FROM almalinux:8', '') }}
+
+              WORKDIR /root
+              RUN mkdir rocm
+
+              RUN dnf install -y cmake curl git gcc gcc-c++ gpg lsb-release lsof ninja-build pkg-config python3 python3-pip wget zip libdrm-devel libelf-devel gtest-devel hsakmt-devel hwloc-devel numactl-devel libstdc++-devel tbb jq \
+                && dnf clean all
+
+              RUN PACKAGE_NAME=$(curl -s https://repo.radeon.com/rocm/rhel8/$(REPO_RADEON_VERSION)/main/ | grep -oP "hsa-amd-aqlprofile-[^\"]+\.rpm" | head -n1) \
+                && wget -nv --retry-connrefused https://repo.radeon.com/rocm/rhel8/$(REPO_RADEON_VERSION)/main/$PACKAGE_NAME \
+                && mkdir hsa-amd-aqlprofile \
+                && sudo dnf -y install rpm-build cpio \
+                && rpm2cpio $PACKAGE_NAME | (cd hsa-amd-aqlprofile && cpio -idmv) \
+                && cp -R hsa-amd-aqlprofile/opt/rocm-*/* rocm
+
+              RUN ARTIFACT_URL="https://dev.azure.com/ROCm-CI/ROCm-CI/_apis/build/builds/$(Build.BuildId)/artifacts?artifactName=nightly${{ job.os }}${{ job.target }}${{ job.source }}&api-version=7.1" \
+                && DOWNLOAD_URL=$(curl -s $ARTIFACT_URL | jq ".resource.downloadUrl" | tr -d '"') \
+                && wget -nv --retry-connrefused $DOWNLOAD_URL -O nightly.zip \
+                && unzip nightly.zip \
+                && tar -xf nightly${{ job.os }}${{ job.target }}${{ job.source }}/rocm-nightly*${{ job.os }}*${{ job.target }}*.tar.gz -C rocm
+
+              RUN echo /root/rocm/lib | tee /etc/ld.so.conf.d/rocm-ci.conf
+              RUN echo /root/rocm/llvm/lib | tee -a /etc/ld.so.conf.d/rocm-ci.conf
+              RUN ldconfig -v
+              ENV PATH="$PATH:/root/rocm/bin"
+              ENTRYPOINT ["/bin/bash"]
+            EOF
+            cat Dockerfile
     - task: Docker@2
       displayName: Build and upload Docker image
       inputs:

--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -90,6 +90,7 @@ schedules:
     - develop
   always: true
 
+jobs:
 - ${{ each job in parameters.jobList }}:
   - job: nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}
     variables:

--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -93,6 +93,7 @@ schedules:
 stages:
 - ${{ each job in parameters.jobList }}:
   - stage: rocm_nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}
+    dependsOn: []
     jobs:
     - job: rocm_nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}
       variables:

--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -93,6 +93,7 @@ schedules:
 jobs:
 - ${{ each job in parameters.jobList }}:
   - job: nightly_${{ job.os }}_${{ job.target }}_${{ job.source }}
+    timeoutInMinutes: 90
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml

--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -198,7 +198,7 @@ jobs:
               WORKDIR /root
               RUN mkdir rocm
 
-              RUN dnf install -y cmake curl git gcc gcc-c++ gnupg2 redhat-lsb-core lsof ninja-build pkgconf python3 python3-pip wget zip libdrm-devel elfutils-libelf-devel hwloc-devel numactl-devel libstdc++-devel tbb-devel jq \
+              RUN dnf install -y cmake curl git gcc gcc-c++ gnupg2 redhat-lsb-core lsof pkgconf python3 python3-pip wget zip libdrm-devel elfutils-libelf-devel numactl-devel libstdc++-devel tbb-devel jq \
                 && dnf clean all
 
               RUN PACKAGE_NAME=$(curl -s https://repo.radeon.com/rocm/rhel8/$(REPO_RADEON_VERSION)/main/ | grep -oP "hsa-amd-aqlprofile-[^\"]+\.rpm" | head -n1) \

--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -204,7 +204,7 @@ jobs:
               RUN PACKAGE_NAME=$(curl -s https://repo.radeon.com/rocm/rhel8/$(REPO_RADEON_VERSION)/main/ | grep -oP "hsa-amd-aqlprofile-[^\"]+\.rpm" | head -n1) \
                 && wget -nv --retry-connrefused https://repo.radeon.com/rocm/rhel8/$(REPO_RADEON_VERSION)/main/$PACKAGE_NAME \
                 && mkdir hsa-amd-aqlprofile \
-                && sudo dnf -y install rpm-build cpio \
+                && dnf -y install rpm-build cpio \
                 && rpm2cpio $PACKAGE_NAME | (cd hsa-amd-aqlprofile && cpio -idmv) \
                 && cp -R hsa-amd-aqlprofile/opt/rocm-*/* rocm
 

--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -131,7 +131,7 @@ jobs:
         includeRootFolder: false
         archiveType: tar
         tarCompression: gz
-        archiveFile: $(Build.ArtifactStagingDirectory)/$(Build.DefinitionName)_$(Build.BuildNumber)_ubuntu2204_${{ job.target }}.tar.gz
+        archiveFile: $(Build.ArtifactStagingDirectory)/$(Build.DefinitionName)_$(Build.BuildNumber)_${{ job.os }}_${{ job.target }}.tar.gz
     - script: du -sh $(Build.ArtifactStagingDirectory)
       displayName: Compressed ROCm size
     - task: PublishPipelineArtifact@1
@@ -144,7 +144,7 @@ jobs:
       inputs:
         workingDirectory: $(Pipeline.Workspace)
         targetType: inline
-        script: echo "$(Build.DefinitionName)_$(Build.BuildNumber)_ubuntu2204_${{ job.target }}.tar.gz" >> pipelineArtifacts.txt
+        script: echo "$(Build.DefinitionName)_$(Build.BuildNumber)_${{ job.os }}_${{ job.target }}.tar.gz" >> pipelineArtifacts.txt
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml
     - ${{ if eq(job.packageManager, 'apt') }}:
       - task: Bash@3
@@ -197,7 +197,7 @@ jobs:
               WORKDIR /root
               RUN mkdir rocm
 
-              RUN dnf install -y cmake curl git gcc gcc-c++ gpg lsb-release lsof ninja-build pkg-config python3 python3-pip wget zip libdrm-devel libelf-devel gtest-devel hsakmt-devel hwloc-devel numactl-devel libstdc++-devel tbb jq \
+              RUN dnf install -y cmake curl git gcc gcc-c++ gnupg2 redhat-lsb-core lsof ninja-build pkgconf python3 python3-pip wget zip libdrm-devel elfutils-libelf-devel hwloc-devel numactl-devel libstdc++-devel tbb-devel jq \
                 && dnf clean all
 
               RUN PACKAGE_NAME=$(curl -s https://repo.radeon.com/rocm/rhel8/$(REPO_RADEON_VERSION)/main/ | grep -oP "hsa-amd-aqlprofile-[^\"]+\.rpm" | head -n1) \

--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -180,6 +180,8 @@ jobs:
 
               RUN echo /root/rocm/lib | tee /etc/ld.so.conf.d/rocm-ci.conf
               RUN echo /root/rocm/llvm/lib | tee -a /etc/ld.so.conf.d/rocm-ci.conf
+              RUN echo /root/rocm/lib64 | tee -a /etc/ld.so.conf.d/rocm-ci.conf
+              RUN echo /root/rocm/llvm/lib64 | tee -a /etc/ld.so.conf.d/rocm-ci.conf
               RUN ldconfig -v
               ENV PATH="$PATH:/root/rocm/bin"
               ENTRYPOINT ["/bin/bash"]
@@ -216,6 +218,8 @@ jobs:
 
               RUN echo /root/rocm/lib | tee /etc/ld.so.conf.d/rocm-ci.conf
               RUN echo /root/rocm/llvm/lib | tee -a /etc/ld.so.conf.d/rocm-ci.conf
+              RUN echo /root/rocm/lib64 | tee -a /etc/ld.so.conf.d/rocm-ci.conf
+              RUN echo /root/rocm/llvm/lib64 | tee -a /etc/ld.so.conf.d/rocm-ci.conf
               RUN ldconfig -v
               ENV PATH="$PATH:/root/rocm/bin"
               ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
Adds the creation of a Docker image to the nightly builds that:
- Installs a basic set of packages
  - Other packages will need to be installed manually, if needed
- Downloads and extracts aqlprofile
  - Can be removed once aqlprofile is added into CI
- Downloads and extracts the tarball from the previous steps
- Sets linker paths
- Adds `rocm/bin` to PATH

After the image is uploaded, it will print a single command to run the image.

Images are named: `rocmexternalcicd.azurecr.io/nightly-{os}-{gfx-target}-{source}:{build-id}`

Sample run:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=38531&view=results

Basic verification was performed for the gfx90a images on an MI250 system by running (UB24 only had the smi's available):
`rocminfo` `rocm_agent_enumerator` `rocm-smi` `amd-smi`

A potential consideration is that regularly pushing these nightly images to our registry may increase costs, since they're pretty large and this would happen on a daily basis.