### PR TITLE
[docs/7.10.0] Fix typo in venv command and installation prerequisites

### DIFF
--- a/docs/install/includes/install.rst
+++ b/docs/install/includes/install.rst
@@ -101,7 +101,7 @@ Use the following instructions to install the ROCm Core SDK on your system.
          .. code-block:: bash
 
             python3.12 -m venv .venv
-            source ./venv/bin/activate
+            source ./.venv/bin/activate
 
       .. selected:: os-version=22
 
@@ -111,7 +111,7 @@ Use the following instructions to install the ROCm Core SDK on your system.
          .. code-block:: bash
 
             python3.11 -m venv .venv
-            source ./venv/bin/activate
+            source ./.venv/bin/activate
 
    .. selected:: os=rhel
 
@@ -123,7 +123,7 @@ Use the following instructions to install the ROCm Core SDK on your system.
          .. code-block:: bash
 
             python3.12 -m venv .venv
-            source ./venv/bin/activate
+            source ./.venv/bin/activate
 
       .. selected:: os-version=9.7 os-version=9.6
 
@@ -133,7 +133,7 @@ Use the following instructions to install the ROCm Core SDK on your system.
          .. code-block:: bash
 
             python3.11 -m venv .venv
-            source ./venv/bin/activate
+            source ./.venv/bin/activate
 
       .. selected:: os-version=8
 
@@ -143,7 +143,7 @@ Use the following instructions to install the ROCm Core SDK on your system.
          .. code-block:: bash
 
             python3.11 -m venv .venv
-            source ./venv/bin/activate
+            source ./.venv/bin/activate
 
    .. selected:: os=sles
 
@@ -153,7 +153,7 @@ Use the following instructions to install the ROCm Core SDK on your system.
       .. code-block:: bash
 
          python3.11 -m venv .venv
-         source ./venv/bin/activate
+         source ./.venv/bin/activate
 
    .. selected:: os=windows
 

--- a/docs/install/includes/prerequisites.rst
+++ b/docs/install/includes/prerequisites.rst
@@ -7,6 +7,49 @@ configuring permissions for GPU access. To confirm that your system is
 supported, see the :doc:`Compatibility matrix
 </compatibility/compatibility-matrix>`.
 
+.. selected:: os=ubuntu os=rhel os=sles
+
+   .. dropdown:: Install essential packages for Docker containers
+      :animate: fade-in-slide-down
+      :color: info
+      :icon: tools
+      :chevron: down-up
+
+      Docker images often include only a minimal set of installations, so some
+      essential packages might be missing. When installing ROCm within a Docker
+      container, you might need to install additional packages for a successful
+      installation.
+
+      If applicable, run the following command to install essential packages:
+
+      .. selected:: os=ubuntu
+
+         .. code-block:: bash
+
+            apt update
+            apt install sudo wget python3 libatomic1
+
+      .. selected:: os=rhel
+
+         .. selected:: os-version=10.1 os-version=10.0 os-version=9.7 os-version=9.6
+
+            .. code-block:: bash
+
+               dnf install sudo wget libatomic
+
+         .. selected:: os-version=8
+
+            .. code-block:: bash
+
+               dnf install sudo wget libatomic python3
+
+      .. selected:: os=sles
+
+         .. code-block:: bash
+
+            zypper install sudo libatomic1 libgfortran5 wget SUSEConnect python3
+
+
 .. selected:: os=windows
 
     1. Remove any existing HIP SDK for Windows installations and other
@@ -48,10 +91,18 @@ supported, see the :doc:`Compatibility matrix
 
    Run the following command to register your system:
 
-   .. code-block:: bash
+   .. selected:: os-version=10.1 os-version=10.0
 
-      subscription-manager register --username <username> --password <password>
-      subscription-manager attach --auto
+      .. code-block:: bash
+
+         subscription-manager register --username <username> --password <password>
+
+   .. selected:: os-version=9.7 os-version=9.6 os-version=8
+
+      .. code-block:: bash
+
+         subscription-manager register --username <username> --password <password>
+         subscription-manager attach --auto
 
 .. selected:: os=sles
    :heading: Register your SUSE Linux Enterprise Server system
@@ -117,41 +168,6 @@ supported, see the :doc:`Compatibility matrix
    .. code-block:: bash
 
       sudo zypper update
-
-.. selected:: os=ubuntu os=rhel os=sles
-
-   |
-   .. dropdown:: Install essential packages for Docker containers
-      :animate: fade-in-slide-down
-      :color: info
-      :icon: tools
-      :chevron: down-up
-
-      Docker images often include only a minimal set of installations, so some
-      essential packages might be missing. When installing ROCm within a Docker
-      container, you might need to install additional packages for a successful
-      installation.
-
-      If applicable, run the following command to install essential packages:
-
-      .. selected:: os=ubuntu
-
-         .. code-block:: bash
-
-            apt update
-            apt install sudo wget python3 libatomic1
-
-      .. selected:: os=rhel
-
-         .. code-block:: bash
-
-            dnf install sudo wget libatomic
-
-      .. selected:: os=sles
-
-         .. code-block:: bash
-
-            zypper install sudo libatomic1 libgfortran5
 
 .. selected:: i=pip
 

--- a/docs/rocm-for-ai/pytorch-comfyui.rst
+++ b/docs/rocm-for-ai/pytorch-comfyui.rst
@@ -255,7 +255,7 @@ Install and run ComfyUI
          To see the GUI go to: http://127.0.0.1:8188
 
    b. Navigate to ``http://127.0.0.1:8188`` in your web browser. You might need to
-      replace `8188` with the appropriate port number.
+      replace ``8188`` with the appropriate port number.
 
       .. image:: /data/comfyui/comfyui-main.png
          :align: center


### PR DESCRIPTION
## Motivation

Fix typo in venv command: `source ./venv/...` --> `source ./.venv/...`

Remove extra `subscription-manager --attach-auto` from RHEL 10.1 and RHEL 10.0

Update essential packages for Docker environments for SLES and RHEL 8.10. Move Docker prerequisites to the top of the page.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
