### PR TITLE
[Azure CI] Increase hiptensor build timeout to 120 minutes

### DIFF
--- a/.azuredevops/components/hipTensor.yml
+++ b/.azuredevops/components/hipTensor.yml
@@ -71,6 +71,7 @@ parameters:
 jobs:
 - ${{ each job in parameters.jobMatrix.buildJobs }}:
   - job: ${{ parameters.componentName }}_build_${{ job.target }}
+    timeoutInMinutes: 120
     variables:
     - group: common
     - template: /.azuredevops/variables-global.yml


### PR DESCRIPTION
As advised by @Ryker0627, new features increased build time. See https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=91671&view=logs&j=8e1588ca-cb3a-59d8-71ec-a3db05bbd107&t=0f722c81-0ab6-59f4-0bfc-6443a3f8d8c5