### PR TITLE
docs(jax-maxtext training): remove single-node for llama 3.1 405b

### DIFF
--- a/docs/data/how-to/rocm-for-ai/training/jax-maxtext-benchmark-models.yaml
+++ b/docs/data/how-to/rocm-for-ai/training/jax-maxtext-benchmark-models.yaml
@@ -49,13 +49,13 @@ model_groups:
         model_repo: Llama-3.1-70B
         precision: bf16
         doc_options: ["single-node"]
-      - model: Llama 3.1 405B
+      - model: Llama 3.1 405B (multi-node)
         mad_tag: jax_maxtext_train_llama-3.1-405b
         model_repo: Llama-3.1-405B
         precision: bf16
         multinode_config:
           gfx950: env_scripts/gfx950_llama3_405b.yml
-        doc_options: ["single-node", "multi-node"]
+        doc_options: ["multi-node"]
       - model: Llama 3.3 70B
         mad_tag: jax_maxtext_train_llama-3.3-70b
         model_repo: Llama-3.3-70B


### PR DESCRIPTION
## Motivation

405B doesn't fit on a single node

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
