### PR TITLE
[Ex CI] MIOpen: use latest CK

### DIFF
--- a/.azuredevops/components/MIOpen.yml
+++ b/.azuredevops/components/MIOpen.yml
@@ -50,6 +50,7 @@ parameters:
 - name: rocmDependencies
   type: object
   default:
+    - composable_kernel
     - half
     - rocRAND
     - rocBLAS
@@ -67,6 +68,7 @@ parameters:
   type: object
   default:
     - clr
+    - composable_kernel
     - half
     - hipBLAS
     - hipBLAS-common
@@ -136,9 +138,6 @@ jobs:
       parameters:
         checkoutRepo: ${{ parameters.checkoutRepo }}
         sparseCheckoutDir: ${{ parameters.sparseCheckoutDir }}
-    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/miopen-get-ck-build.yml
-      parameters:
-        gpuTarget: ${{ job.target }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
       parameters:
         checkoutRef: ${{ parameters.checkoutRef }}
@@ -216,9 +215,6 @@ jobs:
         checkoutRepo: ${{ parameters.checkoutRepo }}
         sparseCheckoutDir: ${{ parameters.sparseCheckoutDir }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-aqlprofile.yml
-    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/miopen-get-ck-build.yml
-      parameters:
-        gpuTarget: ${{ job.target }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
       parameters:
         checkoutRef: ${{ parameters.checkoutRef }}


### PR DESCRIPTION
Change the MIOpen pipeline to pull latest CK instead of using the specific CK commit called out in MIOpen's requirements.txt.

Sample run:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=41431&view=results