### PR TITLE
Adding ROCm-Optiq note to What is ROCm page

### DIFF
--- a/docs/what-is-rocm.rst
+++ b/docs/what-is-rocm.rst
@@ -128,7 +128,7 @@ Performance
 
 .. note::
 
-  `ROCm™ Optiq (beta) <https://rocm.docs.amd.com/projects/roc-optiq/en/latest/>`_  provides deep insights into system-level performance for applications running on the ROCm stack. It serves as the GUI to visualize traces collected by ROCm profiling tools, specifically ROCm Systems Profiler.
+  `ROCm™ Optiq (beta) <https://rocm.docs.amd.com/projects/roc-optiq/en/latest/>`_  provides deep insights into system-level performance for applications running on the ROCm stack. It serves as the GUI to visualize traces collected by ROCm profiling tools, specifically `ROCm Systems Profiler <https://rocm.docs.amd.com/projects/rocprofiler-systems/en/latest/index.html>`_.
 
 Development
 ^^^^^^^^^^^

--- a/docs/what-is-rocm.rst
+++ b/docs/what-is-rocm.rst
@@ -126,6 +126,10 @@ Performance
   `ROCprof Compute Viewer <https://rocm.docs.amd.com/projects/rocprof-compute-viewer/en/amd-mainline/>`_ is a tool for visualizing and analyzing GPU thread trace data collected using :doc:`rocprofv3 <rocprofiler-sdk:index>`.
   Note that `ROCprof Compute Viewer <https://rocm.docs.amd.com/projects/rocprof-compute-viewer/en/amd-mainline/>`_ is in an early access state. Running production workloads is not recommended.
 
+.. note::
+
+  `ROCm™ Optiq (beta) <https://rocm.docs.amd.com/projects/roc-optiq/en/latest/>` is AMD’s tool designed to provide deep insights into system-level performance for applications running on the ROCm stack. It serves as the GUI to visualize traces collected by ROCm profiling tools, specifically ROCm Systems Profiler, enabling developers to analyze traces, identify bottlenecks, optimize workloads, and efficiently scale applications across CPUs and GPUs.
+
 Development
 ^^^^^^^^^^^
 

--- a/docs/what-is-rocm.rst
+++ b/docs/what-is-rocm.rst
@@ -123,9 +123,8 @@ Performance
 
 .. note::
 
-  - `ROCprof Compute Viewer <https://rocm.docs.amd.com/projects/rocprof-compute-viewer/en/amd-mainline/>`_ is a tool for visualizing and analyzing GPU thread trace data collected using :doc:`rocprofv3 <rocprofiler-sdk:index>`.
-  Note that `ROCprof Compute Viewer <https://rocm.docs.amd.com/projects/rocprof-compute-viewer/en/amd-mainline/>`_ is in an early access state. Running production workloads is not recommended.
-  - `ROCm™ Optiq (beta) <https://rocm.docs.amd.com/projects/roc-optiq/en/latest/>`_  provides deep insights into system-level performance for applications running on the ROCm stack. It serves as the GUI to visualize traces collected by ROCm profiling tools, specifically `ROCm Systems Profiler <https://rocm.docs.amd.com/projects/rocprofiler-systems/en/latest/index.html>`_.
+  - `ROCprof Compute Viewer <https://rocm.docs.amd.com/projects/rocprof-compute-viewer/en/amd-mainline/>`_ is a tool for visualizing and analyzing GPU thread trace data collected using :doc:`rocprofv3 <rocprofiler-sdk:index>`. Note that `ROCprof Compute Viewer <https://rocm.docs.amd.com/projects/rocprof-compute-viewer/en/amd-mainline/>`_ is in an early access state. Running production workloads is not recommended.
+  - `ROCm™ Optiq (beta) <https://rocm.docs.amd.com/projects/roc-optiq/en/latest/>`_ provides deep insights into system-level performance for applications running on the ROCm stack. It serves as the GUI to visualize traces collected by ROCm profiling tools, specifically `ROCm Systems Profiler <https://rocm.docs.amd.com/projects/rocprofiler-systems/en/latest/index.html>`_.
 
 Development
 ^^^^^^^^^^^

--- a/docs/what-is-rocm.rst
+++ b/docs/what-is-rocm.rst
@@ -128,7 +128,7 @@ Performance
 
 .. note::
 
-  `ROCm™ Optiq (beta) <https://rocm.docs.amd.com/projects/roc-optiq/en/latest/>` is AMD’s tool designed to provide deep insights into system-level performance for applications running on the ROCm stack. It serves as the GUI to visualize traces collected by ROCm profiling tools, specifically ROCm Systems Profiler, enabling developers to analyze traces, identify bottlenecks, optimize workloads, and efficiently scale applications across CPUs and GPUs.
+  `ROCm™ Optiq (beta) <https://rocm.docs.amd.com/projects/roc-optiq/en/latest/>`_  is AMD’s tool designed to provide deep insights into system-level performance for applications running on the ROCm stack. It serves as the GUI to visualize traces collected by ROCm profiling tools, specifically ROCm Systems Profiler.
 
 Development
 ^^^^^^^^^^^

--- a/docs/what-is-rocm.rst
+++ b/docs/what-is-rocm.rst
@@ -124,7 +124,7 @@ Performance
 .. note::
 
   - `ROCprof Compute Viewer <https://rocm.docs.amd.com/projects/rocprof-compute-viewer/en/amd-mainline/>`_ is a tool for visualizing and analyzing GPU thread trace data collected using :doc:`rocprofv3 <rocprofiler-sdk:index>`. Note that `ROCprof Compute Viewer <https://rocm.docs.amd.com/projects/rocprof-compute-viewer/en/amd-mainline/>`_ is in an early access state. Running production workloads is not recommended.
-  - `ROCm™ Optiq (Beta) <https://rocm.docs.amd.com/projects/roc-optiq/en/latest/>`_ provides deep insights into system-level performance for applications running on the ROCm stack. It serves as the GUI to visualize traces collected by ROCm profiling tools, specifically `ROCm Systems Profiler <https://rocm.docs.amd.com/projects/rocprofiler-systems/en/latest/index.html>`_.
+  - ROCm™ Optiq (Beta)  provides deep insights into system-level performance for applications running on the ROCm stack. It serves as the GUI to visualize traces collected by ROCm profiling tools, specifically `ROCm Systems Profiler <https://rocm.docs.amd.com/projects/rocprofiler-systems/en/latest/index.html>`_.
 
 Development
 ^^^^^^^^^^^

--- a/docs/what-is-rocm.rst
+++ b/docs/what-is-rocm.rst
@@ -124,7 +124,7 @@ Performance
 .. note::
 
   - `ROCprof Compute Viewer <https://rocm.docs.amd.com/projects/rocprof-compute-viewer/en/amd-mainline/>`_ is a tool for visualizing and analyzing GPU thread trace data collected using :doc:`rocprofv3 <rocprofiler-sdk:index>`. Note that `ROCprof Compute Viewer <https://rocm.docs.amd.com/projects/rocprof-compute-viewer/en/amd-mainline/>`_ is in an early access state. Running production workloads is not recommended.
-  - `ROCm™ Optiq (beta) <https://rocm.docs.amd.com/projects/roc-optiq/en/latest/>`_ provides deep insights into system-level performance for applications running on the ROCm stack. It serves as the GUI to visualize traces collected by ROCm profiling tools, specifically `ROCm Systems Profiler <https://rocm.docs.amd.com/projects/rocprofiler-systems/en/latest/index.html>`_.
+  - `ROCm™ Optiq (Beta) <https://rocm.docs.amd.com/projects/roc-optiq/en/latest/>`_ provides deep insights into system-level performance for applications running on the ROCm stack. It serves as the GUI to visualize traces collected by ROCm profiling tools, specifically `ROCm Systems Profiler <https://rocm.docs.amd.com/projects/rocprofiler-systems/en/latest/index.html>`_.
 
 Development
 ^^^^^^^^^^^

--- a/docs/what-is-rocm.rst
+++ b/docs/what-is-rocm.rst
@@ -128,7 +128,7 @@ Performance
 
 .. note::
 
-  `ROCm™ Optiq (beta) <https://rocm.docs.amd.com/projects/roc-optiq/en/latest/>`_  is AMD’s tool designed to provide deep insights into system-level performance for applications running on the ROCm stack. It serves as the GUI to visualize traces collected by ROCm profiling tools, specifically ROCm Systems Profiler.
+  `ROCm™ Optiq (beta) <https://rocm.docs.amd.com/projects/roc-optiq/en/latest/>`_  provides deep insights into system-level performance for applications running on the ROCm stack. It serves as the GUI to visualize traces collected by ROCm profiling tools, specifically ROCm Systems Profiler.
 
 Development
 ^^^^^^^^^^^

--- a/docs/what-is-rocm.rst
+++ b/docs/what-is-rocm.rst
@@ -124,7 +124,7 @@ Performance
 .. note::
 
   - `ROCprof Compute Viewer <https://rocm.docs.amd.com/projects/rocprof-compute-viewer/en/amd-mainline/>`_ is a tool for visualizing and analyzing GPU thread trace data collected using :doc:`rocprofv3 <rocprofiler-sdk:index>`. Note that `ROCprof Compute Viewer <https://rocm.docs.amd.com/projects/rocprof-compute-viewer/en/amd-mainline/>`_ is in an early access state. Running production workloads is not recommended.
-  - ROCm™ Optiq (Beta)  provides deep insights into system-level performance for applications running on the ROCm stack. It serves as the GUI to visualize traces collected by ROCm profiling tools, specifically `ROCm Systems Profiler <https://rocm.docs.amd.com/projects/rocprofiler-systems/en/latest/index.html>`_.
+  - ROCm™ Optiq (Beta) provides deep insights into system-level performance for applications running on the ROCm stack. It serves as the GUI to visualize traces collected by ROCm profiling tools, specifically `ROCm Systems Profiler <https://rocm.docs.amd.com/projects/rocprofiler-systems/en/latest/index.html>`_.
 
 Development
 ^^^^^^^^^^^

--- a/docs/what-is-rocm.rst
+++ b/docs/what-is-rocm.rst
@@ -124,7 +124,7 @@ Performance
 .. note::
 
   - `ROCprof Compute Viewer <https://rocm.docs.amd.com/projects/rocprof-compute-viewer/en/amd-mainline/>`_ is a tool for visualizing and analyzing GPU thread trace data collected using :doc:`rocprofv3 <rocprofiler-sdk:index>`. Note that `ROCprof Compute Viewer <https://rocm.docs.amd.com/projects/rocprof-compute-viewer/en/amd-mainline/>`_ is in an early access state. Running production workloads is not recommended.
-  - ROCm™ Optiq (Beta) provides deep insights into system-level performance for applications running on the ROCm stack. It serves as the GUI to visualize traces collected by ROCm profiling tools, specifically `ROCm Systems Profiler <https://rocm.docs.amd.com/projects/rocprofiler-systems/en/latest/index.html>`_.
+  - ROCm Optiq (Beta) provides deep insights into system-level performance for applications running on the ROCm stack. It serves as the GUI to visualize traces collected by ROCm profiling tools, specifically `ROCm Systems Profiler <https://rocm.docs.amd.com/projects/rocprofiler-systems/en/latest/index.html>`_.
 
 Development
 ^^^^^^^^^^^

--- a/docs/what-is-rocm.rst
+++ b/docs/what-is-rocm.rst
@@ -123,12 +123,9 @@ Performance
 
 .. note::
 
-  `ROCprof Compute Viewer <https://rocm.docs.amd.com/projects/rocprof-compute-viewer/en/amd-mainline/>`_ is a tool for visualizing and analyzing GPU thread trace data collected using :doc:`rocprofv3 <rocprofiler-sdk:index>`.
+  - `ROCprof Compute Viewer <https://rocm.docs.amd.com/projects/rocprof-compute-viewer/en/amd-mainline/>`_ is a tool for visualizing and analyzing GPU thread trace data collected using :doc:`rocprofv3 <rocprofiler-sdk:index>`.
   Note that `ROCprof Compute Viewer <https://rocm.docs.amd.com/projects/rocprof-compute-viewer/en/amd-mainline/>`_ is in an early access state. Running production workloads is not recommended.
-
-.. note::
-
-  `ROCm™ Optiq (beta) <https://rocm.docs.amd.com/projects/roc-optiq/en/latest/>`_  provides deep insights into system-level performance for applications running on the ROCm stack. It serves as the GUI to visualize traces collected by ROCm profiling tools, specifically `ROCm Systems Profiler <https://rocm.docs.amd.com/projects/rocprofiler-systems/en/latest/index.html>`_.
+  - `ROCm™ Optiq (beta) <https://rocm.docs.amd.com/projects/roc-optiq/en/latest/>`_  provides deep insights into system-level performance for applications running on the ROCm stack. It serves as the GUI to visualize traces collected by ROCm profiling tools, specifically `ROCm Systems Profiler <https://rocm.docs.amd.com/projects/rocprofiler-systems/en/latest/index.html>`_.
 
 Development
 ^^^^^^^^^^^


### PR DESCRIPTION
## Motivation

Adding a note for a link to the Optiq docs

## Technical Details

Need to add a link here in a note since Optiq isn't a part of the ROCm stack (yet), and thus can't be added to the normal spaces for components. Optiq will be added to the ROCm stack in a later release. 
