### PR TITLE
docs: fix dbrx-instruct broken link

### DIFF
--- a/docs/data/how-to/rocm-for-ai/inference/previous-versions/vllm_0.9.1_20250715-benchmark-models.yaml
+++ b/docs/data/how-to/rocm-for-ai/inference/previous-versions/vllm_0.9.1_20250715-benchmark-models.yaml
@@ -110,7 +110,7 @@ vllm_benchmark:
       - model: DBRX Instruct
         mad_tag: pyt_vllm_dbrx-instruct
         model_repo: databricks/dbrx-instruct
-        url: https://huggingface.co/databricks/dbrx-instruct
+        url: https://huggingface.co/databricks
         precision: float16
       - model: DBRX Instruct FP8
         mad_tag: pyt_vllm_dbrx_fp8


### PR DESCRIPTION
## Motivation

This no longer exists: https://huggingface.co/databricks/dbrx-instruct
Mostly to satisfy broken link checker. 

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
