### PR TITLE
[External CI] Full checkout of rocm-libraries for hipsparselt pipeline

### DIFF
--- a/.azuredevops/components/hipSPARSELt.yml
+++ b/.azuredevops/components/hipSPARSELt.yml
@@ -113,7 +113,8 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
       parameters:
         checkoutRepo: ${{ parameters.checkoutRepo }}
-        sparseCheckoutDir: ${{ parameters.sparseCheckoutDir }}
+        # ignore sparse checkout for monorepo case
+        # sparseCheckoutDir: ${{ parameters.sparseCheckoutDir }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
       parameters:
         checkoutRef: ${{ parameters.checkoutRef }}
@@ -155,6 +156,9 @@ jobs:
           -DROCM_PATH=$(Agent.BuildDirectory)/rocm
           -DBUILD_CLIENTS_TESTS=ON
           -GNinja
+        ${{ if ne(parameters.sparseCheckoutDir, '') }}:
+          cmakeSourceDir: $(Build.SourcesDirectory)/projects/hipsparselt
+          cmakeBuildDir: $(Build.SourcesDirectory)/projects/hipsparselt
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
       parameters:
         componentName: ${{ parameters.componentName }}

--- a/.azuredevops/components/hipSPARSELt.yml
+++ b/.azuredevops/components/hipSPARSELt.yml
@@ -131,7 +131,7 @@ jobs:
       displayName: Create temp folder for external dependencies
   # hipSPARSELt already has a CMake script for external deps, so we can just run that
   # https://github.com/ROCm/hipSPARSELt/blob/develop/deps/CMakeLists.txt
-    - script: cmake $(Pipeline.Workspace)/s/deps
+    - script: cmake $(Pipeline.Workspace)/s/projects/hipsparselt/deps
       displayName: Configure hipSPARSELt external dependencies
       workingDirectory: $(Pipeline.Workspace)/deps
     - script: make

--- a/.azuredevops/components/hipSPARSELt.yml
+++ b/.azuredevops/components/hipSPARSELt.yml
@@ -134,7 +134,7 @@ jobs:
     - ${{ if ne(parameters.sparseCheckoutDir, '') }}:
         script: cmake $(Pipeline.Workspace)/s/projects/hipsparselt/deps
       ${{ else }}:
-        script: cmake $(Build.SourcesDirectory)/s/deps
+        script: cmake $(Pipeline.Workspace)/s/deps
       displayName: Configure hipSPARSELt external dependencies
       workingDirectory: $(Pipeline.Workspace)/deps
     - script: make

--- a/.azuredevops/components/hipSPARSELt.yml
+++ b/.azuredevops/components/hipSPARSELt.yml
@@ -113,7 +113,7 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
       parameters:
         checkoutRepo: ${{ parameters.checkoutRepo }}
-        # ignore sparse checkout for monorepo case
+        # ignore sparse checkout for monorepo case, we want access to hipblaslt directory
         # sparseCheckoutDir: ${{ parameters.sparseCheckoutDir }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
       parameters:
@@ -131,7 +131,10 @@ jobs:
       displayName: Create temp folder for external dependencies
   # hipSPARSELt already has a CMake script for external deps, so we can just run that
   # https://github.com/ROCm/hipSPARSELt/blob/develop/deps/CMakeLists.txt
-    - script: cmake $(Pipeline.Workspace)/s/projects/hipsparselt/deps
+    - ${{ if ne(parameters.sparseCheckoutDir, '') }}:
+        script: cmake $(Pipeline.Workspace)/s/projects/hipsparselt/deps
+      ${{ else }}:
+        script: cmake $(Build.SourcesDirectory)/s/deps
       displayName: Configure hipSPARSELt external dependencies
       workingDirectory: $(Pipeline.Workspace)/deps
     - script: make


### PR DESCRIPTION
- To support refactoring of hipsparselt build, do not do sparse checkout for hipsparselt from the super-repo.
- Change paths as needed to point to the hipsparselt project subdirectory, when working with the super-repo.
- [Pipeline Log](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=43380&view=results)