### PR TITLE
Add Abseil dependency to MIGraphX Azure DevOps CI

### DIFF
--- a/.azuredevops/components/AMDMIGraphX.yml
+++ b/.azuredevops/components/AMDMIGraphX.yml
@@ -38,7 +38,6 @@ parameters:
     - libdrm-dev
     - libmsgpack-dev
     - libnuma-dev
-    - libabsl-dev
     - libprotobuf-dev
     - libsqlite3-dev
     - libtbb-dev
@@ -211,6 +210,21 @@ jobs:
         gpuTarget: ${{ job.target }}
         ${{ if parameters.triggerDownstreamJobs }}:
           downstreamAggregateNames: ${{ parameters.downstreamAggregateNames }}
+    - task: Bash@3
+      displayName: 'git clone protobuf'
+      inputs:
+        targetType: inline
+        script: git clone -b "v30.0" https://github.com/protocolbuffers/protobuf --recurse-submodules
+        workingDirectory: $(Agent.BuildDirectory)
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
+      parameters:
+        cmakeBuildDir: $(Agent.BuildDirectory)/protobuf/build
+        cmakeSourceDir: $(Agent.BuildDirectory)/protobuf
+        extraBuildFlags: >-
+          -DCMAKE_POSITION_INDEPENDENT_CODE=On
+          -Dprotobuf_BUILD_TESTS=Off
+          -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+          -DCMAKE_BUILD_TYPE=Release
     - task: CMake@1
       displayName: MIGraphXTest CMake Flags
       inputs:

--- a/.azuredevops/components/AMDMIGraphX.yml
+++ b/.azuredevops/components/AMDMIGraphX.yml
@@ -38,6 +38,7 @@ parameters:
     - libdrm-dev
     - libmsgpack-dev
     - libnuma-dev
+    - libabsl-dev
     - libprotobuf-dev
     - libsqlite3-dev
     - libtbb-dev


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
There is an [open PR on AMDMIGraphX](https://github.com/ROCm/AMDMIGraphX/pull/4243) to upgrade the protobuf version dependency. The newer version of protobuf requires Abseil to be a dependency as well. In order for the Azure DevOps CI to run successfully with the new dependency, the template yaml file in ROCm needs to also have the dependency.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Adds `libabsl-dev` to the list of apt packages that are dependencies.
