### PR TITLE
[Ex CI] Add libtiff-dev, libopencv-dev and rpp

### DIFF
--- a/.azuredevops/components/rocm-examples.yml
+++ b/.azuredevops/components/rocm-examples.yml
@@ -18,6 +18,7 @@ parameters:
     - libglfw3-dev
     - libmsgpack-dev
     - libtbb-dev
+    - libtiff-dev
     - libva-amdgpu-dev
     - ninja-build
     - python3-pip
@@ -50,6 +51,7 @@ parameters:
     - rocSPARSE
     - rocThrust
     - rocWMMA
+    - rpp
 - name: rocmTestDependencies
   type: object
   default:
@@ -80,6 +82,7 @@ parameters:
     - rocThrust
     - roctracer
     - rocWMMA
+    - rpp
 
 - name: jobMatrix
   type: object

--- a/.azuredevops/components/rocm-examples.yml
+++ b/.azuredevops/components/rocm-examples.yml
@@ -17,6 +17,7 @@ parameters:
     - libdw-dev
     - libglfw3-dev
     - libmsgpack-dev
+    - libopencv-dev
     - libtbb-dev
     - libtiff-dev
     - libva-amdgpu-dev


### PR DESCRIPTION
## Motivation

Soon, rocm-examples will add a HIP Graph API tutorial which requires LibTIFF and more ROCm library examples which depend on rpp and libopencv-dev.

## Technical Details

## Test Plan

https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=60393&view=results

These tests are failing due to this PR: https://github.com/ROCm/rocm-examples/pull/294

## Test Result

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
