### PR TITLE
[Ex CI] add temporary downstream path from rocBLAS to hipBLAS

### DIFF
--- a/.azuredevops/components/rocBLAS.yml
+++ b/.azuredevops/components/rocBLAS.yml
@@ -115,6 +115,13 @@ parameters:
 #        buildDependsOn:
 #          - rocBLAS_build
 #          - rocPRIM_build
+    # temporary rocblas->hipblas downstream path while the SOLVERs are disabled
+    - hipBLAS:
+      name: hipBLAS
+      sparseCheckoutDir: projects/hipblas
+      skipUnifiedBuild: 'false'
+      buildDependsOn:
+        - rocBLAS_build
 
 jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:


### PR DESCRIPTION
Add in a temporary downstream path from rocBLAS to hipBLAS while the SOLVERs are still disabled, pending their migration.

Sample run for downstream functionality:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=43880&view=results