### PR TITLE
Ensure origami python test step fails on error

### DIFF
--- a/.azuredevops/components/origami.yml
+++ b/.azuredevops/components/origami.yml
@@ -207,6 +207,7 @@ jobs:
             downstreamAggregateNames: ${{ parameters.downstreamAggregateNames }}
       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/gpu-diagnostics.yml
       - script: |
+          set -e
           export PYTHONPATH=$(Agent.BuildDirectory)/s/build/python:$PYTHONPATH
 
           echo "--- Running origami_test.py ---"


### PR DESCRIPTION
## Motivation

The CI test step for Python bindings was falsely passing when a script failed. This was because the shell script "Run Python Bindings Tests" didn't exit on error.

## Technical Details

Added `set -e` to the beginning of the script block for the "Run Python Bindings Tests" step in `origami.yml`. This forces the script to exit immediately on any error which ensures the CI step now fails correctly.

## Test Plan

The fix was verified by running a pipeline.

## Test Result

With this change, the "Run Python Binding Tests" step now correctly reports a failure when the `origami_test.py` script errors out, as expected.

## Submission Checklist

- [ x ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
