### PR TITLE
[origami] Fix skipping of origami tests

### DIFF
--- a/.azuredevops/components/origami.yml
+++ b/.azuredevops/components/origami.yml
@@ -169,7 +169,6 @@ jobs:
       dependsOn: origami_build_${{ job.os }}
       condition:
         and(succeeded(),
-          eq(variables['ENABLE_${{ upper(job.target) }}_TESTS'], 'true'),
           not(containsValue(split(variables['DISABLED_${{ upper(job.target) }}_TESTS'], ','), '${{ parameters.componentName }}')),
           eq(${{ parameters.aggregatePipeline }}, False)
         )


### PR DESCRIPTION
## Motivation

origami_tests are being skipped.

## Technical Details

Removed a condition from origami_test job. This is for the revert PR only.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
