### PR TITLE
Add origami yaml based tests to azure pipelines

### DIFF
--- a/.azuredevops/components/origami.yml
+++ b/.azuredevops/components/origami.yml
@@ -112,6 +112,10 @@ jobs:
         packageManager: ${{ job.packageManager }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-cmake-custom.yml
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-vendor.yml
+      parameters:
+        dependencyList:
+          - gtest
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
       parameters:
         checkoutRepo: ${{ parameters.checkoutRepo }}
@@ -215,7 +219,7 @@ jobs:
           os: ${{ job.os }}
           testDir: '$(Agent.BuildDirectory)/rocm/bin'
           testExecutable: './origami-tests'
-          # testParameters: '--yaml origami-tests.yaml --gtest_output=xml:./test_output.xml --gtest_color=yes'
+          testParameters: '--yaml origami-tests.yaml --gtest_output=xml:./test_output.xml --gtest_color=yes'
       - script: |
           set -e
           export PYTHONPATH=$(Agent.BuildDirectory)/s/build/python:$PYTHONPATH

--- a/.azuredevops/components/origami.yml
+++ b/.azuredevops/components/origami.yml
@@ -206,6 +206,13 @@ jobs:
           ${{ if parameters.triggerDownstreamJobs }}:
             downstreamAggregateNames: ${{ parameters.downstreamAggregateNames }}
       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/gpu-diagnostics.yml
+      - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
+        parameters:
+          componentName: ${{ parameters.componentName }}
+          os: ${{ job.os }}
+          testDir: '$(Agent.BuildDirectory)/rocm/bin'
+          testExecutable: './origami-tests'
+          # testParameters: '--yaml origami-tests.yaml --gtest_output=xml:./test_output.xml --gtest_color=yes'
       - script: |
           set -e
           export PYTHONPATH=$(Agent.BuildDirectory)/s/build/python:$PYTHONPATH

--- a/.azuredevops/components/origami.yml
+++ b/.azuredevops/components/origami.yml
@@ -39,6 +39,9 @@ parameters:
     - python3
     - python3-dev
     - python3-pip
+    - libgtest-dev
+    - libboost-filesystem-dev
+    - libboost-program-options-dev
 - name: pipModules
   type: object
   default:

--- a/.azuredevops/components/origami.yml
+++ b/.azuredevops/components/origami.yml
@@ -132,7 +132,7 @@ jobs:
       parameters:
         os: ${{ job.os }}
         extraBuildFlags: >-
-          -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm
+          -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm;$(Agent.BuildDirectory)/vendor
           -DCMAKE_CXX_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang++
           -DORIGAMI_BUILD_SHARED_LIBS=ON
           -DORIGAMI_ENABLE_PYTHON=ON


### PR DESCRIPTION
## Motivation

Origami now has yaml based testing in rocm-libraries. We need to run the test executable in the Azure pipelines.

## Technical Details

Add the `test.yml` step to the `origami.yml` script where `./origmai-tests` will be run.

## Test Plan

Trigger the pipeline using this branch.

## Test Result

All tests pass: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=55239&view=results

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
