### PR TITLE
[External CI] Disable downstream solver builds

### DIFF
--- a/.azuredevops/components/rocBLAS.yml
+++ b/.azuredevops/components/rocBLAS.yml
@@ -104,17 +104,17 @@ parameters:
         - rocBLAS_build
     # rocSOLVER depends on both rocBLAS and rocPRIM
     # for a unified build, rocBLAS will be the one to call rocSOLVER
-    - rocSOLVER:
-      name: rocSOLVER
-      sparseCheckoutDir: projects/rocsolver
-      skipUnifiedBuild: 'false'
-      buildDependsOn:
-        - rocBLAS_build
-      unifiedBuild:
-        downstreamAggregateNames: rocBLAS+rocPRIM
-        buildDependsOn:
-          - rocBLAS_build
-          - rocPRIM_build
+#    - rocSOLVER:
+#      name: rocSOLVER
+#      sparseCheckoutDir: projects/rocsolver
+#      skipUnifiedBuild: 'false'
+#      buildDependsOn:
+#        - rocBLAS_build
+#      unifiedBuild:
+#        downstreamAggregateNames: rocBLAS+rocPRIM
+#        buildDependsOn:
+#          - rocBLAS_build
+#          - rocPRIM_build
 
 jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:

--- a/.azuredevops/components/rocPRIM.yml
+++ b/.azuredevops/components/rocPRIM.yml
@@ -91,12 +91,12 @@ parameters:
         - rocPRIM_build
     # rocSOLVER depends on both rocBLAS and rocPRIM
     # for a unified build, rocBLAS will be the one to call rocSOLVER
-    - rocSOLVER:
-      name: rocSOLVER
-      sparseCheckoutDir: projects/rocsolver
-      skipUnifiedBuild: 'true'
-      buildDependsOn:
-        - rocPRIM_build
+#    - rocSOLVER:
+#      name: rocSOLVER
+#      sparseCheckoutDir: projects/rocsolver
+#      skipUnifiedBuild: 'true'
+#      buildDependsOn:
+#        - rocPRIM_build
 
 jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:

--- a/.azuredevops/components/rocSOLVER.yml
+++ b/.azuredevops/components/rocSOLVER.yml
@@ -94,17 +94,17 @@ parameters:
         - rocSOLVER_build
     # hipSOLVER depends on both rocSOLVER and rocSPARSE
     # for a unified build, rocSOLVER will be the one to call hipSOLVER
-    - hipSOLVER:
-      name: hipSOLVER
-      sparseCheckoutDir: projects/hipsolver
-      skipUnifiedBuild: 'false'
-      buildDependsOn:
-        - rocSOLVER_build
-      unifiedBuild:
-        downstreamAggregateNames: rocSOLVER+rocSPARSE
-        buildDependsOn:
-          - rocSOLVER_build
-          - rocSPARSE_build
+#    - hipSOLVER:
+#      name: hipSOLVER
+#      sparseCheckoutDir: projects/hipsolver
+#      skipUnifiedBuild: 'false'
+#      buildDependsOn:
+#        - rocSOLVER_build
+#      unifiedBuild:
+#        downstreamAggregateNames: rocSOLVER+rocSPARSE
+#        buildDependsOn:
+#          - rocSOLVER_build
+#          - rocSPARSE_build
 
 jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:


### PR DESCRIPTION
- Disable while migration to monorepo is postponed.