### PR TITLE
[Ex CI] Add rocprofiler-sdk dep to build for rocprofiler-compute

### DIFF
--- a/.azuredevops/components/rocprofiler-compute.yml
+++ b/.azuredevops/components/rocprofiler-compute.yml
@@ -65,6 +65,10 @@ parameters:
     - pytest
     - pytest-cov
     - pytest-xdist
+- name: rocmDependencies
+  type: object
+  default:
+    - rocprofiler-sdk
 - name: rocmTestDependencies
   type: object
   default:
@@ -101,7 +105,7 @@ jobs:
     ${{ if parameters.buildDependsOn }}:
       dependsOn:
         - ${{ each build in parameters.buildDependsOn }}:
-          - ${{ build }}_${{ job.os }}_${{ job.target }}
+          - ${{ build }}_${{ job.target }}
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml
@@ -119,6 +123,14 @@ jobs:
       parameters:
         checkoutRepo: ${{ parameters.checkoutRepo }}
         sparseCheckoutDir: ${{ parameters.sparseCheckoutDir }}
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-rocm.yml
+      parameters:
+        checkoutRef: ${{ parameters.checkoutRef }}
+        dependencyList: ${{ parameters.rocmDependencies }}
+        gpuTarget: ${{ job.target }}
+        aggregatePipeline: ${{ parameters.aggregatePipeline }}
+        ${{ if parameters.triggerDownstreamJobs }}:
+            downstreamAggregateNames: ${{ parameters.downstreamAggregateNames }}
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/build-cmake.yml
       parameters:
         extraBuildFlags: >-


### PR DESCRIPTION
## Motivation
We have now introduced dependency on rocprofiler-sdk being installed inorder to build rocprofiler-compute successfully. Thus added rocprofiler-sdk to build job in Azure CI for rocprofiler-compute
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Related PR on rocm-systems: https://github.com/ROCm/rocm-systems/pull/1212
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Run with related PR: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=72309&view=results
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Sample: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=72301&view=results
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
