### PR TITLE
Fix documented VRAM for Radeon AI Pro R9700

### DIFF
--- a/docs/reference/gpu-arch-specs.rst
+++ b/docs/reference/gpu-arch-specs.rst
@@ -285,7 +285,7 @@ For more information about ROCm hardware compatibility, see the ROCm `Compatibil
           - Radeon AI PRO R9700
           - RDNA4
           - gfx1201
-          - 16
+          - 32
           - 64
           - 32 or 64
           - 128


### PR DESCRIPTION
## Motivation

Radeon AI PRO R9700 VRAM is incorrectly listed as 16GiB. It should be 32GiB https://www.amd.com/en/products/graphics/workstations/radeon-ai-pro/ai-9000-series/amd-radeon-ai-pro-r9700.html

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
