### PR TITLE
[Ex CI] hipBLASLt: build gfx942 on high pool

### DIFF
--- a/.azuredevops/components/hipBLASLt.yml
+++ b/.azuredevops/components/hipBLASLt.yml
@@ -77,12 +77,12 @@ parameters:
   type: object
   default:
     buildJobs:
-      - { pool: rocm-ci_ultra_build_pool, os: ubuntu2204, packageManager: apt, target: gfx942 }
+      - { pool: rocm-ci_high_build_pool, os: ubuntu2204, packageManager: apt, target: gfx942 }
       - { pool: rocm-ci_medium_build_pool, os: ubuntu2204, packageManager: apt, target: gfx90a }
       - { pool: rocm-ci_medium_build_pool, os: ubuntu2204, packageManager: apt, target: gfx1201 }
       - { pool: rocm-ci_medium_build_pool, os: ubuntu2204, packageManager: apt, target: gfx1100 }
       - { pool: rocm-ci_medium_build_pool, os: ubuntu2204, packageManager: apt, target: gfx1030 }
-      - { pool: rocm-ci_ultra_build_pool, os: almalinux8, packageManager: dnf, target: gfx942 }
+      - { pool: rocm-ci_high_build_pool, os: almalinux8, packageManager: dnf, target: gfx942 }
       - { pool: rocm-ci_medium_build_pool, os: almalinux8, packageManager: dnf, target: gfx90a }
       - { pool: rocm-ci_medium_build_pool, os: almalinux8, packageManager: dnf, target: gfx1201 }
       - { pool: rocm-ci_medium_build_pool, os: almalinux8, packageManager: dnf, target: gfx1100 }


### PR DESCRIPTION
We're having issues scaling up the ultra pool, so move hipBLASLt gfx942 builds to the high pool to see if that helps.

Tensile builds are apparently single-threaded anyways, so that would explain why the other arches can be built on the medium pool without much increase in build times.

Sample run, aiming for ~1.5 hour build time:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=37768&view=results