### PR TITLE
Add torch to origami pip modules

### DIFF
--- a/.azuredevops/components/origami.yml
+++ b/.azuredevops/components/origami.yml
@@ -47,6 +47,7 @@ parameters:
   type: object
   default:
     - nanobind>=2.0.0
+    - numpy
     - pytest
     - pytest-cov
     - torch

--- a/.azuredevops/components/origami.yml
+++ b/.azuredevops/components/origami.yml
@@ -49,6 +49,7 @@ parameters:
     - nanobind>=2.0.0
     - pytest
     - pytest-cov
+    - torch
 - name: rocmDependencies
   type: object
   default:

--- a/.azuredevops/components/origami.yml
+++ b/.azuredevops/components/origami.yml
@@ -102,8 +102,7 @@ jobs:
     - template: /.azuredevops/variables-global.yml
     - name: ROCM_PATH
       value: $(Agent.BuildDirectory)/rocm
-    pool:
-      vmImage: ${{ variables.BASE_BUILD_POOL }}
+    pool: ${{ variables.MEDIUM_BUILD_POOL }}
     ${{ if eq(job.os, 'almalinux8') }}:
       container:
         image: rocmexternalcicd.azurecr.io/manylinux228:latest


### PR DESCRIPTION
## Motivation

Add PyTorch as a pip dependency for origami CI pipeline to support new Python tests that require `import torch`.

## Technical Details

Added `torch` to the `pipModules` parameter default list in `origami.yml`.

## Test Plan

Run pipeline against develop and https://github.com/ROCm/rocm-libraries/pull/3792

## Test Result

Develop: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=92263&view=results
PR: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=91950&view=results

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
