### PR TITLE
[docs/7.11.0] Add `libquadmath` as an additional package prerequisite

### DIFF
--- a/docs/install/includes/prerequisites.rst
+++ b/docs/install/includes/prerequisites.rst
@@ -323,26 +323,26 @@ Prerequisites
       :heading: Install additional packages
       :heading-level: 3
 
-      Some ROCm tools require the ``libatomic`` library to run correctly. Install
-      it using your distribution's package manager.
+      Some ROCm tools require the ``libatomic`` and ``libquadmath`` libraries to run
+      correctly. Install them using your distribution's package manager.
 
       .. selected:: os=ubuntu os=debian
 
          .. code-block:: bash
 
-            sudo apt install libatomic1
+            sudo apt install libatomic1 libquadmath0
 
       .. selected:: os=rhel os=oracle-linux os=rocky-linux
 
          .. code-block:: bash
 
-            sudo dnf install libatomic
+            sudo dnf install libatomic libquadmath
 
       .. selected:: os=sles
 
          .. code-block:: bash
 
-            sudo zypper install libatomic1
+            sudo zypper install libatomic1 libquadmath0
 
 
 .. =========================================================== INSTALL PYTHON ==


### PR DESCRIPTION
## Motivation

Addresses https://github.com/ROCm/TheRock/issues/3290

## Technical Details

Cannot merge https://github.com/ROCm/llvm-project/commit/440e2e02b52512c8c4d0d96f9bf8fcb481ef91fe according to `amdflang` maintainers:

> I don't think we can do that, as according to the LGPL, if we statically link to libquadmath we would have to provide the objects required to relink if someone wanted to link with a different version of that library. Users of LLVM just need to have libquadmath installed on the systems where they want to use the compiler.

## Test Plan

Verify documented change suffices to workaround the abovementioned issue.

## Test Result

`amdflang` no longer fails with message: `error while loading shared libraries: libquadmath.so.0: cannot open shared object file: No such file or directory` following the additional package installation according to the docs change.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
