### PR TITLE
[Ex CI] Update RCCL build-cmake

### DIFF
--- a/.azuredevops/components/rccl.yml
+++ b/.azuredevops/components/rccl.yml
@@ -101,6 +101,7 @@ jobs:
         aggregatePipeline: ${{ parameters.aggregatePipeline }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
       parameters:
+        consolidateBuildAndInstall: true 
         extraBuildFlags: >-
           -DCMAKE_CXX_COMPILER=$(Agent.BuildDirectory)/rocm/bin/hipcc
           -DCMAKE_C_COMPILER=$(Agent.BuildDirectory)/rocm/bin/hipcc


### PR DESCRIPTION
## Motivation
Currently rccl runs its cmake build step twice, once in the build step and then a second time in its install step. To prevent this we can add the consolidateBuildAndInstall: true flag to the parameters for the build-cmake.yml.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Waiting for this pr to get merged before testing: https://github.com/ROCm/rccl/pull/1995
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
