### PR TITLE
[Ex CI] temporarily disable high pool

### DIFF
--- a/.azuredevops/components/MIOpen.yml
+++ b/.azuredevops/components/MIOpen.yml
@@ -123,7 +123,7 @@ jobs:
     - template: /.azuredevops/variables-global.yml
     - name: ROCM_PATH
       value: $(Agent.BuildDirectory)/rocm
-    pool: ${{ variables.HIGH_BUILD_POOL }}
+    pool: ${{ variables.MEDIUM_BUILD_POOL }}
     workspace:
       clean: all
     steps:

--- a/.azuredevops/components/llvm-project.yml
+++ b/.azuredevops/components/llvm-project.yml
@@ -30,7 +30,7 @@ parameters:
   default:
     buildJobs:
       - { os: ubuntu2204, packageManager: apt }
-      - { os: ubuntu2404, packageManager: apt }
+      # - { os: ubuntu2404, packageManager: apt }
       - { os: almalinux8, packageManager: dnf }
 
 jobs:
@@ -38,7 +38,7 @@ jobs:
   - job: llvm_project_${{ job.os }}
     pool:
       ${{ if eq(job.os, 'ubuntu2404') }}:
-        name: 'rocm-ci_medium_build_pool_2404' #temporarily using 'high' pool while 'ultra' is down
+        name: 'rocm-ci_high_build_pool_2404' #temporarily using 'high' pool while 'ultra' is down
       ${{ else }}:
         name: 'rocm-ci_ultra_build_pool'
     ${{ if eq(job.os, 'almalinux8') }}:

--- a/.azuredevops/components/llvm-project.yml
+++ b/.azuredevops/components/llvm-project.yml
@@ -38,7 +38,7 @@ jobs:
   - job: llvm_project_${{ job.os }}
     pool:
       ${{ if eq(job.os, 'ubuntu2404') }}:
-        name: 'rocm-ci_high_build_pool_2404' #temporarily using 'high' pool while 'ultra' is down
+        name: 'rocm-ci_ultra_build_pool_2404' #temporarily using 'high' pool while 'ultra' is down
       ${{ else }}:
         name: 'rocm-ci_ultra_build_pool'
     ${{ if eq(job.os, 'almalinux8') }}:

--- a/.azuredevops/components/llvm-project.yml
+++ b/.azuredevops/components/llvm-project.yml
@@ -38,7 +38,7 @@ jobs:
   - job: llvm_project_${{ job.os }}
     pool:
       ${{ if eq(job.os, 'ubuntu2404') }}:
-        name: 'rocm-ci_ultra_build_pool_2404' #temporarily using 'high' pool while 'ultra' is down
+        name: 'rocm-ci_medium_build_pool_2404' #temporarily using 'high' pool while 'ultra' is down
       ${{ else }}:
         name: 'rocm-ci_ultra_build_pool'
     ${{ if eq(job.os, 'almalinux8') }}:

--- a/.azuredevops/components/rccl.yml
+++ b/.azuredevops/components/rccl.yml
@@ -76,7 +76,7 @@ jobs:
     - template: /.azuredevops/variables-global.yml
     - name: HIP_ROCCLR_HOME
       value: $(Build.BinariesDirectory)/rocm
-    pool: ${{ variables.HIGH_BUILD_POOL }}
+    pool: ${{ variables.MEDIUM_BUILD_POOL }}
     workspace:
       clean: all
     steps:

--- a/.azuredevops/components/rocWMMA.yml
+++ b/.azuredevops/components/rocWMMA.yml
@@ -70,7 +70,7 @@ jobs:
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
-    pool: ${{ variables.HIGH_BUILD_POOL }}
+    pool: ${{ variables.MEDIUM_BUILD_POOL }}
     workspace:
       clean: all
     steps:


### PR DESCRIPTION
The high pool is unable to spin up any runners, so switch components that use it to the medium pool temporarily.