### PR TITLE
[Ex CI] disable rocSPARSE to hipSOLVER downstream path

### DIFF
--- a/.azuredevops/components/rocSPARSE.yml
+++ b/.azuredevops/components/rocSPARSE.yml
@@ -88,12 +88,12 @@ parameters:
         - rocSPARSE_build
     # hipSOLVER depends on both rocSOLVER and rocSPARSE
     # for a unified build, rocSOLVER will be the one to call hipSOLVER
-    - hipSOLVER:
-      name: hipSOLVER
-      sparseCheckoutDir: projects/hipsolver
-      skipUnifiedBuild: 'true'
-      buildDependsOn:
-        - rocSPARSE_build
+    # - hipSOLVER:
+    #   name: hipSOLVER
+    #   sparseCheckoutDir: projects/hipsolver
+    #   skipUnifiedBuild: 'true'
+    #   buildDependsOn:
+    #     - rocSPARSE_build
 
 jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:


### PR DESCRIPTION
hipSOLVER is being triggered by rocSPARSE and rocSOLVER, which is causing duplicate jobs names and preventing pipelines from starting. Disable the rocSPARSE trigger temporarily until we fix the trigger logic.