### PR TITLE
[Ex CI] switch rocprofiler pipeline ID

### DIFF
--- a/.azuredevops/components/rocprofiler.yml
+++ b/.azuredevops/components/rocprofiler.yml
@@ -187,6 +187,7 @@ jobs:
       workspace:
         clean: all
       steps:
+      - checkout: none
       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
         parameters:
           aptPackages: ${{ parameters.aptPackages }}

--- a/.azuredevops/templates/steps/dependencies-rocm.yml
+++ b/.azuredevops/templates/steps/dependencies-rocm.yml
@@ -203,7 +203,7 @@ parameters:
       developBranch: develop
       hasGpuTarget: true
     rocprofiler:
-      pipelineId: 143
+      pipelineId: 329
       developBranch: amd-staging
       hasGpuTarget: true
     rocprofiler-compute:


### PR DESCRIPTION
## Motivation

Switch rocprofiler pipeline ID to new monorepo pipeline.

https://dev.azure.com/ROCm-CI/ROCm-CI/_build?definitionId=329

Also disables checkout step in rocprofiler test job, it is unnecessary.

## Technical Details

Changed variable value in dependencies-rocm, disabled checkout in rocprofiler test job.

## Test Plan

https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=44858&view=results

## Test Result

Passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
