### PR TITLE
Use intersphinx links for deep learning (#5859)

### DIFF
--- a/docs/how-to/deep-learning-rocm.rst
+++ b/docs/how-to/deep-learning-rocm.rst
@@ -19,117 +19,95 @@ The table below summarizes information about ROCm-enabled deep learning framewor
     :widths: 5 3 6 3
 
     * - Framework
-      - Installation
+      - Installation guide
       - Installation options
       - GitHub
 
-    * - `PyTorch <https://rocm.docs.amd.com/en/latest/compatibility/ml-compatibility/pytorch-compatibility.html>`__
-      - .. raw:: html
-
-          <a href="https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/pytorch-install.html"><i class="fas fa-link fa-lg"></i></a>
+    * - :doc:`PyTorch <../compatibility/ml-compatibility/pytorch-compatibility>`
+      - :doc:`link <rocm-install-on-linux:install/3rd-party/pytorch-install>`
       - 
-        - `Docker image <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/pytorch-install.html#using-a-docker-image-with-pytorch-pre-installed>`__
-        - `Wheels package <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/pytorch-install.html#using-a-wheels-package>`__
-        - `ROCm Base Docker image <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/pytorch-install.html#using-the-pytorch-rocm-base-docker-image>`__
-        - `Upstream Docker file <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/pytorch-install.html#using-the-pytorch-upstream-dockerfile>`__
+        - Docker image
+        - Wheels package
+        - ROCm Base Docker image
+        - Upstream Docker file
       - .. raw:: html
 
           <a href="https://github.com/ROCm/pytorch"><i class="fab fa-github fa-lg"></i></a>
 
-    * - `TensorFlow <https://rocm.docs.amd.com/en/latest/compatibility/ml-compatibility/tensorflow-compatibility.html>`__
-      - .. raw:: html
-
-          <a href="https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/tensorflow-install.html"><i class="fas fa-link fa-lg"></i></a>
+    * - :doc:`TensorFlow <../compatibility/ml-compatibility/tensorflow-compatibility>`
+      - :doc:`link <rocm-install-on-linux:install/3rd-party/tensorflow-install>`
       - 
-        - `Docker image <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/tensorflow-install.html#using-a-docker-image-with-tensorflow-pre-installed>`__
-        - `Wheels package <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/tensorflow-install.html#using-a-wheels-package>`__
+        - Docker image
+        - Wheels package
 
       - .. raw:: html
 
           <a href="https://github.com/ROCm/tensorflow-upstream"><i class="fab fa-github fa-lg"></i></a> 
 
-    * - `JAX <https://rocm.docs.amd.com/en/latest/compatibility/ml-compatibility/jax-compatibility.html>`__
-      - .. raw:: html
-
-          <a href="https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/jax-install.html"><i class="fas fa-link fa-lg"></i></a>
+    * - :doc:`JAX <../compatibility/ml-compatibility/jax-compatibility>`
+      - :doc:`link <rocm-install-on-linux:install/3rd-party/jax-install>`
       - 
-        - `Docker image <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/jax-install.html#using-a-prebuilt-docker-image>`__
+        - Docker image
       - .. raw:: html
 
           <a href="https://github.com/ROCm/jax"><i class="fab fa-github fa-lg"></i></a>
 
-    * - `verl <https://rocm.docs.amd.com/en/latest/compatibility/ml-compatibility/verl-compatibility.html>`__
-      - .. raw:: html
-
-          <a href="https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/verl-install.html"><i class="fas fa-link fa-lg"></i></a>
+    * - :doc:`verl <../compatibility/ml-compatibility/verl-compatibility>`
+      - :doc:`link <rocm-install-on-linux:install/3rd-party/verl-install>`
       - 
-        - `Docker image <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/verl-install.html#use-a-prebuilt-docker-image-with-verl-pre-installed>`__
+        - Docker image
       - .. raw:: html
 
           <a href="https://github.com/ROCm/verl"><i class="fab fa-github fa-lg"></i></a>
 
-    * - `Stanford Megatron-LM <https://rocm.docs.amd.com/en/latest/compatibility/ml-compatibility/stanford-megatron-lm-compatibility.html>`__
-      - .. raw:: html
-
-          <a href="https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/stanford-megatron-lm-install.html"><i class="fas fa-link fa-lg"></i></a>
+    * - :doc:`Stanford Megatron-LM <../compatibility/ml-compatibility/stanford-megatron-lm-compatibility>`
+      - :doc:`link <rocm-install-on-linux:install/3rd-party/stanford-megatron-lm-install>`
       - 
-        - `Docker image <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/stanford-megatron-lm-install.html#use-a-prebuilt-docker-image-with-stanford-megatron-lm-pre-installed>`__
+        - Docker image
       - .. raw:: html
 
           <a href="https://github.com/ROCm/Stanford-Megatron-LM"><i class="fab fa-github fa-lg"></i></a>
 
-    * - `DGL <https://rocm.docs.amd.com/en/latest/compatibility/ml-compatibility/dgl-compatibility.html>`__
-      - .. raw:: html
-
-          <a href="https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/dgl-install.html"><i class="fas fa-link fa-lg"></i></a>
+    * - :doc:`DGL <../compatibility/ml-compatibility/dgl-compatibility>`
+      - :doc:`link <rocm-install-on-linux:install/3rd-party/dgl-install>`
       - 
-        - `Docker image <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/dgl-install.html#use-a-prebuilt-docker-image-with-dgl-pre-installed>`__
-        - `Wheels package <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/dgl-install.html#use-a-wheels-package>`__
-
+        - Docker image
       - .. raw:: html
 
           <a href="https://github.com/ROCm/dgl"><i class="fab fa-github fa-lg"></i></a> 
 
-    * - `Megablocks <https://rocm.docs.amd.com/en/latest/compatibility/ml-compatibility/megablocks-compatibility.html>`__
-      - .. raw:: html
-
-          <a href="https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/megablocks-install.html"><i class="fas fa-link fa-lg"></i></a>
+    * - :doc:`Megablocks <../compatibility/ml-compatibility/megablocks-compatibility>`
+      - :doc:`link <rocm-install-on-linux:install/3rd-party/megablocks-install>`
       - 
-        - `Docker image <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/megablocks-install.html#using-a-prebuilt-docker-image-with-megablocks-pre-installed>`__
+        - Docker image
       - .. raw:: html
 
           <a href="https://github.com/ROCm/megablocks"><i class="fab fa-github fa-lg"></i></a>
 
-    * - `Ray <https://rocm.docs.amd.com/en/latest/compatibility/ml-compatibility/ray-compatibility.html>`__
-      - .. raw:: html
-
-          <a href="https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/ray-install.html"><i class="fas fa-link fa-lg"></i></a>
+    * - :doc:`Ray <../compatibility/ml-compatibility/ray-compatibility>`
+      - :doc:`link <rocm-install-on-linux:install/3rd-party/ray-install>`
       - 
-        - `Docker image <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/ray-install.html#using-a-prebuilt-docker-image-with-ray-pre-installed>`__
-        - `Wheels package <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/ray-install.html#install-ray-on-bare-metal-or-a-custom-container>`__
-        - `ROCm Base Docker image <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/ray-install.html#build-your-own-docker-image>`__
+        - Docker image
+        - Wheels package
+        - ROCm Base Docker image
       - .. raw:: html
 
           <a href="https://github.com/ROCm/ray"><i class="fab fa-github fa-lg"></i></a>
 
-    * - `llama.cpp <https://rocm.docs.amd.com/en/latest/compatibility/ml-compatibility/llama-cpp-compatibility.html>`__
-      - .. raw:: html
-
-          <a href="https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/llama-cpp-install.html"><i class="fas fa-link fa-lg"></i></a>
+    * - :doc:`llama.cpp <../compatibility/ml-compatibility/llama-cpp-compatibility>`
+      - :doc:`link <rocm-install-on-linux:install/3rd-party/llama-cpp-install>`
       - 
-        - `Docker image <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/llama-cpp-install.html#use-a-prebuilt-docker-image-with-llama-cpp-pre-installed>`__
-        - `ROCm Base Docker image <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/llama-cpp-install.html#build-your-own-docker-image>`__
+        - Docker image
+        - ROCm Base Docker image
       - .. raw:: html
 
           <a href="https://github.com/ROCm/llama.cpp"><i class="fab fa-github fa-lg"></i></a>
 
-    * - `FlashInfer <https://rocm.docs.amd.com/en/latest/compatibility/ml-compatibility/flashinfer-compatibility.html>`__
-      - .. raw:: html
-
-          <a href="https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/flashinfer-install.html"><i class="fas fa-link fa-lg"></i></a>
+    * - :doc:`FlashInfer <../compatibility/ml-compatibility/flashinfer-compatibility>`
+      - :doc:`link <rocm-install-on-linux:install/3rd-party/flashinfer-install>`
       - 
-        - `Docker image <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/flashinfer-install.html#use-a-prebuilt-docker-image-with-flashinfer-pre-installed>`__
-        - `ROCm Base Docker image <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/flashinfer-install.html#build-your-own-docker-image>`__
+        - Docker image
+        - ROCm Base Docker image
       - .. raw:: html
 
           <a href="https://github.com/ROCm/flashinfer"><i class="fab fa-github fa-lg"></i></a>

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -25,7 +25,7 @@ subtrees:
     title: HIP SDK on Windows
   - url: https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/index.html
     title: ROCm on Radeon and Ryzen
-  - file: how-to/deep-learning-rocm.md
+  - file: how-to/deep-learning-rocm
     title: Deep learning frameworks
     subtrees:
     - entries:


### PR DESCRIPTION
* Use intersphinx links for deep learning

* Update deep-learning-rocm.rst

remove Taichi

* Update deep-learning-rocm.rst

Change Install link to "link"

* Apply suggestion from @randyh62
