### PR TITLE
[External CI] Add SIMDe dev package to HIP runtime pipeline

### DIFF
--- a/.azuredevops/components/HIP.yml
+++ b/.azuredevops/components/HIP.yml
@@ -34,6 +34,7 @@ parameters:
   default:
     - cmake
     - libnuma-dev
+    - libsimde-dev
     - mesa-common-dev
     - ninja-build
     - ocl-icd-libopencl1


### PR DESCRIPTION
Latest clr/HIP looks for SIMDe on environment. Adding `libsimde-dev` in list of packages installed via apt.