### PR TITLE
[Ex CI] retry MIOpen CK download if unzip fails

### DIFF
--- a/.azuredevops/templates/steps/miopen-get-ck-build.yml
+++ b/.azuredevops/templates/steps/miopen-get-ck-build.yml
@@ -69,20 +69,29 @@ steps:
 
       RETRIES=0
       MAX_RETRIES=5
-      until wget -nv $ARTIFACT_URL -O $(System.ArtifactsDirectory)/ck.zip; do
-        RETRIES=$((RETRIES+1))
-        if [[ $RETRIES -ge $MAX_RETRIES ]]; then
-          echo "Failed to download CK artifact after $MAX_RETRIES attempts."
-          exit 1
+      SUCCESS=false
+      while [ $RETRIES -lt $MAX_RETRIES ]; do
+        wget -nv $ARTIFACT_URL -O $(System.ArtifactsDirectory)/ck.zip && \
+          unzip $(System.ArtifactsDirectory)/ck.zip -d $(System.ArtifactsDirectory) && \
+          mkdir -p $(Agent.BuildDirectory)/rocm && \
+          tar -zxvf $(System.ArtifactsDirectory)/composable_kernel*/*.tar.gz -C $(Agent.BuildDirectory)/rocm && \
+          rm -r $(System.ArtifactsDirectory)/ck.zip $(System.ArtifactsDirectory)/composable_kernel*
+
+        if [ $? -eq 0 ]; then
+          SUCCESS=true
+          echo "Successfully downloaded CK."
+          break
+        else
+          RETRIES=$((RETRIES + 1))
+          echo "Failed to download CK on attempt $RETRIES/$MAX_RETRIES, retrying..."
+          sleep 1
         fi
-        echo "Download failed, retrying ($RETRIES/$MAX_RETRIES)..."
-        sleep 5
       done
 
-      unzip $(System.ArtifactsDirectory)/ck.zip -d $(System.ArtifactsDirectory)
-      mkdir -p $(Agent.BuildDirectory)/rocm
-      tar -zxvf $(System.ArtifactsDirectory)/composable_kernel*/*.tar.gz -C $(Agent.BuildDirectory)/rocm
-      rm -r $(System.ArtifactsDirectory)/ck.zip $(System.ArtifactsDirectory)/composable_kernel*
+      if [ "$SUCCESS" = false ]; then
+        echo "ERROR: failed to download CK after $MAX_RETRIES attempts."
+        exit 1
+      fi
 
       if [[ $EXIT_CODE -ne 0 ]]; then
         BUILD_COMMIT=$(curl -s $AZ_API/build/builds/$CK_BUILD_ID | jq '.sourceVersion' | tr -d '"')


### PR DESCRIPTION
Change the MIOpen CK download script's retry logic to encompass the entire download+extract+cleanup process, to ensure a proper installation of CK.

Previously, it was possible for the wget command to not report an error but have the zip file be malformed, which caused errors when unzipping the file. Since the unzip commands were not covered by the retry logic, it would continue on with the build as if it was fine, when in reality CK was not downloaded and installed properly.

This manifests during MIOpen builds with errors such as
```
CMake Error at src/CMakeLists.txt:829 (add_library):
  Target "MIOpen" links to target "composable_kernel::device_conv_operations"
  but the target was not found.  Perhaps a find_package() call is missing for
  an IMPORTED target, or an ALIAS target is missing?
```

Sample run:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=42905&view=results

Tested locally with this helper function to simulate flaky downloads:
```
flaky_wget() {
  local url=$1
  local output=$2

  # 50/50 chance to have the download fail
  if [ $((RANDOM % 2)) -eq 0 ]; then
    # Simulate failure
    echo "Simulated failure: Unable to download $url"
  else
    # Proceed with actual download
	echo "Success"
    wget -nv "$url" -O "$output"
  fi
}
```