### PR TITLE
[Ex CI] Added Component and Module Dependencies

### DIFF
--- a/.azuredevops/components/rocm-examples.yml
+++ b/.azuredevops/components/rocm-examples.yml
@@ -108,6 +108,7 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
       parameters:
         aptPackages: ${{ parameters.aptPackages }}
+        registerROCmPackages: true
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-cmake-custom.yml
       parameters:
         cmakeVersion: '3.25.0'
@@ -172,6 +173,7 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
       parameters:
         aptPackages: ${{ parameters.aptPackages }}
+        registerROCmPackages: true
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-cmake-custom.yml
       parameters:
         cmakeVersion: '3.25.0'

--- a/.azuredevops/components/rocm-examples.yml
+++ b/.azuredevops/components/rocm-examples.yml
@@ -14,9 +14,11 @@ parameters:
   type: object
   default:
     - cmake
+    - libdw-dev
     - libglfw3-dev
     - libmsgpack-dev
     - libtbb-dev
+    - libva-amdgpu-dev
     - ninja-build
     - python3-pip
 - name: rocmDependencies
@@ -35,6 +37,7 @@ parameters:
     - hipSPARSE
     - hipTensor
     - llvm-project
+    - MIOpen
     - rocBLAS
     - rocFFT
     - rocJPEG


### PR DESCRIPTION
## Motivation
Rocm-Examples has added new tests for rocprofiler-sdk, rocJPEG and AMDMIGraphX. These components require libdw-dev, libva-amdgpu-dev, and MIOpen respectively.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
rocprofiler-sdk: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=59810&view=results
AMDMIGraphX: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=59809&view=results
rocJPEG: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=59808&view=results

These tests are failing due to the pr, develop branch is not failing: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=60114&view=results

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
