### PR TITLE
Suppress certain pages in RTD search results

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,3 +20,7 @@ build:
      - "doxygen"
      - "gfortran" # For pre-processing fortran sources
      - "graphviz" # For dot graphs in doxygen
+
+search:
+  ignore:
+    - "**/previous-versions/**"

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.10.0-20250812.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.10.0-20250812.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: Learn how to validate LLM inference performance on MI300X GPUs using AMD MAD and the

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.10.0-20250812.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.10.0-20250812.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: Learn how to validate LLM inference performance on MI300X GPUs using AMD MAD and the

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.10.1-20250909.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.10.1-20250909.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: Learn how to validate LLM inference performance on MI300X accelerators using AMD MAD and the ROCm vLLM Docker image.

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.10.1-20250909.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.10.1-20250909.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: Learn how to validate LLM inference performance on MI300X accelerators using AMD MAD and the ROCm vLLM Docker image.

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.10.2-20251006.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.10.2-20251006.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: Learn how to validate LLM inference performance on MI300X GPUs using AMD MAD and the ROCm vLLM Docker image.

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.10.2-20251006.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.10.2-20251006.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: Learn how to validate LLM inference performance on MI300X GPUs using AMD MAD and the ROCm vLLM Docker image.

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.11.1-20251103.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.11.1-20251103.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: Learn how to validate LLM inference performance on MI300X GPUs using AMD MAD and the ROCm vLLM Docker image.

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.11.1-20251103.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.11.1-20251103.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: Learn how to validate LLM inference performance on MI300X GPUs using AMD MAD and the ROCm vLLM Docker image.

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.4.3.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.4.3.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: Learn how to validate LLM inference performance on MI300X GPUs using AMD MAD and the unified

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.4.3.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.4.3.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: Learn how to validate LLM inference performance on MI300X GPUs using AMD MAD and the unified

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.6.4.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.6.4.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: Learn how to validate LLM inference performance on MI300X GPUs using AMD MAD and the unified

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.6.4.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.6.4.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: Learn how to validate LLM inference performance on MI300X GPUs using AMD MAD and the unified

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.6.6.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.6.6.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: Learn how to validate LLM inference performance on MI300X GPUs using AMD MAD and the

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.6.6.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.6.6.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: Learn how to validate LLM inference performance on MI300X GPUs using AMD MAD and the

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.7.3-20250325.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.7.3-20250325.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: Learn how to validate LLM inference performance on MI300X GPUs using AMD MAD and the

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.7.3-20250325.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.7.3-20250325.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: Learn how to validate LLM inference performance on MI300X GPUs using AMD MAD and the

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.8.3-20250415.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.8.3-20250415.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: Learn how to validate LLM inference performance on MI300X GPUs using AMD MAD and the

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.8.3-20250415.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.8.3-20250415.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: Learn how to validate LLM inference performance on MI300X GPUs using AMD MAD and the

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.8.5-20250513.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.8.5-20250513.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: Learn how to validate LLM inference performance on MI300X GPUs using AMD MAD and the

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.8.5-20250513.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.8.5-20250513.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: Learn how to validate LLM inference performance on MI300X GPUs using AMD MAD and the

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.8.5-20250521.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.8.5-20250521.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: Learn how to validate LLM inference performance on MI300X GPUs using AMD MAD and the

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.8.5-20250521.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.8.5-20250521.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: Learn how to validate LLM inference performance on MI300X GPUs using AMD MAD and the

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.9.0.1-20250605.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.9.0.1-20250605.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: Learn how to validate LLM inference performance on MI300X GPUs using AMD MAD and the

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.9.0.1-20250605.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.9.0.1-20250605.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: Learn how to validate LLM inference performance on MI300X GPUs using AMD MAD and the

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.9.1-20250702.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.9.1-20250702.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: Learn how to validate LLM inference performance on MI300X GPUs using AMD MAD and the

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.9.1-20250702.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.9.1-20250702.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: Learn how to validate LLM inference performance on MI300X GPUs using AMD MAD and the

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.9.1-20250715.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.9.1-20250715.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: Learn how to validate LLM inference performance on MI300X GPUs using AMD MAD and the

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.9.1-20250715.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/vllm-0.9.1-20250715.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: Learn how to validate LLM inference performance on MI300X GPUs using AMD MAD and the

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/xdit-25.10.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/xdit-25.10.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: Learn to validate diffusion model video generation on MI300X, MI350X and MI355X accelerators using

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/xdit-25.10.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/xdit-25.10.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: Learn to validate diffusion model video generation on MI300X, MI350X and MI355X accelerators using

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/xdit-25.11.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/xdit-25.11.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: Learn to validate diffusion model video generation on MI300X, MI350X and MI355X accelerators using

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/xdit-25.11.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/xdit-25.11.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: Learn to validate diffusion model video generation on MI300X, MI350X and MI355X accelerators using

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/xdit-25.12.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/xdit-25.12.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: Learn to validate diffusion model video generation on MI300X, MI350X and MI355X accelerators using

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/xdit-25.12.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/xdit-25.12.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: Learn to validate diffusion model video generation on MI300X, MI350X and MI355X accelerators using

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/xdit-25.13.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/xdit-25.13.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: Learn to validate diffusion model video generation on MI300X, MI350X and MI355X accelerators using

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/xdit-25.13.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/xdit-25.13.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: Learn to validate diffusion model video generation on MI300X, MI350X and MI355X accelerators using

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/xdit-26.1.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/xdit-26.1.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: Learn to validate diffusion model video generation on MI300X, MI350X and MI355X accelerators using

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/xdit-26.1.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/xdit-26.1.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: Learn to validate diffusion model video generation on MI300X, MI350X and MI355X accelerators using

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/xdit-26.2.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/xdit-26.2.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: Learn to validate diffusion model video generation on MI300X, MI350X and MI355X accelerators using

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/xdit-26.2.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/xdit-26.2.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: Learn to validate diffusion model video generation on MI300X, MI350X and MI355X accelerators using

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/xdit-26.3.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/xdit-26.3.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: Learn to validate diffusion model video generation on MI300X, MI350X and MI355X accelerators using

--- a/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/xdit-26.3.rst
+++ b/docs/how-to/rocm-for-ai/inference/benchmark-docker/previous-versions/xdit-26.3.rst
@@ -1,3 +1,6 @@
+:orphan:
+:nosearch:
+
 .. meta::
    :description: Learn to validate diffusion model video generation on MI300X, MI350X and MI355X accelerators using
                  prebuilt and optimized docker images.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/jax-maxtext-v25.11.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/jax-maxtext-v25.11.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using JAX MaxText for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/jax-maxtext-v25.11.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/jax-maxtext-v25.11.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using JAX MaxText for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/jax-maxtext-v25.4.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/jax-maxtext-v25.4.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using JAX MaxText for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/jax-maxtext-v25.4.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/jax-maxtext-v25.4.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using JAX MaxText for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/jax-maxtext-v25.5.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/jax-maxtext-v25.5.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using JAX MaxText for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/jax-maxtext-v25.5.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/jax-maxtext-v25.5.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using JAX MaxText for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/jax-maxtext-v25.7.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/jax-maxtext-v25.7.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using JAX MaxText for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/jax-maxtext-v25.7.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/jax-maxtext-v25.7.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using JAX MaxText for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/jax-maxtext-v25.9.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/jax-maxtext-v25.9.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using JAX MaxText for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/jax-maxtext-v25.9.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/jax-maxtext-v25.9.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using JAX MaxText for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/jax-maxtext-v26.1.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/jax-maxtext-v26.1.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using JAX MaxText for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/jax-maxtext-v26.1.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/jax-maxtext-v26.1.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using JAX MaxText for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-primus-migration-guide.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-primus-migration-guide.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 *****************************************************************
 Migrating workloads to Primus (Megatron backend) from Megatron-LM

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-primus-migration-guide.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-primus-migration-guide.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 *****************************************************************
 Migrating workloads to Primus (Megatron backend) from Megatron-LM

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v24.12-dev.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v24.12-dev.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using ROCm Megatron-LM

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v24.12-dev.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v24.12-dev.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using ROCm Megatron-LM

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.10.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.10.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.10.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.10.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.11.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.11.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.11.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.11.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.3.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.3.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.3.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.3.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.4.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.4.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.4.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.4.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.5.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.5.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.5.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.5.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.6.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.6.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.6.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.6.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.7.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.7.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.7.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.7.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.8.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.8.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.8.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.8.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.9.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.9.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.9.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/megatron-lm-v25.9.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-megatron-v25.10.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-megatron-v25.10.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-megatron-v25.10.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-megatron-v25.10.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-megatron-v25.11.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-megatron-v25.11.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-megatron-v25.11.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-megatron-v25.11.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-megatron-v25.7.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-megatron-v25.7.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-megatron-v25.7.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-megatron-v25.7.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-megatron-v25.8.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-megatron-v25.8.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-megatron-v25.8.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-megatron-v25.8.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-megatron-v25.9.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-megatron-v25.9.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-megatron-v25.9.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-megatron-v25.9.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-megatron-v26.1.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-megatron-v26.1.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-megatron-v26.1.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-megatron-v26.1.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using Megatron-LM for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-pytorch-v25.10.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-pytorch-v25.10.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using PyTorch for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-pytorch-v25.10.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-pytorch-v25.10.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using PyTorch for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-pytorch-v25.11.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-pytorch-v25.11.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using PyTorch for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-pytorch-v25.11.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-pytorch-v25.11.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using PyTorch for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-pytorch-v25.8.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-pytorch-v25.8.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using PyTorch for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-pytorch-v25.8.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-pytorch-v25.8.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using PyTorch for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-pytorch-v25.9.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-pytorch-v25.9.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using PyTorch for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-pytorch-v25.9.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-pytorch-v25.9.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using PyTorch for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-pytorch-v26.1.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-pytorch-v26.1.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using PyTorch for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-pytorch-v26.1.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/primus-pytorch-v26.1.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using PyTorch for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.10.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.10.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using PyTorch for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.10.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.10.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using PyTorch for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.11.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.11.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using PyTorch for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.11.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.11.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using PyTorch for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.3.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.3.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using PyTorch for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.3.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.3.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using PyTorch for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.4.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.4.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using PyTorch for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.4.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.4.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using PyTorch for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.5.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.5.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using PyTorch for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.5.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.5.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using PyTorch for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.6.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.6.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using PyTorch for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.6.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.6.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using PyTorch for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.7.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.7.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using PyTorch for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.7.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.7.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using PyTorch for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.8.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.8.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using PyTorch for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.8.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.8.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using PyTorch for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.9.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.9.rst
@@ -1,4 +1,5 @@
 :orphan:
+:nosearch:
 
 .. meta::
    :description: How to train a model using PyTorch for ROCm.

--- a/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.9.rst
+++ b/docs/how-to/rocm-for-ai/training/benchmark-docker/previous-versions/pytorch-training-v25.9.rst
@@ -1,5 +1,5 @@
 :orphan:
-:nosearch:
+:no-search:
 
 .. meta::
    :description: How to train a model using PyTorch for ROCm.


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

A ton of "archived" pages show up in search results, making the list very cluttered. We should only show the most up-to-date (non-archived) version of a page. These archived pages exist for very specific needs and as historical reference (in this case, for previously released Docker images). Most people won't need them.

This fix improves findability and reduces confusion for users who may land on outdated content. The archived pages are still accessible via URL or through a "history" page.

## Technical Details

Suppress these archived pages in RTD search results.

>[!NOTE]
> There are currently 2 search functionalities on the site.
> The ignore list is handled differently for each. Need to do both (until the legacy search is removed) because neither step covers both search functionalities.
>
> - The new RTD modal one requires the ignore list to be specified in `.readthedocs.yaml`. (reference: https://docs.readthedocs.com/platform/stable/config-file/v2.html#search-ignore)
> - The old search feature requires the `:no-search:` field in the pages to be ignored. (reference: https://www.sphinx-doc.org/en/master/usage/restructuredtext/field-lists.html#special-metadata-fields)

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

<img width="1987" height="2347" alt="image" src="https://github.com/user-attachments/assets/2fb7b499-423c-4fed-86f6-26ef359b86ee" />


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
