### PR TITLE
[Ex CI] update rocprofiler-register pipeline ID to monorepo

### DIFF
--- a/.azuredevops/templates/steps/dependencies-rocm.yml
+++ b/.azuredevops/templates/steps/dependencies-rocm.yml
@@ -211,7 +211,7 @@ parameters:
       developBranch: develop
       hasGpuTarget: true
     rocprofiler-register:
-      pipelineId: 1
+      pipelineId: 327
       developBranch: amd-staging
       hasGpuTarget: false
     rocprofiler-sdk:


### PR DESCRIPTION
Change rocprofiler-register's source of truth to the monorepo pipeline.

https://dev.azure.com/ROCm-CI/ROCm-CI/_build?definitionId=327&_a=summary