### PR TITLE
[Ex CI] Increase RCCL build time limit to 120mins

### DIFF
--- a/.azuredevops/components/rccl.yml
+++ b/.azuredevops/components/rccl.yml
@@ -70,7 +70,7 @@ parameters:
 jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
   - job: rccl_build_${{ job.target }}
-    timeoutInMinutes: 90
+    timeoutInMinutes: 120
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml


### PR DESCRIPTION
## Motivation

RCCL CI on `gfx90a` is experiencing build timeouts due to increased RCCL build time on gfx90a. While we resolve this issue, we would like to unblock RCCL CI failures for other PRs due to timeout.

## Technical Details

Timeout Failure: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=60519&view=logs&j=7146f1d6-b917-5ac9-6d7c-6a848f89f889

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
