### PR TITLE
[External CI] Add libsimde-dev to ROCR pipeline

### DIFF
--- a/.azuredevops/components/ROCR-Runtime.yml
+++ b/.azuredevops/components/ROCR-Runtime.yml
@@ -37,6 +37,7 @@ parameters:
     - libdrm-dev
     - libelf-dev
     - libnuma-dev
+    - libsimde-dev
     - ninja-build
     - pkg-config
 - name: rocmDependencies


### PR DESCRIPTION
To enable support for ROCm/rocm-systems#265