### PR TITLE
AzureCI: MIVisionX - Remove MIOpen & MIGraphX deps for build and test

### DIFF
--- a/.azuredevops/components/MIVisionX.yml
+++ b/.azuredevops/components/MIVisionX.yml
@@ -62,14 +62,9 @@ parameters:
 - name: rocmDependencies
   type: object
   default:
-    - AMDMIGraphX
     - clr
     - half
-    - hipBLAS-common
-    - hipBLASLt
     - llvm-project
-    - MIOpen
-    - rocBLAS
     - rocDecode
     - rocm-cmake
     - rocminfo
@@ -82,12 +77,7 @@ parameters:
     - aomp
     - clr
     - half
-    - hipBLAS-common
-    - hipBLASLt
     - llvm-project
-    - MIOpen
-    - rocBLAS
-    - rocprofiler-register
     - ROCR-Runtime
     - roctracer
     - rpp


### PR DESCRIPTION
## Motivation

Disabling MIOpen due to - rocsparse dependency -- MIVisionX depends on MIOpen and AMDMIGraphX, which both depend on hipBLAS. hipBLAS depends on rocsparse. Since rocsparse pipelines are being disabled, this pipeline must also be disabled.

## Technical Details

Required to build MIVisionX

https://github.com/ROCm/MIVisionX/pull/1608

## Test Plan

CTests

## Test Result

All current tests should pass and MIOpen tests will be disabled

## Submission Checklist

- [ x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
