### PR TITLE
[External CI] Updates to rocm-libraries pipelines

### DIFF
--- a/.azuredevops/components/hipSPARSELt.yml
+++ b/.azuredevops/components/hipSPARSELt.yml
@@ -44,6 +44,7 @@ parameters:
   type: object
   default:
     - joblib
+    - msgpack
 - name: rocmDependencies
   type: object
   default:

--- a/.azuredevops/components/rocBLAS.yml
+++ b/.azuredevops/components/rocBLAS.yml
@@ -179,6 +179,8 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
       parameters:
         os: ${{ job.os }}
+        cmakeSourceDir: $(Agent.BuildDirectory)/sparse/projects/rocblas
+        cmakeBuildDir: $(Agent.BuildDirectory)/sparse/projects/rocblas/build
         extraBuildFlags: >-
           -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm/llvm;$(Agent.BuildDirectory)/rocm;$(Agent.BuildDirectory)/vendor
           -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
- Add msgpack python module dependency for hipsparselt pipeline.
- Change CMake dirs for rocblas pipeline to allow relative-path access to shared/tensile directory.

Tagging @vin-huang  and @TorreZuk for awareness.
