### PR TITLE
[Ex CI] rocprof-systems: add libsqlite3-dev

### DIFF
--- a/.azuredevops/components/rocprofiler-systems.yml
+++ b/.azuredevops/components/rocprofiler-systems.yml
@@ -37,6 +37,7 @@ parameters:
     - libpfm4-dev
     - libtool
     - libopenmpi-dev
+    - libsqlite3-dev
     - m4
     - ninja-build
     - openmpi-bin


### PR DESCRIPTION
Fixes rocprofiler-systems builds following https://github.com/ROCm/rocprofiler-systems/commit/26ae543012c4ef876bc40e306f0a11916736e64b

Sample build:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=41257&view=results