### PR TITLE
[docs/6.4.2] Remove broken link to deprecated AMDGPU installer documentation and fix branches for install docs in TOC

### DIFF
--- a/docs/how-to/rocm-for-ai/install.rst
+++ b/docs/how-to/rocm-for-ai/install.rst
@@ -24,11 +24,12 @@ If you’re new to ROCm, refer to the :doc:`ROCm quick start install guide for L
 If you’re using a Radeon GPU for graphics-accelerated applications, refer to the
 `Radeon installation instructions <https://rocm.docs.amd.com/projects/radeon/en/docs-6.1.3/docs/install/native_linux/install-radeon.html>`_.
 
-ROCm supports multiple :doc:`installation methods <rocm-install-on-linux:install/install-overview>`:
+You can install ROCm on :ref:`compatible systems <rocm-install-on-linux:reference/system-requirements>` via your Linux
+distribution's package manager. See the following documentation resources to get started:
+
+* :doc:`ROCm installation overview <rocm-install-on-linux:install/install-overview>`
 
 * :doc:`Using your Linux distribution's package manager <rocm-install-on-linux:install/install-methods/package-manager-index>`
-
-* :doc:`Using the AMDGPU installer <rocm-install-on-linux:install/install-methods/amdgpu-installer-index>`
 
 * :ref:`Multi-version installation <rocm-install-on-linux:installation-types>`
 
@@ -58,6 +59,12 @@ images with the framework pre-installed.
 * :doc:`TensorFlow for ROCm <rocm-install-on-linux:install/3rd-party/tensorflow-install>`
 
 * :doc:`JAX for ROCm <rocm-install-on-linux:install/3rd-party/jax-install>`
+
+* :doc:`verl for ROCm <rocm-install-on-linux:install/3rd-party/verl-install>`
+
+* :doc:`Stanford Megatron-LM for ROCm <rocm-install-on-linux:install/3rd-party/jax-install>`
+
+* :doc:`DGL for ROCm <rocm-install-on-linux:install/3rd-party/jax-install>`
 
 Next steps
 ==========

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -19,9 +19,9 @@ subtrees:
 
 - caption: Install
   entries:
-  - url: https://rocm.docs.amd.com/projects/install-on-linux/en/latest/
+  - url: https://rocm.docs.amd.com/projects/install-on-linux/en/${branch}/
     title: ROCm on Linux
-  - url: https://rocm.docs.amd.com/projects/install-on-windows/en/${branch}/
+  - url: https://rocm.docs.amd.com/projects/install-on-windows/en/latest/
     title: HIP SDK on Windows
   - url: https://rocm.docs.amd.com/projects/radeon/en/latest/index.html
     title: ROCm on Radeon GPUs


### PR DESCRIPTION
(cherry picked from commit https://github.com/ROCm/ROCm/commit/2269e9d25d7309b82c2641911398205c3ecf5e7f)

(cherry picked from commit https://github.com/ROCm/ROCm/commit/15ee605d18e94144ae9a677d3bf3f4badff35ed1)