### PR TITLE
[Ex CI] rocWMMA increase timeout for test job

### DIFF
--- a/.azuredevops/components/rocWMMA.yml
+++ b/.azuredevops/components/rocWMMA.yml
@@ -142,7 +142,7 @@ jobs:
 - ${{ if eq(parameters.unifiedBuild, False) }}:
   - ${{ each job in parameters.jobMatrix.testJobs }}:
     - job: ${{ parameters.componentName }}_test_${{ job.target }}
-      timeoutInMinutes: 270
+      timeoutInMinutes: 350
       dependsOn: ${{ parameters.componentName }}_build_${{ job.target }}
       condition:
         and(succeeded(),


### PR DESCRIPTION
## Motivation
Azure Pipeline for rocWMMA is currently hitting timeout, this PR extends the timeout to 350 mins.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Reran timed out job: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=68368&view=results
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
