### PR TITLE
[External CI] Add dvc to MIOpen pipeline

### DIFF
--- a/.azuredevops/components/MIOpen.yml
+++ b/.azuredevops/components/MIOpen.yml
@@ -42,11 +42,15 @@ parameters:
     - python3-pip
     - python3-venv
     - software-properties-common
+    - wget
     - zip
 - name: pipModules
   type: object
   default:
     - cget
+- name: largeFiles
+  type: boolean
+  default: true
 - name: rocmDependencies
   type: object
   default:
@@ -131,12 +135,14 @@ jobs:
       parameters:
         aptPackages: ${{ parameters.aptPackages }}
         pipModules: ${{ parameters.pipModules }}
+        largeFiles: ${{ parameters.largeFiles }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-cmake-latest.yml
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
       parameters:
         checkoutRepo: ${{ parameters.checkoutRepo }}
         sparseCheckoutDir: ${{ parameters.sparseCheckoutDir }}
+        largeFiles: ${{ parameters.largeFiles }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/miopen-get-ck-build.yml
       parameters:
         gpuTarget: ${{ job.target }}
@@ -212,12 +218,14 @@ jobs:
       parameters:
         aptPackages: ${{ parameters.aptPackages }}
         pipModules: ${{ parameters.pipModules }}
+        largeFiles: ${{ parameters.largeFiles }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-cmake-latest.yml
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
       parameters:
         checkoutRepo: ${{ parameters.checkoutRepo }}
         sparseCheckoutDir: ${{ parameters.sparseCheckoutDir }}
+        largeFiles: ${{ parameters.largeFiles }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-aqlprofile.yml
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/miopen-get-ck-build.yml
       parameters:

--- a/.azuredevops/templates/steps/checkout.yml
+++ b/.azuredevops/templates/steps/checkout.yml
@@ -38,4 +38,7 @@ steps:
       inputs:
         targetType: inline
         script: dvc pull
-        workingDirectory: $(Agent.BuildDirectory)/s
+        ${{ if eq(parameters.sparseCheckoutDir, '') }}:
+          workingDirectory: $(Agent.BuildDirectory)/s
+        ${{ else }}:
+          workingDirectory: $(Agent.BuildDirectory)/sparse

--- a/.azuredevops/templates/steps/checkout.yml
+++ b/.azuredevops/templates/steps/checkout.yml
@@ -37,8 +37,13 @@ steps:
       displayName: dvc pull
       inputs:
         targetType: inline
-        script: dvc pull
         ${{ if eq(parameters.sparseCheckoutDir, '') }}:
-          workingDirectory: $(Agent.BuildDirectory)/s
+          script:
+            pushd $(Agent.BuildDirectory)/s
+            dvc pull
+            popd
         ${{ else }}:
-          workingDirectory: $(Agent.BuildDirectory)/sparse/${{ parameters.sparseCheckoutDir }}
+          script:
+            pushd $(Agent.BuildDirectory)/sparse/${{ parameters.sparseCheckoutDir }}
+            dvc pull
+            popd

--- a/.azuredevops/templates/steps/checkout.yml
+++ b/.azuredevops/templates/steps/checkout.yml
@@ -38,12 +38,12 @@ steps:
       inputs:
         targetType: inline
         ${{ if eq(parameters.sparseCheckoutDir, '') }}:
-          script:
+          script: |
             pushd $(Agent.BuildDirectory)/s
             dvc pull
             popd
         ${{ else }}:
-          script:
+          script: |
             pushd $(Agent.BuildDirectory)/sparse/${{ parameters.sparseCheckoutDir }}
             dvc pull
             popd

--- a/.azuredevops/templates/steps/checkout.yml
+++ b/.azuredevops/templates/steps/checkout.yml
@@ -41,4 +41,4 @@ steps:
         ${{ if eq(parameters.sparseCheckoutDir, '') }}:
           workingDirectory: $(Agent.BuildDirectory)/s
         ${{ else }}:
-          workingDirectory: $(Agent.BuildDirectory)/sparse
+          workingDirectory: $(Agent.BuildDirectory)/sparse/${{ parameters.sparseCheckoutDir }}

--- a/.azuredevops/templates/steps/checkout.yml
+++ b/.azuredevops/templates/steps/checkout.yml
@@ -37,13 +37,8 @@ steps:
       displayName: dvc pull
       inputs:
         targetType: inline
+        script: dvc pull
         ${{ if eq(parameters.sparseCheckoutDir, '') }}:
-          script: |
-            pushd $(Agent.BuildDirectory)/s
-            dvc pull
-            popd
+          workingDirectory: $(Agent.BuildDirectory)/s
         ${{ else }}:
-          script: |
-            pushd $(Agent.BuildDirectory)/sparse/${{ parameters.sparseCheckoutDir }}
-            dvc pull
-            popd
+          workingDirectory: $(Agent.BuildDirectory)/sparse/${{ parameters.sparseCheckoutDir }}

--- a/.azuredevops/templates/steps/checkout.yml
+++ b/.azuredevops/templates/steps/checkout.yml
@@ -12,6 +12,10 @@ parameters:
 - name: submoduleBehaviour
   type: string
   default: 'true'
+# determines if dvc should be used or not
+- name: largeFiles
+  type: boolean
+  default: true
 
 steps:
   - checkout: ${{ parameters.checkoutRepo }}
@@ -28,3 +32,10 @@ steps:
       inputs:
         targetType: inline
         script: ln -s $(Agent.BuildDirectory)/sparse/${{ parameters.sparseCheckoutDir }} $(Agent.BuildDirectory)/s
+  - ${{ if eq(parameters.largeFiles, true) }}:
+    - task: Bash@3
+      displayName: dvc pull
+      inputs:
+        targetType: inline
+        script: dvc pull
+        workingDirectory: $(Agent.BuildDirectory)/s

--- a/.azuredevops/templates/steps/checkout.yml
+++ b/.azuredevops/templates/steps/checkout.yml
@@ -24,7 +24,7 @@ steps:
     retryCountOnTaskFailure: 3
     fetchFilter: blob:none
     ${{ if ne(parameters.sparseCheckoutDir, '') }}:
-      sparseCheckoutDirectories: ${{ parameters.sparseCheckoutDir }} shared
+      sparseCheckoutDirectories: ${{ parameters.sparseCheckoutDir }} shared .dvc .dvcignore .gitignore
       path: sparse
   - ${{ if ne(parameters.sparseCheckoutDir, '') }}:
     - task: Bash@3

--- a/.azuredevops/templates/steps/dependencies-other.yml
+++ b/.azuredevops/templates/steps/dependencies-other.yml
@@ -43,12 +43,12 @@ steps:
     inputs:
       targetType: inline
       ${{ if eq(parameters.os, 'almalinux8') }}:
-        script: >-
+        script: |
           wget https://dvc.org/download/linux-deb/dvc-3.62.0 -O ./dvc_3.62.0_amd64.deb
           sudo DEBIAN_FRONTEND=noninteractive apt-get --yes --fix-missing install ./dvc_3.62.0_amd64.deb
           sudo rm -f ./dvc_3.62.0_amd64.deb
       ${{ if ne(parameters.os, 'almalinux8') }}:
-        script: >-
+        script: |
           wget https://dvc.org/download/linux-rpm/dvc-3.62.0 -O ./dvc-3.62.0-1.x86_64.rpm
           sudo DEBIAN_FRONTEND=noninteractive apt-get --yes --fix-missing install ./dvc-3.62.0-1.x86_64.rpm
           sudo rm -f ./dvc-3.62.0-1.x86_64.rpm

--- a/.azuredevops/templates/steps/dependencies-other.yml
+++ b/.azuredevops/templates/steps/dependencies-other.yml
@@ -12,6 +12,9 @@ parameters:
 - name: packageManager
   type: string
   default: apt
+- name: largeFiles
+  type: boolean
+  default: true
 
 steps:
 - ${{ if eq(parameters.packageManager, 'apt') }}:
@@ -31,3 +34,18 @@ steps:
     inputs:
       targetType: inline
       script: python3 -m pip install -v --force-reinstall ${{ join(' ', parameters.pipModules) }}
+- ${{ if eq(parameters.largeFiles, true) }}:
+  - task: Bash@3
+    displayName: install dvc
+    inputs:
+      targetType: inline
+      ${{ if eq(parameters.os, 'almalinux8') }}:
+        script: >-
+          wget https://dvc.org/download/linux-deb/dvc-3.62.0 -O ./dvc_3.62.0_amd64.deb
+          sudo DEBIAN_FRONTEND=noninteractive apt-get --yes --fix-missing install ./dvc_3.62.0_amd64.deb
+          sudo rm -f ./dvc_3.62.0_amd64.deb
+      ${{ if ne(parameters.os, 'almalinux8') }}:
+        script: >-
+          wget https://dvc.org/download/linux-rpm/dvc-3.62.0 -O ./dvc-3.62.0-1.x86_64.rpm
+          sudo DEBIAN_FRONTEND=noninteractive apt-get --yes --fix-missing install ./dvc-3.62.0-1.x86_64.rpm
+          sudo rm -f ./dvc-3.62.0-1.x86_64.rpm

--- a/.azuredevops/templates/steps/dependencies-other.yml
+++ b/.azuredevops/templates/steps/dependencies-other.yml
@@ -1,5 +1,8 @@
 # download and install non-rocm dependencies through apt and pip
 parameters:
+- name: os
+  type: string
+  default: 'ubuntu2204'
 - name: aptPackages
   type: object
   default: []

--- a/.azuredevops/templates/steps/dependencies-other.yml
+++ b/.azuredevops/templates/steps/dependencies-other.yml
@@ -47,7 +47,7 @@ steps:
           wget https://dvc.org/download/linux-deb/dvc-3.62.0 -O ./dvc_3.62.0_amd64.deb
           sudo DEBIAN_FRONTEND=noninteractive apt-get --yes --fix-missing install ./dvc_3.62.0_amd64.deb
           sudo rm -f ./dvc_3.62.0_amd64.deb
-      ${{ if eq(parameters.os, 'almalinux8') }}:
+      ${{ else }}:
         script: |
           wget https://dvc.org/download/linux-rpm/dvc-3.62.0 -O ./dvc-3.62.0-1.x86_64.rpm
           sudo DEBIAN_FRONTEND=noninteractive apt-get --yes --fix-missing install ./dvc-3.62.0-1.x86_64.rpm

--- a/.azuredevops/templates/steps/dependencies-other.yml
+++ b/.azuredevops/templates/steps/dependencies-other.yml
@@ -42,12 +42,12 @@ steps:
     displayName: install dvc
     inputs:
       targetType: inline
-      ${{ if eq(parameters.os, 'almalinux8') }}:
+      ${{ if ne(parameters.os, 'almalinux8') }}:
         script: |
           wget https://dvc.org/download/linux-deb/dvc-3.62.0 -O ./dvc_3.62.0_amd64.deb
           sudo DEBIAN_FRONTEND=noninteractive apt-get --yes --fix-missing install ./dvc_3.62.0_amd64.deb
           sudo rm -f ./dvc_3.62.0_amd64.deb
-      ${{ if ne(parameters.os, 'almalinux8') }}:
+      ${{ if eq(parameters.os, 'almalinux8') }}:
         script: |
           wget https://dvc.org/download/linux-rpm/dvc-3.62.0 -O ./dvc-3.62.0-1.x86_64.rpm
           sudo DEBIAN_FRONTEND=noninteractive apt-get --yes --fix-missing install ./dvc-3.62.0-1.x86_64.rpm


### PR DESCRIPTION
## Motivation

- MIOpen moved from `git lfs` to `dvc` for its `.kdb.bz2` files.

## Technical Details

- Update template for dependency installation and checkout steps to include `dvc` if `largeFiles` boolean is set to `true`.
- Set that boolean to `true` for MIOpen case.

## Test Plan

- Run experimental MIOpen pipeline in Azure CI with the changes.

## Test Result

- Log: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=52610&view=results

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
