### PR TITLE
[Ex CI] enable MIOpen monorepo

### DIFF
--- a/.azuredevops/components/AMDMIGraphX.yml
+++ b/.azuredevops/components/AMDMIGraphX.yml
@@ -1,10 +1,29 @@
 parameters:
+- name: componentName
+  type: string
+  default: AMDMIGraphX
 - name: checkoutRepo
   type: string
   default: 'self'
 - name: checkoutRef
   type: string
   default: ''
+# monorepo related parameters
+# - name: sparseCheckoutDir
+#   type: string
+#   default: ''
+- name: triggerDownstreamJobs
+  type: boolean
+  default: false
+- name: downstreamAggregateNames
+  type: string
+  default: ''
+- name: buildDependsOn
+  type: object
+  default: null
+- name: unifiedBuild
+  type: boolean
+  default: false
 # set to true if doing full build of ROCm stack
 # and dependencies are pulled from same pipeline
 - name: aggregatePipeline
@@ -93,7 +112,11 @@ parameters:
 
 jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
-  - job: AMDMIGraphX_build_${{ job.target }}
+  - job: ${{ parameters.componentName }}_build_ubuntu2204_${{ job.target }}
+    ${{ if parameters.buildDependsOn }}:
+      dependsOn:
+        - ${{ each build in parameters.buildDependsOn }}:
+          - ${{ build }}_ubuntu2204_${{ job.target }}
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
@@ -121,6 +144,8 @@ jobs:
         dependencyList: ${{ parameters.rocmDependencies }}
         gpuTarget: ${{ job.target }}
         aggregatePipeline: ${{ parameters.aggregatePipeline }}
+        ${{ if parameters.triggerDownstreamJobs }}:
+          downstreamAggregateNames: ${{ parameters.downstreamAggregateNames }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
       parameters:
         extraBuildFlags: >-
@@ -146,12 +171,12 @@ jobs:
         gpuTarget: ${{ job.target }}
 
 - ${{ each job in parameters.jobMatrix.testJobs }}:
-  - job: AMDMIGraphX_test_${{ job.target }}
-    dependsOn: AMDMIGraphX_build_${{ job.target }}
+  - job: ${{ parameters.componentName }}_test_ubuntu2204_${{ job.target }}
+    dependsOn: ${{ parameters.componentName }}_build_ubuntu2204_${{ job.target }}
     condition:
       and(succeeded(),
         eq(variables['ENABLE_${{ upper(job.target) }}_TESTS'], 'true'),
-        not(containsValue(split(variables['DISABLED_${{ upper(job.target) }}_TESTS'], ','), variables['Build.DefinitionName'])),
+        not(containsValue(split(variables['DISABLED_${{ upper(job.target) }}_TESTS'], ','), ${{ parameters.componentName }})),
         eq(${{ parameters.aggregatePipeline }}, False)
       )
     variables:
@@ -183,6 +208,8 @@ jobs:
         checkoutRef: ${{ parameters.checkoutRef }}
         dependencyList: ${{ parameters.rocmTestDependencies }}
         gpuTarget: ${{ job.target }}
+        ${{ if parameters.triggerDownstreamJobs }}:
+          downstreamAggregateNames: ${{ parameters.downstreamAggregateNames }}
     - task: CMake@1
       displayName: MIGraphXTest CMake Flags
       inputs:
@@ -199,7 +226,7 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/gpu-diagnostics.yml
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
       parameters:
-        componentName: AMDMIGraphX
+        componentName: ${{ parameters.componentName }}
         testExecutable: make
         testParameters: -j$(nproc) check
         testPublishResults: false

--- a/.azuredevops/components/AMDMIGraphX.yml
+++ b/.azuredevops/components/AMDMIGraphX.yml
@@ -176,7 +176,7 @@ jobs:
     condition:
       and(succeeded(),
         eq(variables['ENABLE_${{ upper(job.target) }}_TESTS'], 'true'),
-        not(containsValue(split(variables['DISABLED_${{ upper(job.target) }}_TESTS'], ','), ${{ parameters.componentName }})),
+        not(containsValue(split(variables['DISABLED_${{ upper(job.target) }}_TESTS'], ','), '${{ parameters.componentName }}')),
         eq(${{ parameters.aggregatePipeline }}, False)
       )
     variables:

--- a/.azuredevops/components/MIOpen.yml
+++ b/.azuredevops/components/MIOpen.yml
@@ -1,10 +1,29 @@
 parameters:
+- name: componentName
+  type: string
+  default: MIOpen
 - name: checkoutRepo
   type: string
   default: 'self'
 - name: checkoutRef
   type: string
   default: ''
+# monorepo related parameters
+- name: sparseCheckoutDir
+  type: string
+  default: ''
+- name: triggerDownstreamJobs
+  type: boolean
+  default: false
+- name: downstreamAggregateNames
+  type: string
+  default: ''
+- name: buildDependsOn
+  type: object
+  default: null
+- name: unifiedBuild
+  type: boolean
+  default: false
 # set to true if doing full build of ROCm stack
 # and dependencies are pulled from same pipeline
 - name: aggregatePipeline
@@ -77,7 +96,11 @@ parameters:
 
 jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
-  - job: MIOpen_build_${{ job.target }}
+  - job: ${{ parameters.componentName }}_build_ubuntu2204_${{ job.target }}
+    ${{ if parameters.buildDependsOn }}:
+      dependsOn:
+        - ${{ each build in parameters.buildDependsOn }}:
+          - ${{ build }}_ubuntu2204_${{ job.target }}
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
@@ -95,6 +118,7 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
       parameters:
         checkoutRepo: ${{ parameters.checkoutRepo }}
+        sparseCheckoutDir: ${{ parameters.sparseCheckoutDir }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/miopen-get-ck-build.yml
       parameters:
         gpuTarget: ${{ job.target }}
@@ -104,6 +128,8 @@ jobs:
         dependencyList: ${{ parameters.rocmDependencies }}
         gpuTarget: ${{ job.target }}
         aggregatePipeline: ${{ parameters.aggregatePipeline }}
+        ${{ if parameters.triggerDownstreamJobs }}:
+          downstreamAggregateNames: ${{ parameters.downstreamAggregateNames }}
     - task: Bash@3
       displayName: Build and install other dependencies
       inputs:
@@ -130,6 +156,7 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
       parameters:
         gpuTarget: ${{ job.target }}
+        sparseCheckoutDir: ${{ parameters.sparseCheckoutDir }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
       parameters:
         gpuTarget: ${{ job.target }}
@@ -143,9 +170,9 @@ jobs:
           - miopen-deps
 
 - ${{ each job in parameters.jobMatrix.testJobs }}:
-  - job: MIOpen_test_${{ job.target }}
+  - job: ${{ parameters.componentName }}_test_ubuntu2204_${{ job.target }}
     timeoutInMinutes: 180
-    dependsOn: MIOpen_build_${{ job.target }}
+    dependsOn: ${{ parameters.componentName }}_build_ubuntu2204_${{ job.target }}
     condition:
       and(succeeded(),
         eq(variables['ENABLE_${{ upper(job.target) }}_TESTS'], 'true'),
@@ -169,6 +196,7 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
       parameters:
         checkoutRepo: ${{ parameters.checkoutRepo }}
+        sparseCheckoutDir: ${{ parameters.sparseCheckoutDir }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-aqlprofile.yml
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/miopen-get-ck-build.yml
       parameters:
@@ -178,6 +206,8 @@ jobs:
         checkoutRef: ${{ parameters.checkoutRef }}
         dependencyList: ${{ parameters.rocmTestDependencies }}
         gpuTarget: ${{ job.target }}
+        ${{ if parameters.triggerDownstreamJobs }}:
+          downstreamAggregateNames: ${{ parameters.downstreamAggregateNames }}
     - task: Bash@3
       displayName: Build and install other dependencies
       inputs:
@@ -214,7 +244,7 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/gpu-diagnostics.yml
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
       parameters:
-        componentName: MIOpen
+        componentName: ${{ parameters.componentName }}
         testParameters: '--output-on-failure --force-new-ctest-process --output-junit test_output.xml --exclude-regex "test_rnn_seq_api|GPU_Conv2dTuningAsm_FP32"'
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/docker-container.yml
       parameters:

--- a/.azuredevops/components/MIOpen.yml
+++ b/.azuredevops/components/MIOpen.yml
@@ -239,7 +239,7 @@ jobs:
       inputs:
         targetType: inline
         script: |
-          cmake --build $(Agent.BuildDirectory)/s --target tests -- -j$(nproc)
+          cmake --build . --target tests -- -j$(nproc)
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/gpu-diagnostics.yml
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
       parameters:

--- a/.azuredevops/components/MIOpen.yml
+++ b/.azuredevops/components/MIOpen.yml
@@ -134,7 +134,7 @@ jobs:
       displayName: Build and install other dependencies
       inputs:
         targetType: inline
-        workingDirectory: $(Build.SourcesDirectory)
+        workingDirectory: $(Agent.BuildDirectory)/s
         script: |
           sed -i '/composable_kernel/d' requirements.txt
           mkdir -p $(Agent.BuildDirectory)/miopen-deps
@@ -212,7 +212,7 @@ jobs:
       displayName: Build and install other dependencies
       inputs:
         targetType: inline
-        workingDirectory: $(Build.SourcesDirectory)
+        workingDirectory: $(Agent.BuildDirectory)/s
         script: |
           sed -i '/composable_kernel/d' requirements.txt
           mkdir -p $(Agent.BuildDirectory)/miopen-deps
@@ -223,7 +223,7 @@ jobs:
       displayName: 'MIOpen Test CMake Flags'
       inputs:
         cmakeArgs: >-
-          -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm;$(Build.SourcesDirectory)/bin;$(Agent.BuildDirectory)/miopen-deps
+          -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm;$(Agent.BuildDirectory)/s/bin;$(Agent.BuildDirectory)/miopen-deps
           -DCMAKE_INSTALL_PREFIX=$(Agent.BuildDirectory)/rocm
           -DCMAKE_CXX_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang++
           -DCMAKE_C_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang
@@ -240,7 +240,7 @@ jobs:
         targetType: inline
         script: |
           cmake --build . --target tests -- -j$(nproc)
-        workingDirectory: $(Build.SourcesDirectory)/build
+        workingDirectory: $(Agent.BuildDirectory)/s/build
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/gpu-diagnostics.yml
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
       parameters:

--- a/.azuredevops/components/MIOpen.yml
+++ b/.azuredevops/components/MIOpen.yml
@@ -233,7 +233,7 @@ jobs:
           -DBUILD_DEV=OFF
           -DMIOPEN_USE_MLIR=ON
           -DMIOPEN_GPU_SYNC=OFF
-          ..
+          $(Agent.BuildDirectory)/s
     - task: Bash@3
       displayName: 'MIOpen Test Build'
       inputs:

--- a/.azuredevops/components/MIOpen.yml
+++ b/.azuredevops/components/MIOpen.yml
@@ -239,8 +239,7 @@ jobs:
       inputs:
         targetType: inline
         script: |
-          cmake --build . --target tests -- -j$(nproc)
-        workingDirectory: $(Agent.BuildDirectory)/s/build
+          cmake --build $(Agent.BuildDirectory)/s --target tests -- -j$(nproc)
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/gpu-diagnostics.yml
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
       parameters:

--- a/.azuredevops/components/MIOpen.yml
+++ b/.azuredevops/components/MIOpen.yml
@@ -106,7 +106,7 @@ jobs:
     - template: /.azuredevops/variables-global.yml
     - name: ROCM_PATH
       value: $(Agent.BuildDirectory)/rocm
-    pool: ${{ variables.ULTRA_BUILD_POOL }}
+    pool: ${{ variables.HIGH_BUILD_POOL }}
     workspace:
       clean: all
     steps:

--- a/.azuredevops/components/MIOpen.yml
+++ b/.azuredevops/components/MIOpen.yml
@@ -98,12 +98,14 @@ parameters:
   default:
     - MIVisionX:
       name: MIVisionX
+      checkoutRepo: mivisionx_repo
       sparseCheckoutDir: ''
       skipUnifiedBuild: 'false'
       buildDependsOn:
         - MIOpen_build
     - AMDMIGraphX:
       name: AMDMIGraphX
+      checkoutRepo: amdmigraphx_repo
       sparseCheckoutDir: ''
       skipUnifiedBuild: 'false'
       buildDependsOn:
@@ -276,7 +278,7 @@ jobs:
     - ${{ if not(and(parameters.unifiedBuild, eq(component.skipUnifiedBuild, 'true'))) }}:
       - template: /.azuredevops/components/${{ component.name }}.yml@pipelines_repo
         parameters:
-          checkoutRepo: ${{ parameters.checkoutRepo }}
+          checkoutRepo: ${{ component.checkoutRepo }}
           # sparseCheckoutDir: ${{ component.sparseCheckoutDir }}
           buildDependsOn: ${{ component.buildDependsOn }}
           downstreamAggregateNames: ${{ parameters.downstreamAggregateNames }}+${{ parameters.componentName }}

--- a/.azuredevops/components/MIOpen.yml
+++ b/.azuredevops/components/MIOpen.yml
@@ -174,6 +174,7 @@ jobs:
         sparseCheckoutDir: ${{ parameters.sparseCheckoutDir }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-upload.yml
       parameters:
+        componentName: ${{ parameters.componentName }}
         gpuTarget: ${{ job.target }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/artifact-links.yml
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/docker-container.yml

--- a/.azuredevops/components/MIOpen.yml
+++ b/.azuredevops/components/MIOpen.yml
@@ -93,6 +93,21 @@ parameters:
         target: gfx942
       - gfx90a:
         target: gfx90a
+- name: downstreamComponentMatrix
+  type: object
+  default:
+    - MIVisionX:
+      name: MIVisionX
+      sparseCheckoutDir: ''
+      skipUnifiedBuild: 'false'
+      buildDependsOn:
+        - MIOpen_build
+    - AMDMIGraphX:
+      name: AMDMIGraphX
+      sparseCheckoutDir: ''
+      skipUnifiedBuild: 'false'
+      buildDependsOn:
+        - MIOpen_build
 
 jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
@@ -254,3 +269,15 @@ jobs:
         gpuTarget: ${{ job.target }}
         extraCopyDirectories:
           - miopen-deps
+
+- ${{ if parameters.triggerDownstreamJobs }}:
+  - ${{ each component in parameters.downstreamComponentMatrix }}:
+    - ${{ if not(and(parameters.unifiedBuild, eq(component.skipUnifiedBuild, 'true'))) }}:
+      - template: /.azuredevops/components/${{ component.name }}.yml@pipelines_repo
+        parameters:
+          checkoutRepo: ${{ parameters.checkoutRepo }}
+          sparseCheckoutDir: ${{ component.sparseCheckoutDir }}
+          buildDependsOn: ${{ component.buildDependsOn }}
+          downstreamAggregateNames: ${{ parameters.downstreamAggregateNames }}+${{ parameters.componentName }}
+          triggerDownstreamJobs: true
+          unifiedBuild: ${{ parameters.unifiedBuild }}

--- a/.azuredevops/components/MIOpen.yml
+++ b/.azuredevops/components/MIOpen.yml
@@ -238,6 +238,7 @@ jobs:
       displayName: 'MIOpen Test Build'
       inputs:
         targetType: inline
+        workingDirectory: build
         script: |
           cmake --build . --target tests -- -j$(nproc)
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/gpu-diagnostics.yml

--- a/.azuredevops/components/MIOpen.yml
+++ b/.azuredevops/components/MIOpen.yml
@@ -245,7 +245,7 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
       parameters:
         componentName: ${{ parameters.componentName }}
-        testParameters: '--output-on-failure --force-new-ctest-process --output-junit test_output.xml --exclude-regex "test_rnn_seq_api|GPU_Conv2dTuningAsm_FP32"'
+        testParameters: '--output-on-failure --force-new-ctest-process --output-junit test_output.xml --exclude-regex "test_rnn_seq_api|GPU_Conv2dTuningAsm_FP32|GPU_Conv2dTuningAsmBwdWrw_FP32"'
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/docker-container.yml
       parameters:
         aptPackages: ${{ parameters.aptPackages }}

--- a/.azuredevops/components/MIOpen.yml
+++ b/.azuredevops/components/MIOpen.yml
@@ -106,7 +106,7 @@ jobs:
     - template: /.azuredevops/variables-global.yml
     - name: ROCM_PATH
       value: $(Agent.BuildDirectory)/rocm
-    pool: ${{ variables.HIGH_BUILD_POOL }}
+    pool: ${{ variables.ULTRA_BUILD_POOL }}
     workspace:
       clean: all
     steps:

--- a/.azuredevops/components/MIOpen.yml
+++ b/.azuredevops/components/MIOpen.yml
@@ -276,7 +276,7 @@ jobs:
       - template: /.azuredevops/components/${{ component.name }}.yml@pipelines_repo
         parameters:
           checkoutRepo: ${{ parameters.checkoutRepo }}
-          sparseCheckoutDir: ${{ component.sparseCheckoutDir }}
+          # sparseCheckoutDir: ${{ component.sparseCheckoutDir }}
           buildDependsOn: ${{ component.buildDependsOn }}
           downstreamAggregateNames: ${{ parameters.downstreamAggregateNames }}+${{ parameters.componentName }}
           triggerDownstreamJobs: true

--- a/.azuredevops/components/MIVisionX.yml
+++ b/.azuredevops/components/MIVisionX.yml
@@ -1,10 +1,29 @@
 parameters:
+- name: componentName
+  type: string
+  default: MIVisionX
 - name: checkoutRepo
   type: string
   default: 'self'
 - name: checkoutRef
   type: string
   default: ''
+# monorepo related parameters
+# - name: sparseCheckoutDir
+#   type: string
+#   default: ''
+- name: triggerDownstreamJobs
+  type: boolean
+  default: false
+- name: downstreamAggregateNames
+  type: string
+  default: ''
+- name: buildDependsOn
+  type: object
+  default: null
+- name: unifiedBuild
+  type: boolean
+  default: false
 # set to true if doing full build of ROCm stack
 # and dependencies are pulled from same pipeline
 - name: aggregatePipeline
@@ -88,7 +107,11 @@ parameters:
 
 jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
-  - job: MIVisionX_build_${{ job.target }}
+  - job: ${{ parameters.componentName }}_build_ubuntu2204_${{ job.target }}
+    ${{ if parameters.buildDependsOn }}:
+      dependsOn:
+        - ${{ each build in parameters.buildDependsOn }}:
+          - ${{ build }}_ubuntu2204_${{ job.target }}
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
@@ -110,6 +133,8 @@ jobs:
         dependencyList: ${{ parameters.rocmDependencies }}
         gpuTarget: ${{ job.target }}
         aggregatePipeline: ${{ parameters.aggregatePipeline }}
+        ${{ if parameters.triggerDownstreamJobs }}:
+          downstreamAggregateNames: ${{ parameters.downstreamAggregateNames }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
       parameters:
         extraBuildFlags: >-
@@ -131,12 +156,12 @@ jobs:
     #     gpuTarget: ${{ job.target }}
 
 - ${{ each job in parameters.jobMatrix.testJobs }}:
-  - job: MIVisionX_test_${{ job.target }}
-    dependsOn: MIVisionX_build_${{ job.target }}
+  - job: ${{ parameters.componentName }}_test_ubuntu2204_${{ job.target }}
+    dependsOn: ${{ parameters.componentName }}_build_ubuntu2204_${{ job.target }}
     condition:
       and(succeeded(),
         eq(variables['ENABLE_${{ upper(job.target) }}_TESTS'], 'true'),
-        not(containsValue(split(variables['DISABLED_${{ upper(job.target) }}_TESTS'], ','), variables['Build.DefinitionName'])),
+        not(containsValue(split(variables['DISABLED_${{ upper(job.target) }}_TESTS'], ','), ${{ parameters.componentName }})),
         eq(${{ parameters.aggregatePipeline }}, False)
       )
     variables:
@@ -161,6 +186,8 @@ jobs:
         checkoutRef: ${{ parameters.checkoutRef }}
         dependencyList: ${{ parameters.rocmTestDependencies }}
         gpuTarget: ${{ job.target }}
+        ${{ if parameters.triggerDownstreamJobs }}:
+          downstreamAggregateNames: ${{ parameters.downstreamAggregateNames }}
     - task: Bash@3
       displayName: Build MIVisionX tests
       inputs:
@@ -174,7 +201,7 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/gpu-diagnostics.yml
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
       parameters:
-        componentName: MIVisionX
+        componentName: ${{ parameters.componentName }}
         testDir: 'mivisionx-tests'
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/docker-container.yml
       parameters:

--- a/.azuredevops/components/MIVisionX.yml
+++ b/.azuredevops/components/MIVisionX.yml
@@ -79,6 +79,7 @@ parameters:
 - name: rocmTestDependencies
   type: object
   default:
+    - aomp
     - clr
     - half
     - hipBLAS-common

--- a/.azuredevops/components/MIVisionX.yml
+++ b/.azuredevops/components/MIVisionX.yml
@@ -161,7 +161,7 @@ jobs:
     condition:
       and(succeeded(),
         eq(variables['ENABLE_${{ upper(job.target) }}_TESTS'], 'true'),
-        not(containsValue(split(variables['DISABLED_${{ upper(job.target) }}_TESTS'], ','), ${{ parameters.componentName }})),
+        not(containsValue(split(variables['DISABLED_${{ upper(job.target) }}_TESTS'], ','), '${{ parameters.componentName }}')),
         eq(${{ parameters.aggregatePipeline }}, False)
       )
     variables:

--- a/.azuredevops/components/hipBLAS.yml
+++ b/.azuredevops/components/hipBLAS.yml
@@ -90,24 +90,24 @@ parameters:
         target: gfx90a
 # MIOpen depends on both rocRAND and hipBLAS
 # for a unified build, hipBLAS will be the one to call MIOpen
-# - name: downstreamComponentMatrix
-#   type: object
-#   default:
-#     - MIOpen:
-#       name: MIOpen
-#       sparseCheckoutDir: projects/miopen
-#       skipUnifiedBuild: 'false'
-#       buildDependsOn:
-#         - hipBLAS_build
-#       unifiedBuild:
-#         downstreamAggregateNames: hipBLAS+rocRAND
-#         buildDependsOn:
-#           - hipBLAS_build
-#           - rocRAND_build
+- name: downstreamComponentMatrix
+  type: object
+  default:
+    - MIOpen:
+      name: MIOpen
+      sparseCheckoutDir: projects/miopen
+      skipUnifiedBuild: 'false'
+      buildDependsOn:
+        - hipBLAS_build
+      unifiedBuild:
+        downstreamAggregateNames: hipBLAS+rocRAND
+        buildDependsOn:
+          - hipBLAS_build
+          - rocRAND_build
 
 jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
-  - job: ${{ parameters.componentName }}_build_${{ job.target }}
+  - job: ${{ parameters.componentName }}_build_ubuntu2204_${{ job.target }}
     ${{ if parameters.buildDependsOn }}:
       dependsOn:
         - ${{ each build in parameters.buildDependsOn }}:
@@ -168,8 +168,8 @@ jobs:
 
 - ${{ if eq(parameters.unifiedBuild, False) }}:
   - ${{ each job in parameters.jobMatrix.testJobs }}:
-    - job: ${{ parameters.componentName }}_test_${{ job.target }}
-      dependsOn: ${{ parameters.componentName }}_build_${{ job.target }}
+    - job: ${{ parameters.componentName }}_test_ubuntu2204_${{ job.target }}
+      dependsOn: ${{ parameters.componentName }}_build_ubuntu2204_${{ job.target }}
       condition:
         and(succeeded(),
           eq(variables['ENABLE_${{ upper(job.target) }}_TESTS'], 'true'),
@@ -215,18 +215,18 @@ jobs:
           environment: test
           gpuTarget: ${{ job.target }}
 
-# - ${{ if parameters.triggerDownstreamJobs }}:
-#   - ${{ each component in parameters.downstreamComponentMatrix }}:
-#     - ${{ if not(and(parameters.unifiedBuild, eq(component.skipUnifiedBuild, 'true'))) }}:
-#       - template: /.azuredevops/components/${{ component.name }}.yml@pipelines_repo
-#         parameters:
-#           checkoutRepo: ${{ parameters.checkoutRepo }}
-#           sparseCheckoutDir: ${{ component.sparseCheckoutDir }}
-#           triggerDownstreamJobs: true
-#           unifiedBuild: ${{ parameters.unifiedBuild }}
-#           ${{ if parameters.unifiedBuild }}:
-#             buildDependsOn: ${{ component.unifiedBuild.buildDependsOn }}
-#             downstreamAggregateNames: ${{ parameters.downstreamAggregateNames }}+${{ component.unifiedBuild.downstreamAggregateNames }}
-#           ${{ else }}:
-#             buildDependsOn: ${{ component.buildDependsOn }}
-#             downstreamAggregateNames: ${{ parameters.downstreamAggregateNames }}+${{ parameters.componentName }}
+- ${{ if parameters.triggerDownstreamJobs }}:
+  - ${{ each component in parameters.downstreamComponentMatrix }}:
+    - ${{ if not(and(parameters.unifiedBuild, eq(component.skipUnifiedBuild, 'true'))) }}:
+      - template: /.azuredevops/components/${{ component.name }}.yml@pipelines_repo
+        parameters:
+          checkoutRepo: ${{ parameters.checkoutRepo }}
+          sparseCheckoutDir: ${{ component.sparseCheckoutDir }}
+          triggerDownstreamJobs: true
+          unifiedBuild: ${{ parameters.unifiedBuild }}
+          ${{ if parameters.unifiedBuild }}:
+            buildDependsOn: ${{ component.unifiedBuild.buildDependsOn }}
+            downstreamAggregateNames: ${{ parameters.downstreamAggregateNames }}+${{ component.unifiedBuild.downstreamAggregateNames }}
+          ${{ else }}:
+            buildDependsOn: ${{ component.buildDependsOn }}
+            downstreamAggregateNames: ${{ parameters.downstreamAggregateNames }}+${{ parameters.componentName }}

--- a/.azuredevops/components/rocRAND.yml
+++ b/.azuredevops/components/rocRAND.yml
@@ -79,6 +79,12 @@ parameters:
       skipUnifiedBuild: 'false'
       buildDependsOn:
         - rocRAND_build
+    - MIOpen:
+      name: MIOpen
+      sparseCheckoutDir: projects/miopen
+      skipUnifiedBuild: 'true'
+      buildDependsOn:
+        - rocRAND_build
 
 jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:

--- a/.azuredevops/templates/steps/miopen-get-ck-build.yml
+++ b/.azuredevops/templates/steps/miopen-get-ck-build.yml
@@ -13,7 +13,7 @@ steps:
     CC: $(Agent.BuildDirectory)/rocm/llvm/bin/amdclang
   inputs:
     targetType: inline
-    workingDirectory: $(Build.SourcesDirectory)
+    workingDirectory: $(Agent.BuildDirectory)/s
     script: |
       AZ_API="https://dev.azure.com/ROCm-CI/ROCm-CI/_apis"
       GH_API="https://api.github.com/repos/ROCm"

--- a/.azuredevops/templates/steps/miopen-get-ck-build.yml
+++ b/.azuredevops/templates/steps/miopen-get-ck-build.yml
@@ -15,6 +15,8 @@ steps:
     targetType: inline
     workingDirectory: $(Agent.BuildDirectory)/s
     script: |
+      set -e
+
       AZ_API="https://dev.azure.com/ROCm-CI/ROCm-CI/_apis"
       GH_API="https://api.github.com/repos/ROCm"
       EXIT_CODE=0


### PR DESCRIPTION
For https://github.com/ROCm/rocm-libraries/pull/864

- Enables monorepo builds for MIOpen.
- Excludes the `GPU_Conv2dTuningAsmBwdWrw_FP32` MIOpen test for being flaky on gfx90a.
- Fixed MIOpen CK fetch script to use the correct dir, and also to exit on command errors with `set -e`
- Modifies MIVisionX and AMDMIGraphX pipeline to allow being triggered by MIOpen (or any other monorepo pipeline)
  - These two components will continue to use their standalone repositories
- Adds AOMP as a test dependency for MIVisionX to resolve `vx_rpp_test` failure.

Enables downstream paths:
rocRAND -> MIOpen
hipBLAS -> MIOpen
MIOpen -> MIVisionX
MIOpen -> AMDMIGraphX

Sample runs:
MIOpen: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=40984&view=results
rocRAND: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=40735&view=results
hipBLAS: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=40732&view=results