### PR TITLE
Update jax-compatibility.rst

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -246,6 +246,7 @@ Intersphinx
 Intra
 Ioffe
 JAX's
+JAXLIB
 Jinja
 JSON
 Jupyter
@@ -381,6 +382,7 @@ perf
 PEQT
 PIL
 PILImage
+PJRT
 POR
 PRNG
 PRs

--- a/docs/compatibility/ml-compatibility/jax-compatibility.rst
+++ b/docs/compatibility/ml-compatibility/jax-compatibility.rst
@@ -47,8 +47,10 @@ with ROCm support:
    `Community ROCm JAX Docker images <https://hub.docker.com/r/rocm/jax-community>`_
    follow upstream JAX releases and use the latest available ROCm version.
 
-JAX Plugin-PJRT with JAX/JAXLIB Compatibility
+JAX Plugin-PJRT with JAX/JAXLIB compatibility
 ================================================================================
+
+Portable JIT Runtime (PJRT) is an open, stable interface for device runtime and compiler. The table below shows the compatibility between the JAX Plugin–PJRT (column) and JAX/JAXLIB (row).
 +------------------------------+-------+-------+
 | JAX Plugin-PJRT / JAX-JAXLIB | 0.6.0 | 0.6.2 |
 +==============================+=======+=======+

--- a/docs/compatibility/ml-compatibility/jax-compatibility.rst
+++ b/docs/compatibility/ml-compatibility/jax-compatibility.rst
@@ -47,6 +47,15 @@ with ROCm support:
    `Community ROCm JAX Docker images <https://hub.docker.com/r/rocm/jax-community>`_
    follow upstream JAX releases and use the latest available ROCm version.
 
+JAX Plugin-PJRT with JAX/JAXLIB Compatibility
+================================================================================
++------------------------------+-------+-------+
+| JAX Plugin-PJRT / JAX-JAXLIB | 0.6.0 | 0.6.2 |
++==============================+=======+=======+
+| 0.6.0                        | X     | X     |
++------------------------------+-------+-------+
+
+
 Use cases and recommendations
 ================================================================================
 

--- a/docs/compatibility/ml-compatibility/jax-compatibility.rst
+++ b/docs/compatibility/ml-compatibility/jax-compatibility.rst
@@ -51,12 +51,18 @@ JAX Plugin-PJRT with JAX/JAXLIB compatibility
 ================================================================================
 
 Portable JIT Runtime (PJRT) is an open, stable interface for device runtime and compiler. The table below shows the compatibility between the JAX Plugin–PJRT (column) and JAX/JAXLIB (row).
-+------------------------------+-------+-------+
-| JAX Plugin-PJRT / JAX-JAXLIB | 0.6.0 | 0.6.2 |
-+==============================+=======+=======+
-| 0.6.0                        | ✅   | ✅    |
-+------------------------------+-------+-------+
 
+.. list-table::
+   :header-rows: 1
+
+    * - JAX Plugin-PJRT / JAX-JAXLIB
+      - 0.6.0
+      - 0.6.2
+    * - 0.6.0
+      - ✅
+      - ✅
+
+✅: Supported 
 
 Use cases and recommendations
 ================================================================================

--- a/docs/compatibility/ml-compatibility/jax-compatibility.rst
+++ b/docs/compatibility/ml-compatibility/jax-compatibility.rst
@@ -53,7 +53,7 @@ JAX Plugin-PJRT with JAX/JAXLIB compatibility
 Portable JIT Runtime (PJRT) is an open, stable interface for device runtime and compiler. The table below shows the compatibility between the JAX Plugin–PJRT (column) and JAX/JAXLIB (row).
 
 .. list-table::
-   :header-rows: 1
+    :header-rows: 1
 
     * - JAX Plugin-PJRT / JAX-JAXLIB
       - 0.6.0

--- a/docs/compatibility/ml-compatibility/jax-compatibility.rst
+++ b/docs/compatibility/ml-compatibility/jax-compatibility.rst
@@ -50,7 +50,7 @@ with ROCm support:
 JAX Plugin-PJRT with JAX/JAXLIB compatibility
 ================================================================================
 
-Portable JIT Runtime (PJRT) is an open, stable interface for device runtime and compiler. The table below shows the compatibility between the JAX Plugin–PJRT (column) and JAX/JAXLIB (row).
+Portable JIT Runtime (PJRT) is an open, stable interface for device runtime and compiler. The table below shows the compatibility between the JAX Plugin–PJRT and JAX/JAXLIB.
 
 .. list-table::
     :header-rows: 1

--- a/docs/compatibility/ml-compatibility/jax-compatibility.rst
+++ b/docs/compatibility/ml-compatibility/jax-compatibility.rst
@@ -54,7 +54,7 @@ Portable JIT Runtime (PJRT) is an open, stable interface for device runtime and 
 +------------------------------+-------+-------+
 | JAX Plugin-PJRT / JAX-JAXLIB | 0.6.0 | 0.6.2 |
 +==============================+=======+=======+
-| 0.6.0                        | X     | X     |
+| 0.6.0                        | ✅   | ✅    |
 +------------------------------+-------+-------+
 
 

--- a/docs/compatibility/ml-compatibility/jax-compatibility.rst
+++ b/docs/compatibility/ml-compatibility/jax-compatibility.rst
@@ -55,14 +55,12 @@ Portable JIT Runtime (PJRT) is an open, stable interface for device runtime and 
 .. list-table::
     :header-rows: 1
 
-    * - JAX Plugin-PJRT / JAX-JAXLIB
-      - 0.6.0
-      - 0.6.2
+    * - JAX Plugin-PJRT
+      - JAX/JAXLIB
+      - ROCm
     * - 0.6.0
-      - ✅
-      - ✅
-
-✅: Supported 
+      - 0.6.2, 0.6.0
+      - 7.0.2, 7.0.1, 7.0.0 
 
 Use cases and recommendations
 ================================================================================


### PR DESCRIPTION
## Motivation
Added table to reflect JAX/JAXLIB multiple versions compatibility with 0.6.0 pjrt and plugin version. 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
