### PR TITLE
Fix Azure failures introduced by hipsparse build system refactor

### DIFF
--- a/.azuredevops/components/hipSPARSE.yml
+++ b/.azuredevops/components/hipSPARSE.yml
@@ -177,11 +177,11 @@ jobs:
         clean: all
       steps:
       - checkout: none
+      - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-cmake-custom.yml
       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
         parameters:
           aptPackages: ${{ parameters.aptPackages }}
           packageManager: ${{ job.packageManager }}
-      - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-cmake-custom.yml
       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/local-artifact-download.yml
         parameters:

--- a/.azuredevops/components/hipSPARSE.yml
+++ b/.azuredevops/components/hipSPARSE.yml
@@ -38,6 +38,7 @@ parameters:
     - libfftw3-dev
     - ninja-build
     - python3-pip
+    - libopenblas-dev
 - name: rocmDependencies
   type: object
   default:

--- a/.azuredevops/components/hipSPARSE.yml
+++ b/.azuredevops/components/hipSPARSE.yml
@@ -41,6 +41,7 @@ parameters:
 - name: rocmDependencies
   type: object
   default:
+    - aomp
     - clr
     - llvm-project
     - rocminfo
@@ -50,6 +51,7 @@ parameters:
 - name: rocmTestDependencies
   type: object
   default:
+    - aomp
     - clr
     - llvm-project
     - hipBLAS-common

--- a/.azuredevops/components/hipSPARSE.yml
+++ b/.azuredevops/components/hipSPARSE.yml
@@ -38,7 +38,6 @@ parameters:
     - libfftw3-dev
     - ninja-build
     - python3-pip
-    - libopenblas-dev
 - name: rocmDependencies
   type: object
   default:
@@ -131,6 +130,7 @@ jobs:
           -DCMAKE_PREFIX_PATH=$(Agent.BuildDirectory)/rocm;$(Agent.BuildDirectory)/vendor
           -DCMAKE_CXX_COMPILER=$(Agent.BuildDirectory)/rocm/llvm/bin/amdclang++
           -DCMAKE_C_COMPILER=$(Agent.BuildDirectory)/rocm/bin/amdclang
+          -DCMAKE_Fortran_COMPILER=gfortran
           -DCMAKE_BUILD_TYPE=Release
           -DBUILD_CLIENTS_TESTS=ON
           -DBUILD_CLIENTS_SAMPLES=OFF

--- a/.azuredevops/components/hipSPARSE.yml
+++ b/.azuredevops/components/hipSPARSE.yml
@@ -102,6 +102,7 @@ jobs:
       parameters:
         aptPackages: ${{ parameters.aptPackages }}
         packageManager: ${{ job.packageManager }}
+    - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-cmake-custom.yml
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
     - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/checkout.yml
       parameters:
@@ -177,7 +178,6 @@ jobs:
         clean: all
       steps:
       - checkout: none
-      - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-cmake-custom.yml
       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-other.yml
         parameters:
           aptPackages: ${{ parameters.aptPackages }}

--- a/.azuredevops/components/hipSPARSE.yml
+++ b/.azuredevops/components/hipSPARSE.yml
@@ -32,7 +32,6 @@ parameters:
 - name: aptPackages
   type: object
   default:
-    - cmake
     - gfortran
     - git
     - libboost-program-options-dev
@@ -182,6 +181,7 @@ jobs:
         parameters:
           aptPackages: ${{ parameters.aptPackages }}
           packageManager: ${{ job.packageManager }}
+      - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/dependencies-cmake-custom.yml
       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/preamble.yml
       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/local-artifact-download.yml
         parameters:


### PR DESCRIPTION
## Motivation

hipsparse is failing due to cmake version.

## Technical Details

Use the custom cmake install rather than system package.

## Test Plan

Run standard pipelines.

## Test Result


## Submission Checklist

- [ x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
