### PR TITLE
[superbuild] Configure pipeline

### DIFF
--- a/.azuredevops/components/rocm-libraries.yml
+++ b/.azuredevops/components/rocm-libraries.yml
@@ -137,6 +137,7 @@ jobs:
           rocm-libraries | ${{ job.os }}
     - script: |
         echo "##vso[task.setvariable variable=PytestCmakePath]$(python3 -m pytest_cmake --cmake-dir)"
+        find / -name "PytestConfig.cmake"
       displayName: Set cmake configure paths
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
       parameters:

--- a/.azuredevops/components/rocm-libraries.yml
+++ b/.azuredevops/components/rocm-libraries.yml
@@ -138,8 +138,13 @@ jobs:
       parameters:
         os: ${{ job.os }}
         extraBuildFlags: >-
-          -DROCM_LIBRARIES_SUPERBUILD=ON
-          -GNinja
+          -D CMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm;$(Agent.BuildDirectory)/vendor
+          -D CMAKE_INCLUDE_PATH=$(Agent.BuildDirectory)/rocm/llvm/include
+          -D CMAKE_CXX_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang++
+          -D CMAKE_C_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang
+          -D CMAKE_CXX_COMPILER_LAUNCHER=ccache
+          -D CMAKE_C_COMPILER_LAUNCHER=ccache
+          -G Ninja
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
       parameters:
         componentName: ${{ parameters.componentName }}

--- a/.azuredevops/components/rocm-libraries.yml
+++ b/.azuredevops/components/rocm-libraries.yml
@@ -135,11 +135,14 @@ jobs:
           rocm-libraries | ${{ job.os }} | ${{ job.target }} | $(DAY_STRING)
           rocm-libraries | ${{ job.os }} | ${{ job.target }}
           rocm-libraries | ${{ job.os }}
+    - script: |
+        echo "##vso[task.setvariable variable=PytestCmakePath]$(python3 -m pytest_cmake --cmake-dir)"
+      displayName: Set cmake configure paths
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
       parameters:
         os: ${{ job.os }}
         extraBuildFlags: >-
-          -D CMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm;$(Agent.BuildDirectory)/vendor;$(python3 -m pytest_cmake --cmake-dir)
+          -D CMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm;$(Agent.BuildDirectory)/vendor;$(PytestCmakePath)
           -D CMAKE_INCLUDE_PATH=$(Agent.BuildDirectory)/rocm/llvm/include
           -D CMAKE_CXX_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang++
           -D CMAKE_C_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang

--- a/.azuredevops/components/rocm-libraries.yml
+++ b/.azuredevops/components/rocm-libraries.yml
@@ -138,6 +138,7 @@ jobs:
           rocm-libraries | ${{ job.os }}
     - script: |
         echo "##vso[task.setvariable variable=PytestCmakePath]/home/AzDevOps/.local/share/Pytest/cmake"
+        find / -name "pytest"
       displayName: Set cmake configure paths
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
       parameters:

--- a/.azuredevops/components/rocm-libraries.yml
+++ b/.azuredevops/components/rocm-libraries.yml
@@ -99,12 +99,12 @@ jobs:
     workspace:
       clean: all
     steps:
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-cmake-latest.yml
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
       parameters:
         aptPackages: ${{ parameters.aptPackages }}
         pipModules: ${{ parameters.pipModules }}
         packageManager: ${{ job.packageManager }}
-    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-cmake-latest.yml
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
       parameters:

--- a/.azuredevops/components/rocm-libraries.yml
+++ b/.azuredevops/components/rocm-libraries.yml
@@ -142,7 +142,7 @@ jobs:
       parameters:
         os: ${{ job.os }}
         extraBuildFlags: >-
-          -D CMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm;$(Agent.BuildDirectory)/vendor;$(PytestCmakePath)
+          -D CMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm;$(Agent.BuildDirectory)/vendor;/home/AzDevOps/.local/bin;$(PytestCmakePath)
           -D CMAKE_INCLUDE_PATH=$(Agent.BuildDirectory)/rocm/llvm/include
           -D CMAKE_CXX_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang++
           -D CMAKE_C_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang

--- a/.azuredevops/components/rocm-libraries.yml
+++ b/.azuredevops/components/rocm-libraries.yml
@@ -138,12 +138,12 @@ jobs:
           rocm-libraries | ${{ job.os }}
     - script: |
         echo "##vso[task.setvariable variable=PytestCmakePath]/home/AzDevOps/.local/share/Pytest/cmake"
-        find / -name "pytest"
       displayName: Set cmake configure paths
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
       parameters:
         os: ${{ job.os }}
         extraBuildFlags: >-
+          -D Pytest_ROOT=/home/AzDevOps/.local/bin
           -D CMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm;$(Agent.BuildDirectory)/vendor;$(PytestCmakePath)
           -D CMAKE_INCLUDE_PATH=$(Agent.BuildDirectory)/rocm/llvm/include
           -D CMAKE_CXX_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang++

--- a/.azuredevops/components/rocm-libraries.yml
+++ b/.azuredevops/components/rocm-libraries.yml
@@ -36,8 +36,10 @@ parameters:
     - gfortran
     - git
     - libdrm-dev
+    - liblapack-dev
     - libmsgpack-dev
     - libnuma-dev
+    - libopenblas-dev
     - ninja-build
     - python3-pip
     - python3-venv

--- a/.azuredevops/components/rocm-libraries.yml
+++ b/.azuredevops/components/rocm-libraries.yml
@@ -138,14 +138,19 @@ jobs:
           rocm-libraries | ${{ job.os }} | ${{ job.target }} | $(DAY_STRING)
           rocm-libraries | ${{ job.os }} | ${{ job.target }}
           rocm-libraries | ${{ job.os }}
-    - script: |
-        echo "##vso[task.setvariable variable=PytestCmakePath]/home/AzDevOps/.local/share/Pytest/cmake"
-      displayName: Set cmake configure paths
+    - task: Bash@3
+      displayName: Add paths for CMake and Python site-packages binaries
+      inputs:
+        targetType: inline
+        script: |
+          USER_BASE=$(python3 -m site --user-base)
+          echo "##vso[task.prependpath]$USER_BASE/bin"
+          echo "##vso[task.setvariable variable=PytestCmakePath]$USER_BASE/share/Pytest/cmake"
+        displayName: Set cmake configure paths
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
       parameters:
         os: ${{ job.os }}
         extraBuildFlags: >-
-          -D Pytest_ROOT=/home/AzDevOps/.local/bin
           -D CMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm;$(Agent.BuildDirectory)/vendor;$(PytestCmakePath)
           -D CMAKE_INCLUDE_PATH=$(Agent.BuildDirectory)/rocm/llvm/include
           -D CMAKE_CXX_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang++

--- a/.azuredevops/components/rocm-libraries.yml
+++ b/.azuredevops/components/rocm-libraries.yml
@@ -136,14 +136,13 @@ jobs:
           rocm-libraries | ${{ job.os }} | ${{ job.target }}
           rocm-libraries | ${{ job.os }}
     - script: |
-        echo "##vso[task.setvariable variable=PytestCmakePath]$(python3 -m pytest_cmake --cmake-dir)"
-        find / -name "PytestConfig.cmake"
+        echo "##vso[task.setvariable variable=PytestCmakePath]/home/AzDevOps/.local/share/Pytest/cmake"
       displayName: Set cmake configure paths
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
       parameters:
         os: ${{ job.os }}
         extraBuildFlags: >-
-          -D CMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm;$(Agent.BuildDirectory)/vendor;/home/AzDevOps/.local/bin;$(PytestCmakePath)
+          -D CMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm;$(Agent.BuildDirectory)/vendor;$(PytestCmakePath)
           -D CMAKE_INCLUDE_PATH=$(Agent.BuildDirectory)/rocm/llvm/include
           -D CMAKE_CXX_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang++
           -D CMAKE_C_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang

--- a/.azuredevops/components/rocm-libraries.yml
+++ b/.azuredevops/components/rocm-libraries.yml
@@ -46,6 +46,7 @@ parameters:
   default:
     - joblib
     - "packaging>=22.0"
+    - pytest-cmake
     - --upgrade
 - name: rocmDependencies
   type: object

--- a/.azuredevops/components/rocm-libraries.yml
+++ b/.azuredevops/components/rocm-libraries.yml
@@ -139,7 +139,7 @@ jobs:
       parameters:
         os: ${{ job.os }}
         extraBuildFlags: >-
-          -D CMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm;$(Agent.BuildDirectory)/vendor
+          -D CMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm;$(Agent.BuildDirectory)/vendor;$(python3 -m pytest_cmake --cmake-dir)
           -D CMAKE_INCLUDE_PATH=$(Agent.BuildDirectory)/rocm/llvm/include
           -D CMAKE_CXX_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang++
           -D CMAKE_C_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang

--- a/.azuredevops/components/rocm-libraries.yml
+++ b/.azuredevops/components/rocm-libraries.yml
@@ -46,6 +46,7 @@ parameters:
   default:
     - joblib
     - "packaging>=22.0"
+    - pytest
     - pytest-cmake
     - --upgrade
 - name: rocmDependencies


### PR DESCRIPTION
## Motivation

Create a pipeline to test the superbuild

## Technical Details

Leverages the monorepo superbuild with a top-level CMakeLists.txt to invoke a build of all currently supported projects. This commit only establishes the pipeline, it doesn't setup the trigger.

## Test Plan

Testing PR https://github.com/ROCm/rocm-libraries/pull/1239 alongside this change to verify pipeline checks pass. Afterwards, update the triggers to have superbuild tests running on every PR using cached outputs from previous builds.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
