### PR TITLE
[Ex CI] add OS to copyHIP filenames

### DIFF
--- a/.azuredevops/components/copyHIP.yml
+++ b/.azuredevops/components/copyHIP.yml
@@ -39,4 +39,6 @@ jobs:
       parameters:
         os: ${{ job.os }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
+      inputs:
+        os: ${{ job.os }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml


### PR DESCRIPTION
Fixes an issue where clr zip files were incorrectly named with ubuntu2204 instead of the actual OS.