### PR TITLE
[Ex CI] Add aomp, aomp-extras, composable_kernel and rocALUTION; remove libomp-dev

### DIFF
--- a/.azuredevops/components/rocm-examples.yml
+++ b/.azuredevops/components/rocm-examples.yml
@@ -17,7 +17,6 @@ parameters:
     - libdw-dev
     - libglfw3-dev
     - libmsgpack-dev
-    - libomp-dev
     - libopencv-dev
     - libtbb-dev
     - libtiff-dev
@@ -31,7 +30,10 @@ parameters:
   type: object
   default:
     - AMDMIGraphX
+    - aomp
+    - aomp-extras
     - clr
+    - composable_kernel
     - hipBLAS
     - hipBLAS-common
     - hipBLASLt
@@ -45,6 +47,7 @@ parameters:
     - llvm-project
     - MIOpen
     - MIVisionX
+    - rocALUTION
     - rocBLAS
     - rocDecode
     - rocFFT
@@ -63,7 +66,10 @@ parameters:
   type: object
   default:
     - AMDMIGraphX
+    - aomp
+    - aomp-extras
     - clr
+    - composable_kernel
     - hipBLAS
     - hipBLAS-common
     - hipBLASLt
@@ -77,6 +83,7 @@ parameters:
     - llvm-project
     - MIOpen
     - MIVisionX
+    - rocALUTION
     - rocBLAS
     - rocDecode
     - rocFFT


### PR DESCRIPTION
## Motivation

We are adding more examples to the rocm-examples repository which require these packages. The dependency `libomp-dev` (recently and mistakenly introduced with #5531) is replaced by the `aomp` packages.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
