### PR TITLE
Update Deep Frameworks to use intersphinx links where possible

### DIFF
--- a/docs/how-to/deep-learning-rocm.rst
+++ b/docs/how-to/deep-learning-rocm.rst
@@ -10,7 +10,7 @@ Deep learning frameworks provide environments for machine learning, training, fi
 
 ROCm offers a complete ecosystem for developing and running deep learning applications efficiently. It also provides ROCm-compatible versions of popular frameworks and libraries, such as PyTorch, TensorFlow, JAX, and others.
 
-The AMD ROCm organization actively contributes to open-source development and collaborates closely with framework organizations. This collaboration ensures that framework-specific optimizations effectively leverage AMD GPUs and accelerators.
+The AMD ROCm organization actively contributes to open-source development and collaborates closely with framework organizations. This collaboration ensures that framework-specific optimizations effectively leverage AMD GPUs.
 
 The table below summarizes information about ROCm-enabled deep learning frameworks. It includes details on ROCm compatibility and third-party tool support, installation steps and options, and links to GitHub resources. For a complete list of supported framework versions on ROCm, see the :doc:`Compatibility matrix <../compatibility/compatibility-matrix>` topic.
 

--- a/docs/how-to/deep-learning-rocm.rst
+++ b/docs/how-to/deep-learning-rocm.rst
@@ -10,7 +10,7 @@ Deep learning frameworks provide environments for machine learning, training, fi
 
 ROCm offers a complete ecosystem for developing and running deep learning applications efficiently. It also provides ROCm-compatible versions of popular frameworks and libraries, such as PyTorch, TensorFlow, JAX, and others.
 
-The AMD ROCm organization actively contributes to open-source development and collaborates closely with framework organizations. This collaboration ensures that framework-specific optimizations effectively leverage AMD GPUs.
+The AMD ROCm organization actively contributes to open-source development and collaborates closely with framework organizations. This collaboration ensures that framework-specific optimizations effectively leverage AMD GPUs and accelerators.
 
 The table below summarizes information about ROCm-enabled deep learning frameworks. It includes details on ROCm compatibility and third-party tool support, installation steps and options, and links to GitHub resources. For a complete list of supported framework versions on ROCm, see the :doc:`Compatibility matrix <../compatibility/compatibility-matrix>` topic.
 
@@ -19,117 +19,104 @@ The table below summarizes information about ROCm-enabled deep learning framewor
     :widths: 5 3 6 3
 
     * - Framework
-      - Installation
+      - Installation guide
       - Installation options
       - GitHub
 
-    * - `PyTorch <https://rocm.docs.amd.com/en/latest/compatibility/ml-compatibility/pytorch-compatibility.html>`__
-      - .. raw:: html
-
-          <a href="https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/pytorch-install.html"><i class="fas fa-link fa-lg"></i></a>
+    * - :doc:`PyTorch <../compatibility/ml-compatibility/pytorch-compatibility>`
+      - :doc:`Pytorch install <rocm-install-on-linux:install/3rd-party/pytorch-install>`
       - 
-        - `Docker image <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/pytorch-install.html#using-a-docker-image-with-pytorch-pre-installed>`__
-        - `Wheels package <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/pytorch-install.html#using-a-wheels-package>`__
-        - `ROCm Base Docker image <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/pytorch-install.html#using-the-pytorch-rocm-base-docker-image>`__
-        - `Upstream Docker file <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/pytorch-install.html#using-the-pytorch-upstream-dockerfile>`__
+        - Docker image
+        - Wheels package
+        - ROCm Base Docker image
+        - Upstream Docker file
       - .. raw:: html
 
           <a href="https://github.com/ROCm/pytorch"><i class="fab fa-github fa-lg"></i></a>
 
-    * - `TensorFlow <https://rocm.docs.amd.com/en/latest/compatibility/ml-compatibility/tensorflow-compatibility.html>`__
-      - .. raw:: html
-
-          <a href="https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/tensorflow-install.html"><i class="fas fa-link fa-lg"></i></a>
+    * - :doc:`TensorFlow <../compatibility/ml-compatibility/tensorflow-compatibility>`
+      - :doc:`TensorFlow install <rocm-install-on-linux:install/3rd-party/tensorflow-install>`
       - 
-        - `Docker image <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/tensorflow-install.html#using-a-docker-image-with-tensorflow-pre-installed>`__
-        - `Wheels package <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/tensorflow-install.html#using-a-wheels-package>`__
+        - Docker image
+        - Wheels package
 
       - .. raw:: html
 
           <a href="https://github.com/ROCm/tensorflow-upstream"><i class="fab fa-github fa-lg"></i></a> 
 
-    * - `JAX <https://rocm.docs.amd.com/en/latest/compatibility/ml-compatibility/jax-compatibility.html>`__
-      - .. raw:: html
-
-          <a href="https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/jax-install.html"><i class="fas fa-link fa-lg"></i></a>
+    * - :doc:`JAX <../compatibility/ml-compatibility/jax-compatibility>`
+      - :doc:`JAX install <rocm-install-on-linux:install/3rd-party/jax-install>`
       - 
-        - `Docker image <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/jax-install.html#using-a-prebuilt-docker-image>`__
+        - Docker image
       - .. raw:: html
 
           <a href="https://github.com/ROCm/jax"><i class="fab fa-github fa-lg"></i></a>
 
-    * - `verl <https://rocm.docs.amd.com/en/latest/compatibility/ml-compatibility/verl-compatibility.html>`__
-      - .. raw:: html
-
-          <a href="https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/verl-install.html"><i class="fas fa-link fa-lg"></i></a>
+    * - :doc:`verl <../compatibility/ml-compatibility/verl-compatibility>`
+      - :doc:`verl install <rocm-install-on-linux:install/3rd-party/verl-install>`
       - 
-        - `Docker image <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/verl-install.html#use-a-prebuilt-docker-image-with-verl-pre-installed>`__
+        - Docker image
       - .. raw:: html
 
           <a href="https://github.com/ROCm/verl"><i class="fab fa-github fa-lg"></i></a>
 
-    * - `Stanford Megatron-LM <https://rocm.docs.amd.com/en/latest/compatibility/ml-compatibility/stanford-megatron-lm-compatibility.html>`__
-      - .. raw:: html
-
-          <a href="https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/stanford-megatron-lm-install.html"><i class="fas fa-link fa-lg"></i></a>
+    * - :doc:`Stanford Megatron-LM <../compatibility/ml-compatibility/stanford-megatron-lm-compatibility>`
+      - :doc:`Stanford Megatron-LM install <rocm-install-on-linux:install/3rd-party/stanford-megatron-lm-install>`
       - 
-        - `Docker image <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/stanford-megatron-lm-install.html#use-a-prebuilt-docker-image-with-stanford-megatron-lm-pre-installed>`__
+        - Docker image
       - .. raw:: html
 
           <a href="https://github.com/ROCm/Stanford-Megatron-LM"><i class="fab fa-github fa-lg"></i></a>
 
-    * - `DGL <https://rocm.docs.amd.com/en/latest/compatibility/ml-compatibility/dgl-compatibility.html>`__
-      - .. raw:: html
-
-          <a href="https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/dgl-install.html"><i class="fas fa-link fa-lg"></i></a>
+    * - :doc:`DGL <../compatibility/ml-compatibility/dgl-compatibility>`
+      - :doc:`DGL install <rocm-install-on-linux:install/3rd-party/dgl-install>`
       - 
-        - `Docker image <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/dgl-install.html#use-a-prebuilt-docker-image-with-dgl-pre-installed>`__
-        - `Wheels package <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/dgl-install.html#use-a-wheels-package>`__
-
+        - Docker image
       - .. raw:: html
 
           <a href="https://github.com/ROCm/dgl"><i class="fab fa-github fa-lg"></i></a> 
 
-    * - `Megablocks <https://rocm.docs.amd.com/en/latest/compatibility/ml-compatibility/megablocks-compatibility.html>`__
-      - .. raw:: html
-
-          <a href="https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/megablocks-install.html"><i class="fas fa-link fa-lg"></i></a>
+    * - :doc:`Megablocks <../compatibility/ml-compatibility/megablocks-compatibility>`
+      - :doc:`Megablocks install <rocm-install-on-linux:install/3rd-party/megablocks-install>`
       - 
-        - `Docker image <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/megablocks-install.html#using-a-prebuilt-docker-image-with-megablocks-pre-installed>`__
+        - Docker image
       - .. raw:: html
 
           <a href="https://github.com/ROCm/megablocks"><i class="fab fa-github fa-lg"></i></a>
 
-    * - `Ray <https://rocm.docs.amd.com/en/latest/compatibility/ml-compatibility/ray-compatibility.html>`__
+    * - :doc:`Taichi <../compatibility/ml-compatibility/taichi-compatibility>`
+      - `Taichi install <https://rocm.docs.amd.com/projects/taichi/en/latest/install/taichi-install.html>`__
+      - 
+        - Docker image
+        - Wheels package
       - .. raw:: html
 
-          <a href="https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/ray-install.html"><i class="fas fa-link fa-lg"></i></a>
+          <a href="https://github.com/ROCm/taichi"><i class="fab fa-github fa-lg"></i></a>
+
+    * - :doc:`Ray <../compatibility/ml-compatibility/ray-compatibility>`
+      - :doc:`Ray install <rocm-install-on-linux:install/3rd-party/ray-install>`
       - 
-        - `Docker image <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/ray-install.html#using-a-prebuilt-docker-image-with-ray-pre-installed>`__
-        - `Wheels package <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/ray-install.html#install-ray-on-bare-metal-or-a-custom-container>`__
-        - `ROCm Base Docker image <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/ray-install.html#build-your-own-docker-image>`__
+        - Docker image
+        - Wheels package
+        - ROCm Base Docker image
       - .. raw:: html
 
           <a href="https://github.com/ROCm/ray"><i class="fab fa-github fa-lg"></i></a>
 
-    * - `llama.cpp <https://rocm.docs.amd.com/en/latest/compatibility/ml-compatibility/llama-cpp-compatibility.html>`__
-      - .. raw:: html
-
-          <a href="https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/llama-cpp-install.html"><i class="fas fa-link fa-lg"></i></a>
+    * - :doc:`llama.cpp <../compatibility/ml-compatibility/llama-cpp-compatibility>`
+      - :doc:`llama.cpp install <rocm-install-on-linux:install/3rd-party/llama-cpp-install>`
       - 
-        - `Docker image <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/llama-cpp-install.html#use-a-prebuilt-docker-image-with-llama-cpp-pre-installed>`__
-        - `ROCm Base Docker image <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/llama-cpp-install.html#build-your-own-docker-image>`__
+        - Docker image
+        - ROCm Base Docker image
       - .. raw:: html
 
           <a href="https://github.com/ROCm/llama.cpp"><i class="fab fa-github fa-lg"></i></a>
 
-    * - `FlashInfer <https://rocm.docs.amd.com/en/latest/compatibility/ml-compatibility/flashinfer-compatibility.html>`__
-      - .. raw:: html
-
-          <a href="https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/flashinfer-install.html"><i class="fas fa-link fa-lg"></i></a>
+    * - :doc:`FlashInfer <../compatibility/ml-compatibility/flashinfer-compatibility>`
+      - :doc:`FlashInfer install <rocm-install-on-linux:install/3rd-party/flashinfer-install>`
       - 
-        - `Docker image <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/flashinfer-install.html#use-a-prebuilt-docker-image-with-flashinfer-pre-installed>`__
-        - `ROCm Base Docker image <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/flashinfer-install.html#build-your-own-docker-image>`__
+        - Docker image
+        - ROCm Base Docker image
       - .. raw:: html
 
           <a href="https://github.com/ROCm/flashinfer"><i class="fab fa-github fa-lg"></i></a>

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -99,7 +99,7 @@ subtrees:
               - file: how-to/rocm-for-ai/fine-tuning/single-gpu-fine-tuning-and-inference.rst
                 title: Use a single GPU
               - file: how-to/rocm-for-ai/fine-tuning/multi-gpu-fine-tuning-and-inference.rst
-                title: Use multiple accelerators
+                title: Use multiple GPUs
 
       - file: how-to/rocm-for-ai/inference/index.rst
         title: Inference

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -97,7 +97,7 @@ subtrees:
             subtrees:
             - entries:
               - file: how-to/rocm-for-ai/fine-tuning/single-gpu-fine-tuning-and-inference.rst
-                title: Use a single accelerator
+                title: Use a single GPU
               - file: how-to/rocm-for-ai/fine-tuning/multi-gpu-fine-tuning-and-inference.rst
                 title: Use multiple accelerators
 

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -25,29 +25,31 @@ subtrees:
     title: HIP SDK on Windows
   - url: https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/index.html
     title: ROCm on Radeon and Ryzen
-  - file: how-to/deep-learning-rocm.md
+  - file: how-to/deep-learning-rocm
     title: Deep learning frameworks
     subtrees:
     - entries:
-      - file: compatibility/ml-compatibility/pytorch-compatibility.rst
+      - file: compatibility/ml-compatibility/pytorch-compatibility
         title: PyTorch compatibility
-      - file: compatibility/ml-compatibility/tensorflow-compatibility.rst
+      - file: compatibility/ml-compatibility/tensorflow-compatibility
         title: TensorFlow compatibility
-      - file: compatibility/ml-compatibility/jax-compatibility.rst
+      - file: compatibility/ml-compatibility/jax-compatibility
         title: JAX compatibility
-      - file: compatibility/ml-compatibility/verl-compatibility.rst
+      - file: compatibility/ml-compatibility/verl-compatibility
         title: verl compatibility
-      - file: compatibility/ml-compatibility/stanford-megatron-lm-compatibility.rst
+      - file: compatibility/ml-compatibility/stanford-megatron-lm-compatibility
         title: Stanford Megatron-LM compatibility
-      - file: compatibility/ml-compatibility/dgl-compatibility.rst
+      - file: compatibility/ml-compatibility/dgl-compatibility
         title: DGL compatibility
-      - file: compatibility/ml-compatibility/megablocks-compatibility.rst
+      - file: compatibility/ml-compatibility/megablocks-compatibility
         title: Megablocks compatibility
-      - file: compatibility/ml-compatibility/ray-compatibility.rst
+      - file: compatibility/ml-compatibility/taichi-compatibility
+        title: Taichi compatibility
+      - file: compatibility/ml-compatibility/ray-compatibility
         title: Ray compatibility
-      - file: compatibility/ml-compatibility/llama-cpp-compatibility.rst
+      - file: compatibility/ml-compatibility/llama-cpp-compatibility
         title: llama.cpp compatibility
-      - file: compatibility/ml-compatibility/flashinfer-compatibility.rst
+      - file: compatibility/ml-compatibility/flashinfer-compatibility
         title: FlashInfer compatibility
   - file: how-to/build-rocm.rst
     title: Build ROCm from source
@@ -75,14 +77,8 @@ subtrees:
         - entries:
           - file: how-to/rocm-for-ai/training/benchmark-docker/primus-megatron.rst
             title: Train a model with Primus and Megatron-LM
-            entries:
-            - file: how-to/rocm-for-ai/training/benchmark-docker/megatron-lm.rst
-              title: Train a model with Megatron-LM
           - file: how-to/rocm-for-ai/training/benchmark-docker/primus-pytorch.rst
             title: Train a model with Primus and PyTorch
-            entries:
-            - file: how-to/rocm-for-ai/training/benchmark-docker/pytorch-training.rst
-              title: Train a model with PyTorch
           - file: how-to/rocm-for-ai/training/benchmark-docker/jax-maxtext.rst
             title: Train a model with JAX MaxText
           - file: how-to/rocm-for-ai/training/benchmark-docker/mpt-llm-foundry
@@ -101,9 +97,9 @@ subtrees:
             subtrees:
             - entries:
               - file: how-to/rocm-for-ai/fine-tuning/single-gpu-fine-tuning-and-inference.rst
-                title: Use a single GPU
+                title: Use a single accelerator
               - file: how-to/rocm-for-ai/fine-tuning/multi-gpu-fine-tuning-and-inference.rst
-                title: Use multiple GPUs
+                title: Use multiple accelerators
 
       - file: how-to/rocm-for-ai/inference/index.rst
         title: Inference
@@ -121,8 +117,6 @@ subtrees:
             title: SGLang inference performance testing
           - file: how-to/rocm-for-ai/inference/benchmark-docker/sglang-distributed.rst
             title: SGLang distributed inference with Mooncake
-          - file: how-to/rocm-for-ai/inference/xdit-diffusion-inference.rst
-            title: xDiT diffusion inference
           - file: how-to/rocm-for-ai/inference/deploy-your-model.rst
             title: Deploy your model
 
@@ -140,8 +134,6 @@ subtrees:
             title: Profile and debug
           - file: how-to/rocm-for-ai/inference-optimization/workload.rst
             title: Workload optimization
-          - file: how-to/rocm-for-ai/inference-optimization/vllm-optimization.rst
-            title: vLLM V1 performance optimization
 
       - url: https://rocm.docs.amd.com/projects/ai-developer-hub/en/latest/
         title: AI tutorials
@@ -188,7 +180,7 @@ subtrees:
           - file: conceptual/gpu-arch/mi300-mi200-performance-counters.rst
             title: MI300 and MI200 performance counters
           - file: conceptual/gpu-arch/mi350-performance-counters.rst
-            title: MI350 Series performance counters
+            title: MI350 series performance counters
       - file: conceptual/gpu-arch/mi250.md
         title: MI250 microarchitecture
         subtrees:
@@ -222,8 +214,6 @@ subtrees:
     title: ROCm tools, compilers, and runtimes
   - file: reference/gpu-arch-specs.rst
   - file: reference/gpu-atomics-operation.rst
-  - file: reference/env-variables.rst
-    title: Environment variables
   - file: reference/precision-support.rst
     title: Data types and precision support
   - file: reference/graph-safe-support.rst


### PR DESCRIPTION
## Motivation

Update the how-to/deep-learning-rocm table to use intersphinx links where available. 
Taichi needs to be added to project.yaml
