### PR TITLE
CTest - Output verbose

### DIFF
--- a/.azuredevops/components/hipTensor.yml
+++ b/.azuredevops/components/hipTensor.yml
@@ -130,7 +130,7 @@ jobs:
       parameters:
         componentName: hipTensor
         testDir: '$(Agent.BuildDirectory)/rocm/bin/hiptensor'
-        testParameters: '-E ".*-extended" --output-on-failure --force-new-ctest-process --output-junit test_output.xml'
+        testParameters: '-E ".*-extended" --extra-verbose --output-on-failure --force-new-ctest-process --output-junit test_output.xml'
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/docker-container.yml
       parameters:
         aptPackages: ${{ parameters.aptPackages }}

--- a/.azuredevops/components/rocm-cmake.yml
+++ b/.azuredevops/components/rocm-cmake.yml
@@ -81,7 +81,7 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml
       parameters:
         componentName: rocm-cmake
-        testParameters: '-E "pass-version-parent" --output-on-failure --force-new-ctest-process --output-junit test_output.xml'
+        testParameters: '-E "pass-version-parent" --extra-verbose --output-on-failure --force-new-ctest-process --output-junit test_output.xml'
         os: ${{ job.os }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/manifest.yml
       parameters:

--- a/.azuredevops/templates/steps/test.yml
+++ b/.azuredevops/templates/steps/test.yml
@@ -13,7 +13,7 @@ parameters:
   default: ctest
 - name: testParameters
   type: string
-  default: --output-on-failure --force-new-ctest-process --output-junit test_output.xml
+  default: --extra-verbose --output-on-failure --force-new-ctest-process --output-junit test_output.xml
 - name: extraTestParameters
   type: string
   default: ''


### PR DESCRIPTION
## Motivation

The CTest run with verbose output will help developers identify issues faster

## Technical Details

-VV option will detail the results from tests

## Test Plan

ALL Current tests

## Test Result

Pass all CTests

## Submission Checklist

- [ x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
