### PR TITLE
[Ex CI] Add missing dependencies for RCCL, MIGraphX and MIVisionX

### DIFF
--- a/.azuredevops/components/AMDMIGraphX.yml
+++ b/.azuredevops/components/AMDMIGraphX.yml
@@ -152,6 +152,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=Release
           -DGPU_TARGETS=${{ job.target }}
           -DAMDGPU_TARGETS=${{ job.target }}
+          -DCMAKE_CXX_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang++
           -DCMAKE_MODULE_PATH=$(Agent.BuildDirectory)/rocm/lib/cmake/hip
           -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm/llvm;$(Agent.BuildDirectory)/rocm
           -DHALF_INCLUDE_DIR=$(Agent.BuildDirectory)/rocm/include
@@ -217,6 +218,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=Release
           -DGPU_TARGETS=${{ job.target }}
           -DAMDGPU_TARGETS=${{ job.target }}
+          -DCMAKE_CXX_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang++
           -DCMAKE_MODULE_PATH=$(Agent.BuildDirectory)/rocm/lib/cmake/hip
           -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm/llvm;$(Agent.BuildDirectory)/rocm
           -DHALF_INCLUDE_DIR=$(Agent.BuildDirectory)/rocm/include

--- a/.azuredevops/components/rocm-examples.yml
+++ b/.azuredevops/components/rocm-examples.yml
@@ -62,6 +62,7 @@ parameters:
     - llvm-project
     - MIOpen
     - MIVisionX
+    - rocm_smi_lib
     - rccl
     - rocALUTION
     - rocBLAS
@@ -100,6 +101,7 @@ parameters:
     - llvm-project
     - MIOpen
     - MIVisionX
+    - rocm_smi_lib
     - rccl
     - rocALUTION
     - rocBLAS
@@ -146,6 +148,7 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
       parameters:
         aptPackages: ${{ parameters.aptPackages }}
+        pipModules: ${{ parameters.pipModules }}
         registerROCmPackages: true
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-cmake-custom.yml
       parameters:
@@ -245,5 +248,6 @@ jobs:
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/docker-container.yml
       parameters:
         aptPackages: ${{ parameters.aptPackages }}
+        pipModules: ${{ parameters.pipModules }}
         environment: test
         gpuTarget: ${{ job.target }}


### PR DESCRIPTION
## Motivation

The Examples CI complains that some dependencies for RCCL are missing, and the MIVisionX pip dependencies weren't initialized properly. Additionally, it would appear that GPU targets for MIGraphX are not installed - so a CXX override has been added. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
