### PR TITLE
Remove continuous numbering of tables and figures

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -241,3 +241,6 @@ html_context = {
     "granularity_type" : [('Coarse-grained', 'coarse-grained'), ('Fine-grained', 'fine-grained')],
     "scope_type" : [('Device', 'device'), ('System', 'system')]
 }
+
+# Disable figure and table numbering
+numfig = False


### PR DESCRIPTION
## Motivation

This PR disables automatic numbering of figures and tables. Due to the way Sphinx works with numbers across subsections, these numbers can be inconsistent and confusing.

## Technical Details

Disables automatic numbering of figures and tables.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
