### PR TITLE
[Ex CI] change rocprofiler's branch to develop

### DIFF
--- a/.azuredevops/templates/steps/dependencies-rocm.yml
+++ b/.azuredevops/templates/steps/dependencies-rocm.yml
@@ -204,7 +204,7 @@ parameters:
       hasGpuTarget: true
     rocprofiler:
       pipelineId: 329
-      developBranch: amd-staging
+      developBranch: develop
       hasGpuTarget: true
     rocprofiler-compute:
       pipelineId: 257


### PR DESCRIPTION
Change rocprofiler's branch name to `develop`, as rocm-systems does not use amd-staging.

This was overlooked because, for rocm-libraries, the mathlibs all already used the `develop` branch, so no change was needed for them. The components under rocm-systems have varying branch names, so it's now necessary to check this. 

Instructions on enabling monorepo support have been updated to reflect this new step.