### PR TITLE
[Ex CI] change hip-clr pipeline ID

### DIFF
--- a/.azuredevops/templates/steps/dependencies-rocm.yml
+++ b/.azuredevops/templates/steps/dependencies-rocm.yml
@@ -47,8 +47,8 @@ parameters:
       developBranch: aomp-dev
       hasGpuTarget: false
     clr:
-      pipelineId: 145
-      developBranch: amd-staging
+      pipelineId: 335
+      developBranch: develop
       hasGpuTarget: false
     composable_kernel:
       pipelineId: 86
@@ -59,8 +59,8 @@ parameters:
       developBranch: rocm
       hasGpuTarget: false
     HIP:
-      pipelineId: 93
-      developBranch: amd-staging
+      pipelineId: 335
+      developBranch: develop
       hasGpuTarget: false
     hip-tests:
       pipelineId: 233


### PR DESCRIPTION
Change hip-clr pipeline IDs to the combined monorepo pipeline and changed their branch name to `develop`.

https://dev.azure.com/ROCm-CI/ROCm-CI/_build?definitionId=335&_a=summary