### PR TITLE
[Ex CI] re-enable rocm-examples rocfft_callback

### DIFF
--- a/.azuredevops/components/rocm-examples.yml
+++ b/.azuredevops/components/rocm-examples.yml
@@ -184,7 +184,7 @@ jobs:
       parameters:
         componentName: rocm-examples
         testDir: $(Build.SourcesDirectory)/build
-        testParameters: '--output-on-failure --force-new-ctest-process --output-junit test_output.xml --exclude-regex "rocfft_callback"'
+        testParameters: '--output-on-failure --force-new-ctest-process --output-junit test_output.xml'
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/docker-container.yml
       parameters:
         aptPackages: ${{ parameters.aptPackages }}


### PR DESCRIPTION
Test failure was fixed in https://github.com/ROCm/rocm-examples/pull/269, so re-enabling it.

Sample run:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=39095&view=results