### PR TITLE
Fix documented AMD SMI version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ different versions of the ROCm software stack and its components.
 See the [ROCm 7.0.2 release notes](https://rocm.docs.amd.com/en/docs-7.0.2/about/release-notes.html#rocm-7-0-2-release-notes)
 for a complete overview of this release.
 
-### **AMD SMI** (26.0.1)
+### **AMD SMI** (26.0.2)
 
 #### Added
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -441,7 +441,7 @@ Click {fab}`github` to go to the component's source code on GitHub.
                 <th rowspan="7">Tools</th>
                 <th rowspan="7">System management</th>
                 <td><a href="https://rocm.docs.amd.com/projects/amdsmi/en/docs-7.0.2/index.html">AMD SMI</a></td>
-                <td>26.0.0&nbsp;&Rightarrow;&nbsp;<a href="#amd-smi-26-0-1">26.0.1</a></td>
+                <td>26.0.0&nbsp;&Rightarrow;&nbsp;<a href="#amd-smi-26-0-2">26.0.2</a></td>
                 <td><a href="https://github.com/ROCm/amdsmi"><i class="fab fa-github fa-lg"></i></a></td>
             </tr>
             <tr>


### PR DESCRIPTION
## Motivation

Title. CHANGELOG and RELEASE list AMD SMI version as 26.0.1.

(The compatibility matrix already lists 26.0.2)

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
