### PR TITLE
[Ex CI] add retries to potentially flaky steps

### DIFF
--- a/.azuredevops/components/MIOpen.yml
+++ b/.azuredevops/components/MIOpen.yml
@@ -149,6 +149,7 @@ jobs:
           downstreamAggregateNames: ${{ parameters.downstreamAggregateNames }}
     - task: Bash@3
       displayName: Build and install other dependencies
+      retryCountOnTaskFailure: 3
       inputs:
         targetType: inline
         workingDirectory: $(Agent.BuildDirectory)/s

--- a/.azuredevops/components/MIOpen.yml
+++ b/.azuredevops/components/MIOpen.yml
@@ -229,6 +229,7 @@ jobs:
           downstreamAggregateNames: ${{ parameters.downstreamAggregateNames }}
     - task: Bash@3
       displayName: Build and install other dependencies
+      retryCountOnTaskFailure: 3
       inputs:
         targetType: inline
         workingDirectory: $(Agent.BuildDirectory)/s

--- a/.azuredevops/components/Tensile.yml
+++ b/.azuredevops/components/Tensile.yml
@@ -171,7 +171,6 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
     - task: DownloadPipelineArtifact@2
       displayName: 'Download Pipeline Wheel Files'
-      timeoutInMinutes: 3
       retryCountOnTaskFailure: 3
       inputs:
         itemPattern: '**/*${{ job.os }}*.whl'

--- a/.azuredevops/components/Tensile.yml
+++ b/.azuredevops/components/Tensile.yml
@@ -171,6 +171,8 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
     - task: DownloadPipelineArtifact@2
       displayName: 'Download Pipeline Wheel Files'
+      timeoutInMinutes: 3
+      retryCountOnTaskFailure: 3
       inputs:
         itemPattern: '**/*${{ job.os }}*.whl'
         targetPath: $(Agent.BuildDirectory)

--- a/.azuredevops/components/rocPyDecode.yml
+++ b/.azuredevops/components/rocPyDecode.yml
@@ -190,6 +190,8 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
     - task: DownloadPipelineArtifact@2
       displayName: 'Download Pipeline Wheel Files'
+      timeoutInMinutes: 3
+      retryCountOnTaskFailure: 3
       inputs:
         itemPattern: '**/*.whl'
         targetPath: $(Agent.BuildDirectory)

--- a/.azuredevops/components/rocPyDecode.yml
+++ b/.azuredevops/components/rocPyDecode.yml
@@ -190,7 +190,6 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
     - task: DownloadPipelineArtifact@2
       displayName: 'Download Pipeline Wheel Files'
-      timeoutInMinutes: 3
       retryCountOnTaskFailure: 3
       inputs:
         itemPattern: '**/*.whl'

--- a/.azuredevops/components/rocprofiler.yml
+++ b/.azuredevops/components/rocprofiler.yml
@@ -115,6 +115,7 @@ jobs:
         extraBuildFlags: >-
           -DCMAKE_MODULE_PATH=$(Build.SourcesDirectory)/cmake_modules;$(Agent.BuildDirectory)/rocm/lib/cmake;$(Agent.BuildDirectory)/rocm/lib/cmake/hip;$(Agent.BuildDirectory)/rocm/lib64/cmake;$(Agent.BuildDirectory)/rocm/lib64/cmake/hip
           -DCMAKE_PREFIX_PATH="$(Agent.BuildDirectory)/rocm;$(Agent.BuildDirectory)/vendor"
+          -DROCM_PATH=$(Agent.BuildDirectory)/rocm
           -DCMAKE_POSITION_INDEPENDENT_CODE=ON
           -DENABLE_LDCONFIG=OFF
           -DUSE_PROF_API=1

--- a/.azuredevops/nightly/pytorch.yml
+++ b/.azuredevops/nightly/pytorch.yml
@@ -397,7 +397,6 @@ jobs:
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
   - task: DownloadPipelineArtifact@2
     displayName: 'Download Pipeline Wheel Files'
-    timeoutInMinutes: 3
     retryCountOnTaskFailure: 3
     inputs:
       itemPattern: '**/*.whl'

--- a/.azuredevops/nightly/pytorch.yml
+++ b/.azuredevops/nightly/pytorch.yml
@@ -397,6 +397,8 @@ jobs:
   - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
   - task: DownloadPipelineArtifact@2
     displayName: 'Download Pipeline Wheel Files'
+    timeoutInMinutes: 3
+    retryCountOnTaskFailure: 3
     inputs:
       itemPattern: '**/*.whl'
       targetPath: $(Agent.BuildDirectory)

--- a/.azuredevops/nightly/rocm-nightly.yml
+++ b/.azuredevops/nightly/rocm-nightly.yml
@@ -93,7 +93,7 @@ schedules:
 jobs:
 - ${{ each job in parameters.jobList }}:
   - job: nightly_${{ job.os }}_${{ job.target }}
-    timeoutInMinutes: 90
+    timeoutInMinutes: 120
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
@@ -226,6 +226,7 @@ jobs:
             cat Dockerfile
     - task: Docker@2
       displayName: Build and upload Docker image
+      retryCountOnTaskFailure: 3
       inputs:
         containerRegistry: ContainerService3
         repository: 'nightly-${{ job.os }}-${{ job.target }}'

--- a/.azuredevops/templates/steps/artifact-download.yml
+++ b/.azuredevops/templates/steps/artifact-download.yml
@@ -24,7 +24,6 @@ parameters:
 steps:
 - task: DownloadPipelineArtifact@2
   displayName: Download ${{ parameters.componentName }}
-  timeoutInMinutes: 3
   retryCountOnTaskFailure: 3
   inputs:
     itemPattern: '**/*${{ parameters.componentName }}*${{ parameters.fileFilter }}*'

--- a/.azuredevops/templates/steps/artifact-download.yml
+++ b/.azuredevops/templates/steps/artifact-download.yml
@@ -24,6 +24,8 @@ parameters:
 steps:
 - task: DownloadPipelineArtifact@2
   displayName: Download ${{ parameters.componentName }}
+  timeoutInMinutes: 3
+  retryCountOnTaskFailure: 3
   inputs:
     itemPattern: '**/*${{ parameters.componentName }}*${{ parameters.fileFilter }}*'
     targetPath: '$(Pipeline.Workspace)/d'

--- a/.azuredevops/templates/steps/checkout.yml
+++ b/.azuredevops/templates/steps/checkout.yml
@@ -17,6 +17,7 @@ steps:
   - checkout: ${{ parameters.checkoutRepo }}
     clean: true
     submodules: ${{ parameters.submoduleBehaviour }}
+    timeoutInMinutes: 10
     retryCountOnTaskFailure: 3
     fetchFilter: blob:none
     ${{ if ne(parameters.sparseCheckoutDir, '') }}:

--- a/.azuredevops/templates/steps/checkout.yml
+++ b/.azuredevops/templates/steps/checkout.yml
@@ -17,7 +17,6 @@ steps:
   - checkout: ${{ parameters.checkoutRepo }}
     clean: true
     submodules: ${{ parameters.submoduleBehaviour }}
-    timeoutInMinutes: 10
     retryCountOnTaskFailure: 3
     fetchFilter: blob:none
     ${{ if ne(parameters.sparseCheckoutDir, '') }}:

--- a/.azuredevops/templates/steps/dependencies-apt.yml
+++ b/.azuredevops/templates/steps/dependencies-apt.yml
@@ -10,7 +10,6 @@ steps:
 - ${{ if eq(parameters.registerROCmPackages, true) }}:
   - task: Bash@3
     displayName: 'Register AMDGPU & ROCm repos (apt)'
-    timeoutInMinutes: 3
     retryCountOnTaskFailure: 3
     inputs:
       targetType: inline
@@ -23,7 +22,6 @@ steps:
         sudo apt update
 - task: Bash@3
   displayName: 'APT update and install packages'
-  timeoutInMinutes: 10
   retryCountOnTaskFailure: 3
   inputs:
     targetType: inline

--- a/.azuredevops/templates/steps/dependencies-apt.yml
+++ b/.azuredevops/templates/steps/dependencies-apt.yml
@@ -10,6 +10,8 @@ steps:
 - ${{ if eq(parameters.registerROCmPackages, true) }}:
   - task: Bash@3
     displayName: 'Register AMDGPU & ROCm repos (apt)'
+    timeoutInMinutes: 3
+    retryCountOnTaskFailure: 3
     inputs:
       targetType: inline
       script: |
@@ -20,7 +22,9 @@ steps:
         echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | sudo tee /etc/apt/preferences.d/rocm-pin-600
         sudo apt update
 - task: Bash@3
-  displayName: 'sudo apt-get update'
+  displayName: 'APT update and install packages'
+  timeoutInMinutes: 10
+  retryCountOnTaskFailure: 3
   inputs:
     targetType: inline
     script: |
@@ -28,15 +32,6 @@ steps:
       echo "deb http://archive.ubuntu.com/ubuntu/ jammy-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/default.list
       echo "deb http://archive.ubuntu.com/ubuntu/ jammy-backports main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/default.list
       echo "deb http://archive.ubuntu.com/ubuntu/ jammy-security main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/default.list
-      sudo DEBIAN_FRONTEND=noninteractive apt-get --yes update
-- task: Bash@3
-  displayName: 'sudo apt-get fix'
-  inputs:
-    targetType: inline
-    script: sudo DEBIAN_FRONTEND=noninteractive apt-get --yes --fix-broken install
-- ${{ if gt(length(parameters.aptPackages), 0) }}:
-  - task: Bash@3
-    displayName: 'sudo apt-get install ...'
-    inputs:
-      targetType: inline
-      script: sudo DEBIAN_FRONTEND=noninteractive apt-get --yes --fix-missing install ${{ join(' ', parameters.aptPackages) }}
+      sudo DEBIAN_FRONTEND=noninteractive apt-get --yes update && \
+        sudo DEBIAN_FRONTEND=noninteractive apt-get --yes --fix-broken install && \
+        sudo DEBIAN_FRONTEND=noninteractive apt-get --yes --fix-missing install ${{ join(' ', parameters.aptPackages) }}

--- a/.azuredevops/templates/steps/dependencies-aqlprofile.yml
+++ b/.azuredevops/templates/steps/dependencies-aqlprofile.yml
@@ -14,15 +14,15 @@ steps:
       set -e
       if [ "${{ parameters.os }}" = "ubuntu2204" ]; then
         packageName=$(curl -s https://repo.radeon.com/rocm/apt/$(REPO_RADEON_VERSION)/pool/main/h/hsa-amd-aqlprofile/ | grep -oP "href=\"\K[^\"]*$(lsb_release -rs)[^\"]*\.deb") && \
-          wget -nv https://repo.radeon.com/rocm/apt/$(REPO_RADEON_VERSION)/pool/main/h/hsa-amd-aqlprofile/$packageName && \
-          mkdir -p hsa-amd-aqlprofile && \
-          dpkg-deb -R $packageName hsa-amd-aqlprofile
+        wget -nv https://repo.radeon.com/rocm/apt/$(REPO_RADEON_VERSION)/pool/main/h/hsa-amd-aqlprofile/$packageName && \
+        mkdir -p hsa-amd-aqlprofile && \
+        dpkg-deb -R $packageName hsa-amd-aqlprofile
       elif [ "${{ parameters.os }}" = "almalinux8" ]; then
         sudo dnf -y install rpm-build cpio && \
-          packageName=$(curl -s https://repo.radeon.com/rocm/rhel8/$(REPO_RADEON_VERSION)/main/ | grep -oP "hsa-amd-aqlprofile-[^\"]+\.rpm" | head -n1) && \
-          wget -nv https://repo.radeon.com/rocm/rhel8/$(REPO_RADEON_VERSION)/main/$packageName && \
-          mkdir -p hsa-amd-aqlprofile && \
-          rpm2cpio $packageName | (cd hsa-amd-aqlprofile && cpio -idmv)
+        packageName=$(curl -s https://repo.radeon.com/rocm/rhel8/$(REPO_RADEON_VERSION)/main/ | grep -oP "hsa-amd-aqlprofile-[^\"]+\.rpm" | head -n1) && \
+        wget -nv https://repo.radeon.com/rocm/rhel8/$(REPO_RADEON_VERSION)/main/$packageName && \
+        mkdir -p hsa-amd-aqlprofile && \
+        rpm2cpio $packageName | (cd hsa-amd-aqlprofile && cpio -idmv)
       else
         echo "Unsupported OS: ${{ parameters.os }}"
         exit 1

--- a/.azuredevops/templates/steps/dependencies-aqlprofile.yml
+++ b/.azuredevops/templates/steps/dependencies-aqlprofile.yml
@@ -6,7 +6,6 @@ parameters:
 steps:
 - task: Bash@3
   displayName: Download and install aqlprofile
-  timeoutInMinutes: 3
   retryCountOnTaskFailure: 3
   inputs:
     targetType: inline

--- a/.azuredevops/templates/steps/dependencies-aqlprofile.yml
+++ b/.azuredevops/templates/steps/dependencies-aqlprofile.yml
@@ -5,51 +5,29 @@ parameters:
 
 steps:
 - task: Bash@3
-  displayName: Get aqlprofile package name
+  displayName: Download and install aqlprofile
+  timeoutInMinutes: 3
+  retryCountOnTaskFailure: 3
   inputs:
     targetType: inline
-    ${{ if eq(parameters.os, 'ubuntu2204') }}:
-      script: |
-        export packageName=$(curl -s https://repo.radeon.com/rocm/apt/$(REPO_RADEON_VERSION)/pool/main/h/hsa-amd-aqlprofile/ | grep -oP "href=\"\K[^\"]*$(lsb_release -rs)[^\"]*\.deb")
-        echo "##vso[task.setvariable variable=packageName;isreadonly=true]$packageName"
-    ${{ if eq(parameters.os, 'almalinux8') }}:
-      script: |
-        export packageName=$(curl -s https://repo.radeon.com/rocm/rhel8/$(REPO_RADEON_VERSION)/main/ | grep -oP "hsa-amd-aqlprofile-[^\"]+\.rpm" | head -n1)
-        echo "##vso[task.setvariable variable=packageName;isreadonly=true]$packageName"
-- task: Bash@3
-  displayName: 'Download aqlprofile'
-  inputs:
-    targetType: inline
-    workingDirectory: '$(Pipeline.Workspace)'
-    ${{ if eq(parameters.os, 'ubuntu2204') }}:
-      script: wget -nv https://repo.radeon.com/rocm/apt/$(REPO_RADEON_VERSION)/pool/main/h/hsa-amd-aqlprofile/$(packageName)
-    ${{ if eq(parameters.os, 'almalinux8') }}:
-      script: wget -nv https://repo.radeon.com/rocm/rhel8/$(REPO_RADEON_VERSION)/main/$(packageName)
-- task: Bash@3
-  displayName: 'Extract aqlprofile'
-  inputs:
-    targetType: inline
-    workingDirectory: '$(Pipeline.Workspace)'
-    ${{ if eq(parameters.os, 'ubuntu2204') }}:
-      script: |
-        mkdir hsa-amd-aqlprofile
-        dpkg-deb -R $(packageName) hsa-amd-aqlprofile
-    ${{ if eq(parameters.os, 'almalinux8') }}:
-      script: |
-        mkdir hsa-amd-aqlprofile
-        sudo dnf -y install rpm-build cpio
-        rpm2cpio $(packageName) | (cd hsa-amd-aqlprofile && cpio -idmv)
-- task: Bash@3
-  displayName: 'Copy aqlprofile files'
-  inputs:
-    targetType: inline
+    workingDirectory: $(Agent.BuildDirectory)
     script: |
-      mkdir -p $(Agent.BuildDirectory)/rocm
-      cp -R hsa-amd-aqlprofile/opt/rocm-*/* $(Agent.BuildDirectory)/rocm
-    workingDirectory: '$(Pipeline.Workspace)'
-- task: Bash@3
-  displayName: 'Clean up aqlprofile'
-  inputs:
-    targetType: inline
-    script: rm -rf hsa-amd-aqlprofile $(packageName)
-    workingDirectory: '$(Pipeline.Workspace)'
+      set -e
+      if [ "${{ parameters.os }}" = "ubuntu2204" ]; then
+        packageName=$(curl -s https://repo.radeon.com/rocm/apt/$(REPO_RADEON_VERSION)/pool/main/h/hsa-amd-aqlprofile/ | grep -oP "href=\"\K[^\"]*$(lsb_release -rs)[^\"]*\.deb") && \
+          wget -nv https://repo.radeon.com/rocm/apt/$(REPO_RADEON_VERSION)/pool/main/h/hsa-amd-aqlprofile/$packageName && \
+          mkdir -p hsa-amd-aqlprofile && \
+          dpkg-deb -R $packageName hsa-amd-aqlprofile
+      elif [ "${{ parameters.os }}" = "almalinux8" ]; then
+        sudo dnf -y install rpm-build cpio && \
+          packageName=$(curl -s https://repo.radeon.com/rocm/rhel8/$(REPO_RADEON_VERSION)/main/ | grep -oP "hsa-amd-aqlprofile-[^\"]+\.rpm" | head -n1) && \
+          wget -nv https://repo.radeon.com/rocm/rhel8/$(REPO_RADEON_VERSION)/main/$packageName && \
+          mkdir -p hsa-amd-aqlprofile && \
+          rpm2cpio $packageName | (cd hsa-amd-aqlprofile && cpio -idmv)
+      else
+        echo "Unsupported OS: ${{ parameters.os }}"
+        exit 1
+      fi && \
+      mkdir -p $(Agent.BuildDirectory)/rocm && \
+      cp -R hsa-amd-aqlprofile/opt/rocm-*/* $(Agent.BuildDirectory)/rocm && \
+      rm -rf hsa-amd-aqlprofile $packageName

--- a/.azuredevops/templates/steps/dependencies-dnf.yml
+++ b/.azuredevops/templates/steps/dependencies-dnf.yml
@@ -87,6 +87,8 @@ steps:
 - ${{ if eq(parameters.registerROCmPackages, true) }}:
   - task: Bash@3
     displayName: 'Register AMDGPU & ROCm repos (dnf)'
+    timeoutInMinutes: 3
+    retryCountOnTaskFailure: 3
     inputs:
       targetType: inline
       script: |
@@ -107,6 +109,8 @@ steps:
         sudo dnf makecache
 - task: Bash@3
   displayName: 'Install base dnf packages'
+  timeoutInMinutes: 3
+  retryCountOnTaskFailure: 3
   inputs:
     targetType: inline
     script: |
@@ -126,6 +130,8 @@ steps:
       g++ -print-file-name=libstdc++.so
 - task: Bash@3
   displayName: 'Set python 3.11 as default'
+  timeoutInMinutes: 3
+  retryCountOnTaskFailure: 3
   inputs:
     targetType: inline
     script: |
@@ -140,6 +146,8 @@ steps:
   - ${{ if eq(pkg, 'ninja-build') }}:
     - task: Bash@3
       displayName: 'Install ninja 1.11.1'
+      timeoutInMinutes: 3
+      retryCountOnTaskFailure: 3
       inputs:
         targetType: inline
         script: |
@@ -152,6 +160,8 @@ steps:
   - ${{ if ne(parameters.aptToDnfMap[pkg], '') }}:
     - task: Bash@3
       displayName: 'dnf install ${{ parameters.aptToDnfMap[pkg] }}'
+      timeoutInMinutes: 3
+      retryCountOnTaskFailure: 3
       inputs:
         targetType: inline
         script: |

--- a/.azuredevops/templates/steps/dependencies-dnf.yml
+++ b/.azuredevops/templates/steps/dependencies-dnf.yml
@@ -87,7 +87,6 @@ steps:
 - ${{ if eq(parameters.registerROCmPackages, true) }}:
   - task: Bash@3
     displayName: 'Register AMDGPU & ROCm repos (dnf)'
-    timeoutInMinutes: 3
     retryCountOnTaskFailure: 3
     inputs:
       targetType: inline
@@ -109,7 +108,6 @@ steps:
         sudo dnf makecache
 - task: Bash@3
   displayName: 'Install base dnf packages'
-  timeoutInMinutes: 3
   retryCountOnTaskFailure: 3
   inputs:
     targetType: inline
@@ -130,7 +128,6 @@ steps:
       g++ -print-file-name=libstdc++.so
 - task: Bash@3
   displayName: 'Set python 3.11 as default'
-  timeoutInMinutes: 3
   retryCountOnTaskFailure: 3
   inputs:
     targetType: inline
@@ -146,7 +143,6 @@ steps:
   - ${{ if eq(pkg, 'ninja-build') }}:
     - task: Bash@3
       displayName: 'Install ninja 1.11.1'
-      timeoutInMinutes: 3
       retryCountOnTaskFailure: 3
       inputs:
         targetType: inline
@@ -160,7 +156,6 @@ steps:
   - ${{ if ne(parameters.aptToDnfMap[pkg], '') }}:
     - task: Bash@3
       displayName: 'dnf install ${{ parameters.aptToDnfMap[pkg] }}'
-      timeoutInMinutes: 3
       retryCountOnTaskFailure: 3
       inputs:
         targetType: inline

--- a/.azuredevops/templates/steps/dependencies-dnf.yml
+++ b/.azuredevops/templates/steps/dependencies-dnf.yml
@@ -112,9 +112,9 @@ steps:
   inputs:
     targetType: inline
     script: |
-      sudo dnf config-manager --set-enabled powertools
       # rpm fusion free repo for some dependencies
-      sudo dnf -y install https://download1.rpmfusion.org/free/el/rpmfusion-free-release-8.noarch.rpm
+      sudo dnf config-manager --set-enabled powertools && \
+      sudo dnf -y install https://download1.rpmfusion.org/free/el/rpmfusion-free-release-8.noarch.rpm && \
       sudo dnf -y install ${{ join(' ', parameters.basePackages) }}
 - task: Bash@3
   displayName: 'Check gcc environment'
@@ -147,11 +147,11 @@ steps:
       inputs:
         targetType: inline
         script: |
-          curl -LO https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-linux.zip
-          sudo dnf -y install unzip
-          unzip ninja-linux.zip
-          sudo mv ninja /usr/local/bin/ninja
-          sudo chmod +x /usr/local/bin/ninja
+          sudo dnf -y install unzip && \
+          curl -LO https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-linux.zip && \
+          unzip ninja-linux.zip && \
+          sudo mv ninja /usr/local/bin/ninja && \
+          sudo chmod +x /usr/local/bin/ninja && \
           echo "##vso[task.prependpath]/usr/local/bin"
   - ${{ if ne(parameters.aptToDnfMap[pkg], '') }}:
     - task: Bash@3

--- a/.azuredevops/templates/steps/dependencies-other.yml
+++ b/.azuredevops/templates/steps/dependencies-other.yml
@@ -27,6 +27,8 @@ steps:
 - ${{ if gt(length(parameters.pipModules), 0) }}:
   - task: Bash@3
     displayName: 'pip install  ...'
+    timeoutInMinutes: 10
+    retryCountOnTaskFailure: 3
     inputs:
       targetType: inline
       script: python3 -m pip install -v --force-reinstall ${{ join(' ', parameters.pipModules) }}

--- a/.azuredevops/templates/steps/dependencies-other.yml
+++ b/.azuredevops/templates/steps/dependencies-other.yml
@@ -27,7 +27,6 @@ steps:
 - ${{ if gt(length(parameters.pipModules), 0) }}:
   - task: Bash@3
     displayName: 'pip install  ...'
-    timeoutInMinutes: 10
     retryCountOnTaskFailure: 3
     inputs:
       targetType: inline

--- a/.azuredevops/templates/steps/dependencies-vendor.yml
+++ b/.azuredevops/templates/steps/dependencies-vendor.yml
@@ -17,6 +17,8 @@ steps:
 - ${{ each dependency in parameters.dependencyList }}:
   - task: DownloadPipelineArtifact@2
     displayName: Download ${{ dependency }}
+    timeoutInMinutes: 3
+    retryCountOnTaskFailure: 3
     inputs:
       project: ROCm-CI
       buildType: specific

--- a/.azuredevops/templates/steps/dependencies-vendor.yml
+++ b/.azuredevops/templates/steps/dependencies-vendor.yml
@@ -17,7 +17,6 @@ steps:
 - ${{ each dependency in parameters.dependencyList }}:
   - task: DownloadPipelineArtifact@2
     displayName: Download ${{ dependency }}
-    timeoutInMinutes: 3
     retryCountOnTaskFailure: 3
     inputs:
       project: ROCm-CI

--- a/.azuredevops/templates/steps/local-artifact-download.yml
+++ b/.azuredevops/templates/steps/local-artifact-download.yml
@@ -33,7 +33,6 @@ parameters:
 steps:
   - task: DownloadPipelineArtifact@2
     displayName: Download ${{ parameters.preTargetFilter}}*${{ parameters.os }}_${{ parameters.gpuTarget}}*${{ parameters.postTargetFilter}}
-    timeoutInMinutes: 3
     retryCountOnTaskFailure: 3
     inputs:
       ${{ if eq(parameters.buildType, 'specific') }}:

--- a/.azuredevops/templates/steps/local-artifact-download.yml
+++ b/.azuredevops/templates/steps/local-artifact-download.yml
@@ -33,6 +33,8 @@ parameters:
 steps:
   - task: DownloadPipelineArtifact@2
     displayName: Download ${{ parameters.preTargetFilter}}*${{ parameters.os }}_${{ parameters.gpuTarget}}*${{ parameters.postTargetFilter}}
+    timeoutInMinutes: 3
+    retryCountOnTaskFailure: 3
     inputs:
       ${{ if eq(parameters.buildType, 'specific') }}:
         buildType: specific

--- a/.azuredevops/templates/steps/miopen-get-ck-build.yml
+++ b/.azuredevops/templates/steps/miopen-get-ck-build.yml
@@ -7,6 +7,7 @@ steps:
 - task: Bash@3
   name: downloadCKBuild
   displayName: Download specific CK build
+  retryCountOnTaskFailure: 3
   env:
     CXX: $(Agent.BuildDirectory)/rocm/llvm/bin/amdclang++
     CC: $(Agent.BuildDirectory)/rocm/llvm/bin/amdclang

--- a/.azuredevops/templates/steps/miopen-get-ck-build.yml
+++ b/.azuredevops/templates/steps/miopen-get-ck-build.yml
@@ -7,7 +7,6 @@ steps:
 - task: Bash@3
   name: downloadCKBuild
   displayName: Download specific CK build
-  timeoutInMinutes: 5
   retryCountOnTaskFailure: 3
   env:
     CXX: $(Agent.BuildDirectory)/rocm/llvm/bin/amdclang++

--- a/.azuredevops/templates/steps/miopen-get-ck-build.yml
+++ b/.azuredevops/templates/steps/miopen-get-ck-build.yml
@@ -7,6 +7,7 @@ steps:
 - task: Bash@3
   name: downloadCKBuild
   displayName: Download specific CK build
+  timeoutInMinutes: 5
   retryCountOnTaskFailure: 3
   env:
     CXX: $(Agent.BuildDirectory)/rocm/llvm/bin/amdclang++


### PR DESCRIPTION
~Adds time limits and retries to flaky steps, which mostly means steps that download things from the internet. Package installs, artifact downloads, etc.~

Azure does not retry steps if they time out, which makes combining the two options useless. [reference](https://developercommunity.visualstudio.com/t/A-way-to-retry-a-build-pipeline-task-aft/10090126?q=retryCountOnTaskFailure+timeoutInMinutes)
We can settle for adding only retries to flaky steps.

Added 3 retries to:

- All instances of `DownloadPipelineArtifact`
- checkout template
- Consolidated apt update+install steps
- Consolidated aqlprofile download+install steps
- Each dnf install step
- pip install step
- MIOpen's dependency build step
- miopen-get-ck-build script

Also fixed rocprofiler compilation by setting `ROCM_PATH` var.

Sample runs:
MIOpen: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=43563&view=results
rocprofiler (uses aqlprofile): https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=43562&view=results
hipBLAS: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=43561&view=results
rocRAND: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=43631&view=results

The hipBLAS run was fortunate (unfortunate?) enough to run into some download issues, which perfectly demonstrate the retries:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=43561&view=logs&j=1e78615e-d3e9-57a3-9807-690402cdca85&t=b5e9555b-d106-5fff-b40b-b2437cda2cb1&l=36
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=43561&view=logs&j=a4e61d63-4801-5e82-2251-8db993791213&t=72750ec0-3540-5fe3-60d2-8a4a8b687191&l=73