### PR TITLE
Adding dependencies to rocprofiler-compute azure workflow

### DIFF
--- a/.azuredevops/components/rocprofiler-compute.yml
+++ b/.azuredevops/components/rocprofiler-compute.yml
@@ -68,6 +68,9 @@ parameters:
 - name: rocmDependencies
   type: object
   default:
+    - clr
+    - llvm-project
+    - ROCR-Runtime
     - rocprofiler-sdk
 - name: rocmTestDependencies
   type: object


### PR DESCRIPTION
## Motivation

Added clr, ROCR-Runtime, and llvm-project into rocmDependencies for rocprof-compute.
Needed for building because of rocprofiler-sdk dependency.

## Technical Details

## Test Plan

## Test Result

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
