### PR TITLE
[superbuild] Add dependencies for hipblaslt and origami

### DIFF
--- a/.azuredevops/components/rocm-libraries.yml
+++ b/.azuredevops/components/rocm-libraries.yml
@@ -43,6 +43,10 @@ parameters:
     - ninja-build
     - python3-pip
     - python3-venv
+    - googletest
+    - libgtest-dev
+    - libgmock-dev
+    - libboost-filesystem-dev
 - name: pipModules
   type: object
   default:

--- a/.azuredevops/components/rocm-libraries.yml
+++ b/.azuredevops/components/rocm-libraries.yml
@@ -50,6 +50,7 @@ parameters:
 - name: pipModules
   type: object
   default:
+    - msgpack
     - joblib
     - "packaging>=22.0"
     - pytest

--- a/.azuredevops/components/rocm-libraries.yml
+++ b/.azuredevops/components/rocm-libraries.yml
@@ -151,6 +151,13 @@ jobs:
           echo "##vso[task.prependpath]$USER_BASE/bin"
           echo "##vso[task.setvariable variable=PytestCmakePath]$USER_BASE/share/Pytest/cmake"
         displayName: Set cmake configure paths
+    - task: Bash@3
+      displayName: Add ROCm binaries to PATH
+      inputs:
+        targetType: inline
+        script: |
+          echo "##vso[task.prependpath]$(Agent.BuildDirectory)/rocm/bin"
+          echo "##vso[task.prependpath]$(Agent.BuildDirectory)/rocm/llvm/bin"
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
       parameters:
         os: ${{ job.os }}


### PR DESCRIPTION
## Motivation

The superbuild needs new dependencies to support hipblaslt and origami.

## Technical Details

Add apt packages for required dependencies.

## Test Plan

CI testing through rocm-libraries-superbuild prior to merge

## Test Result

[Build succeeds](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=60847&view=logs&j=7cc13035-2e67-5189-6728-9dc93c5ce047&t=182da22c-d989-54a2-6115-49a53c67ab74) when combined with https://github.com/ROCm/rocm-libraries/pull/1499

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
