### PR TITLE
[Ex CI] Add libomp-dev, MIVisionX, rocDecode and dependencies

### DIFF
--- a/.azuredevops/components/rocm-examples.yml
+++ b/.azuredevops/components/rocm-examples.yml
@@ -17,10 +17,14 @@ parameters:
     - libdw-dev
     - libglfw3-dev
     - libmsgpack-dev
+    - libomp-dev
     - libopencv-dev
     - libtbb-dev
     - libtiff-dev
     - libva-amdgpu-dev
+    - libavcodec-dev
+    - libavformat-dev
+    - libavutil-dev
     - ninja-build
     - python3-pip
 - name: rocmDependencies
@@ -40,7 +44,9 @@ parameters:
     - hipTensor
     - llvm-project
     - MIOpen
+    - MIVisionX
     - rocBLAS
+    - rocDecode
     - rocFFT
     - rocJPEG
     - rocPRIM
@@ -70,7 +76,9 @@ parameters:
     - hipTensor
     - llvm-project
     - MIOpen
+    - MIVisionX
     - rocBLAS
+    - rocDecode
     - rocFFT
     - rocminfo
     - rocPRIM


### PR DESCRIPTION
## Motivation

Soon, rocm-examples will add MIVisionX and rocDecode library examples. Some other library examples depend on libomp-dev

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=61092&view=results -> https://github.com/ROCm/rocm-examples/pull/328
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=62200&view=results -> https://github.com/ROCm/rocm-examples/pull/331
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=61175&view=results -> https://github.com/ROCm/rocm-examples/pull/330

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
