### PR TITLE
[origami] Replace old python bindings target with new target

### DIFF
--- a/.azuredevops/components/origami.yml
+++ b/.azuredevops/components/origami.yml
@@ -239,7 +239,7 @@ jobs:
           targetType: inline
           workingDirectory: build
           script: |
-            cmake --build . --target origami-tests origami_python -- -j$(nproc)
+            cmake --build . --target origami-tests _pyorigami -- -j$(nproc)
       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/gpu-diagnostics.yml
       # Run tests using CTest (discovers and runs both C++ and Python tests)
       - template: ${{ variables.CI_TEMPLATE_PATH }}/steps/test.yml


### PR DESCRIPTION
## Motivation

The `origami_python` target was removed from origami's python/CMakeLists.txt and was replaced by `_pyorigami`. This change updates the CI to use the new `_pyorigami` target.

## Technical Details

Changed the CMake build target from `origami_python` to `_pyorigami` in origami.yml.

## Test Plan

Run pipeline against tip of develop in rocm-libraries.

## Test Result

All tests pass: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=90668&view=results

## Submission Checklist

- [x ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
