### PR TITLE
[docs/7.12.0] Document workarounds for vLLM installation via pip

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1881,7 +1881,7 @@ libraries, their compatible operating systems, and validated versions.
 				<p>Linux</p>
 			</td>
 			<td>
-				<p>3.12</p>
+				<p>3.12<br>(requires PyTorch 2.9.1)</p>
 			</td>
 		</tr>
     </tbody>

--- a/docs/compatibility/includes/ai-ecosystem.rst
+++ b/docs/compatibility/includes/ai-ecosystem.rst
@@ -41,5 +41,5 @@
       .. matrix-cell:: 0.16.0
          :show-when: gpu=mi355x gpu=mi350x gpu=mi325x gpu=mi300x gpu=mi300a gpu=ai-r9700 gpu=ai-r9600d gpu=rx-9070-xt gpu=rx-9070-gre gpu=rx-9070 gpu=rx-9060-xt-lp gpu=rx-9060-xt gpu=rx-9060 gpu=max-pro-395 gpu=max-pro-390 gpu=max-pro-385 gpu=max-pro-380 gpu=max-395 gpu=max-390 gpu=max-385
 
-      .. matrix-cell:: 3.12
+      .. matrix-cell:: 3.12 (requires PyTorch 2.9.1)
          :show-when: gpu=mi355x gpu=mi350x gpu=mi325x gpu=mi300x gpu=mi300a gpu=ai-r9700 gpu=ai-r9600d gpu=rx-9070-xt gpu=rx-9070-gre gpu=rx-9070 gpu=rx-9060-xt-lp gpu=rx-9060-xt gpu=rx-9060 gpu=max-pro-395 gpu=max-pro-390 gpu=max-pro-385 gpu=max-pro-380 gpu=max-395 gpu=max-390 gpu=max-385

--- a/docs/install/includes/post-install.rst
+++ b/docs/install/includes/post-install.rst
@@ -195,7 +195,7 @@ installation.
 
          .. code-block:: shell-session
 
-            AMDSMI Tool: 26.2.1+7b886380f9 | AMDSMI Library version: 26.2.1 | ROCm version: 7.11.0 | amdgpu version: 6.18.4 | hsmp version: N/A
+            AMDSMI Tool: 26.3.0+2bd1678d3d | AMDSMI Library version: 26.3.0 | ROCm version: 7.12.0 | amdgpu version: 6.16.13 | hsmp version: N/A | AINIC version: N/A
 
    .. selected:: i=pip
 

--- a/docs/rocm-for-ai/vllm.rst
+++ b/docs/rocm-for-ai/vllm.rst
@@ -312,8 +312,8 @@ Get started
             python -m pip install \
               --index-url https://repo.amd.com/rocm/whl/gfx950-dcgpu/ \
               "torch==2.9.1+rocm7.12.0" \
-              "torchvision==2.9.0+rocm7.12.0" \
-              "torchaudio==0.24.0+rocm7.12.0"
+              "torchaudio==2.9.0+rocm7.12.0" \
+              "torchvision==0.24.0+rocm7.12.0"
 
       .. selected:: gpu=mi325x gpu=mi300x gpu=mi300a
 
@@ -322,8 +322,8 @@ Get started
             python -m pip install \
               --index-url https://repo.amd.com/rocm/whl/gfx94X-dcgpu/ \
               "torch==2.9.1+rocm7.12.0" \
-              "torchvision==2.9.0+rocm7.12.0" \
-              "torchaudio==0.24.0+rocm7.12.0"
+              "torchaudio==2.9.0+rocm7.12.0" \
+              "torchvision==0.24.0+rocm7.12.0"
 
       .. selected:: fam=radeon-pro fam=radeon
 
@@ -332,8 +332,8 @@ Get started
             python -m pip install \
               --index-url https://repo.amd.com/rocm/whl/gfx120X-all/ \
               "torch==2.9.1+rocm7.12.0" \
-              "torchvision==2.9.0+rocm7.12.0" \
-              "torchaudio==0.24.0+rocm7.12.0"
+              "torchaudio==2.9.0+rocm7.12.0" \
+              "torchvision==0.24.0+rocm7.12.0"
 
       .. selected:: fam=ryzen
 
@@ -342,8 +342,8 @@ Get started
             python -m pip install \
               --index-url https://repo.amd.com/rocm/whl/gfx1151/ \
               "torch==2.9.1+rocm7.12.0" \
-              "torchvision==2.9.0+rocm7.12.0" \
-              "torchaudio==0.24.0+rocm7.12.0"
+              "torchaudio==2.9.0+rocm7.12.0" \
+              "torchvision==0.24.0+rocm7.12.0"
 
    4. Install the appropriate vLLM 0.16.0 build for your GFX architecture from the ROCm package repository.
 

--- a/docs/rocm-for-ai/vllm.rst
+++ b/docs/rocm-for-ai/vllm.rst
@@ -303,7 +303,47 @@ Get started
 
          source .venv/bin/activate
 
-   3. Install ROCm |ROCM_VERSION| and PyTorch using pip. See :ref:`pip-install-pytorch` for details.
+   3. Install ROCm |ROCM_VERSION| and PyTorch 2.9.1 in your virtual environment using pip.
+
+      ..selected:: gpu=mi355x gpu=mi350x
+
+         .. code-block:: bash
+
+            python -m pip install \
+              --index-url https://repo.amd.com/rocm/whl/gfx950-dcgpu/ \
+              "torch==2.9.1+rocm7.12.0" \
+              "torchvision==2.9.0+rocm7.12.0" \
+              "torchaudio==0.24.0+rocm7.12.0"
+
+      ..selected:: gpu=mi325x gpu=mi300x gpu=mi300a
+
+         .. code-block:: bash
+
+            python -m pip install \
+              --index-url https://repo.amd.com/rocm/whl/gfx94X-dcgpu/ \
+              "torch==2.9.1+rocm7.12.0" \
+              "torchvision==2.9.0+rocm7.12.0" \
+              "torchaudio==0.24.0+rocm7.12.0"
+
+      ..selected:: fam=radeon-pro fam=radeon
+
+         .. code-block:: bash
+
+            python -m pip install \
+              --index-url https://repo.amd.com/rocm/whl/gfx120X-all/ \
+              "torch==2.9.1+rocm7.12.0" \
+              "torchvision==2.9.0+rocm7.12.0" \
+              "torchaudio==0.24.0+rocm7.12.0"
+
+      ..selected:: fam=ryzen
+
+         .. code-block:: bash
+
+            python -m pip install \
+              --index-url https://repo.amd.com/rocm/whl/gfx1151/ \
+              "torch==2.9.1+rocm7.12.0" \
+              "torchvision==2.9.0+rocm7.12.0" \
+              "torchaudio==0.24.0+rocm7.12.0"
 
    4. Install the appropriate vLLM 0.16.0 build for your GFX architecture from the ROCm package repository.
 
@@ -339,6 +379,21 @@ Get started
               --extra-index-url https://rocm.frameworks.amd.com/whl/gfx1151/ \
               "vllm==0.16.1.dev10+g11515110f.d20260323.rocm712"
 
+   5. Apply the following environment variables to prevent errors when running vLLM.
+
+      .. code-block:: bash
+
+         export PYTHONPATH=.venv/lib/python3.12/site-packages/_rocm_sdk_core/share/amd_smi
+         export FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE
+
+   6. Check your installation.
+
+      .. code-block:: bash
+
+         echo "=== vLLM ===" && python -c "import vllm; print('vLLM version:', vllm.__version__)"
+         echo "=== PyTorch ===" && python -c "import torch; print('PyTorch:', torch.__version__); print('HIP available:', torch.cuda.is_available()); print('HIP built:', torch.backends.hip.is_built() if hasattr(torch.backends, 'hip') else 'N/A')"
+         echo "=== flash-attn ===" && python -c "import flash_attn; print('flash-attn:', flash_attn.__version__)"
+
    .. seealso::
 
       `Set up using Python (vLLM docs) <https://docs.vllm.ai/en/v0.16.0/getting_started/installation/gpu/#amd-rocm_3>`__
@@ -349,7 +404,7 @@ vLLM <https://docs.vllm.ai/en/v0.16.0/usage/>`__.
 Known issues
 ============
 
-- vLLM server startup might fail due to a path resolution issue. See
+- vLLM server startup in Docker containers might fail due to a path resolution issue. See
   :ref:`release-vllm-path-known-issue`.
 
   As a workaround, before starting the vLLM server inside the ROCm 7.12 vLLM

--- a/docs/rocm-for-ai/vllm.rst
+++ b/docs/rocm-for-ai/vllm.rst
@@ -305,7 +305,7 @@ Get started
 
    3. Install ROCm |ROCM_VERSION| and PyTorch 2.9.1 in your virtual environment using pip.
 
-      ..selected:: gpu=mi355x gpu=mi350x
+      .. selected:: gpu=mi355x gpu=mi350x
 
          .. code-block:: bash
 
@@ -315,7 +315,7 @@ Get started
               "torchvision==2.9.0+rocm7.12.0" \
               "torchaudio==0.24.0+rocm7.12.0"
 
-      ..selected:: gpu=mi325x gpu=mi300x gpu=mi300a
+      .. selected:: gpu=mi325x gpu=mi300x gpu=mi300a
 
          .. code-block:: bash
 
@@ -325,7 +325,7 @@ Get started
               "torchvision==2.9.0+rocm7.12.0" \
               "torchaudio==0.24.0+rocm7.12.0"
 
-      ..selected:: fam=radeon-pro fam=radeon
+      .. selected:: fam=radeon-pro fam=radeon
 
          .. code-block:: bash
 
@@ -335,7 +335,7 @@ Get started
               "torchvision==2.9.0+rocm7.12.0" \
               "torchaudio==0.24.0+rocm7.12.0"
 
-      ..selected:: fam=ryzen
+      .. selected:: fam=ryzen
 
          .. code-block:: bash
 
@@ -379,7 +379,7 @@ Get started
               --extra-index-url https://rocm.frameworks.amd.com/whl/gfx1151/ \
               "vllm==0.16.1.dev10+g11515110f.d20260323.rocm712"
 
-   5. Apply the following environment variables to prevent errors when running vLLM.
+   5. Set the following environment variables to prevent errors related ROCm platform and Flash Attention availability when running vLLM.
 
       .. code-block:: bash
 


### PR DESCRIPTION
## Motivation

PyTorch version should be 2.9.1.
User needs to export these env vars to avoid errors.

```
export PYTHONPATH=.venv/lib/python3.12/site-packages/_rocm_sdk_core/share/amd_smi
export FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE
```

The amd_smi one relates to https://github.com/ROCm/TheRock/issues/3054#issue-3844580312.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
