### PR TITLE
[Ex CI] update to 6.4.2

### DIFF
--- a/.azuredevops/variables-global.yml
+++ b/.azuredevops/variables-global.yml
@@ -32,13 +32,13 @@ variables:
 - name: GFX90A_TEST_POOL
   value: gfx90a_test_pool
 - name: LATEST_RELEASE_VERSION
-  value: 6.4.1
+  value: 6.4.2
 - name: REPO_RADEON_VERSION
-  value: 6.4.1
+  value: 6.4.2
 - name: NEXT_RELEASE_VERSION
   value: 7.0.0
 - name: LATEST_RELEASE_TAG
-  value: rocm-6.4.1
+  value: rocm-6.4.2
 - name: DOCKER_SKIP_GFX
   value: gfx90a
 - name: AMDMIGRAPHX_PIPELINE_ID


### PR DESCRIPTION
Sample run, gfx942 test failures are known by component team:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=39714&view=results