### PR TITLE
Update README.md removing reference to instructions that were moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,6 @@ source software compilers, debuggers, and libraries. ROCm is fully integrated in
 > A new open source build platform for ROCm is under development at
 > https://github.com/ROCm/TheRock, featuring a unified CMake build with bundled
 > dependencies, Windows support, and more.
->
-> The instructions below describe the prior process for building from source
-> which will be replaced once TheRock is mature enough.
 
 ## Getting and Building ROCm from Source
 


### PR DESCRIPTION
Followup to the change in https://github.com/ROCm/ROCm/pull/4907/files - the instructions are no longer below.

(Could also move the previous paragraph into this section.)